### PR TITLE
Recursively scan parent POMs for license

### DIFF
--- a/src/main/groovy/com/jaredsburrows/license/internal/pom/Project.groovy
+++ b/src/main/groovy/com/jaredsburrows/license/internal/pom/Project.groovy
@@ -5,7 +5,9 @@ package com.jaredsburrows.license.internal.pom
  */
 final class Project {
   String name
-  License license
+  String description
+  String version
+  List<License> licenses
   String url
   List<Developer> developers
   String year

--- a/src/main/groovy/com/jaredsburrows/license/internal/report/HtmlReport.groovy
+++ b/src/main/groovy/com/jaredsburrows/license/internal/report/HtmlReport.groovy
@@ -45,7 +45,7 @@ final class HtmlReport {
   def openSourceHtml() {
     final writer = new StringWriter()
     final markup = new MarkupBuilder(writer)
-    final Set<License> licenses = new HashSet<>()
+    final Set<License> licenses = new LinkedHashSet<>()
     markup.html {
       head {
         style(CSS_STYLE)
@@ -56,9 +56,9 @@ final class HtmlReport {
         h3(NOTICE_LIBRARIES)
         ul {
           projects.each { project ->
-            licenses << project.license
+            licenses << project.licenses[0]
             li {
-              a(href: String.format("%s%s", "#", project.license.hashCode()), project.name)
+              a(href: String.format("%s%s", "#", project.licenses[0].hashCode()), project.name)
             }
           }
         }

--- a/src/main/groovy/com/jaredsburrows/license/internal/report/JsonReport.groovy
+++ b/src/main/groovy/com/jaredsburrows/license/internal/report/JsonReport.groovy
@@ -1,6 +1,7 @@
 package com.jaredsburrows.license.internal.report
 
 import com.jaredsburrows.license.internal.pom.Project
+import com.jaredsburrows.license.internal.pom.License
 import groovy.json.JsonBuilder
 
 /**
@@ -8,12 +9,16 @@ import groovy.json.JsonBuilder
  */
 final class JsonReport {
   final static PROJECT = "project"
+  final static DESCRIPTION = "description"
+  final static VERSION = "version"
   final static DEVELOPERS = "developers"
   final static URL = "url"
   final static YEAR = "year"
+  final static LICENSES = "licenses"
   final static LICENSE = "license"
   final static LICENSE_URL = "license_url"
   final static EMPTY_JSON_ARRAY = "[]"
+  final List<License> licenses
   final List<Project> projects
 
   JsonReport(projects) {
@@ -25,13 +30,18 @@ final class JsonReport {
    */
   def jsonArray() {
     new JsonBuilder(projects.collect { project ->
+      def licensesJson = []
+      project.licenses.each { license -> 
+        licensesJson << [ "$LICENSE": license.name, "$LICENSE_URL": license.url]
+      }
       [
         "$PROJECT"    : project.name ? project.name : null,
-        "$DEVELOPERS" : project.developers ? project.developers.collect { developer -> developer?.name }?.join(", ") : null,
+        "$DESCRIPTION": project.description ? project.description : null,
+        "$VERSION"    : project.version ? project.version : null,
+        "$DEVELOPERS" : project.developers*.name,
         "$URL"        : project.url ? project.url : null,
         "$YEAR"       : project.year ? project.year : null,
-        "$LICENSE"    : project.license?.name ? project.license?.name : null,
-        "$LICENSE_URL": project.license?.url ? project.license?.url : null
+        "$LICENSES"   : licensesJson
       ]
     })
   }

--- a/src/test/groovy/com/jaredsburrows/license/LicenseReportTaskAndroidSpec.groovy
+++ b/src/test/groovy/com/jaredsburrows/license/LicenseReportTaskAndroidSpec.groovy
@@ -154,19 +154,35 @@ final class LicenseReportTaskAndroidSpec extends BaseAndroidSpecification {
 [
     {
         "project": "Appcompat-v7",
-        "developers": null,
+        "description": null,
+        "version": "26.1.0",
+        "developers": [
+            
+        ],
         "url": null,
         "year": null,
-        "license": "The Apache Software License",
-        "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        "licenses": [
+            {
+                "license": "The Apache Software License",
+                "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+        ]
     },
     {
         "project": "Design",
-        "developers": null,
+        "description": null,
+        "version": "26.1.0",
+        "developers": [
+            
+        ],
         "url": null,
         "year": null,
-        "license": "The Apache Software License",
-        "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        "licenses": [
+            {
+                "license": "The Apache Software License",
+                "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+        ]
     }
 ]
 """.trim()
@@ -238,19 +254,35 @@ final class LicenseReportTaskAndroidSpec extends BaseAndroidSpecification {
 [
     {
         "project": "Appcompat-v7",
-        "developers": null,
+        "description": null,
+        "version": "26.1.0",
+        "developers": [
+            
+        ],
         "url": null,
         "year": null,
-        "license": "The Apache Software License",
-        "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        "licenses": [
+            {
+                "license": "The Apache Software License",
+                "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+        ]
     },
     {
         "project": "Design",
-        "developers": null,
+        "description": null,
+        "version": "26.1.0",
+        "developers": [
+            
+        ],
         "url": null,
         "year": null,
-        "license": "The Apache Software License",
-        "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        "licenses": [
+            {
+                "license": "The Apache Software License",
+                "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+        ]
     }
 ]
 """.trim()
@@ -342,35 +374,67 @@ final class LicenseReportTaskAndroidSpec extends BaseAndroidSpecification {
 [
     {
         "project": "Appcompat-v7",
-        "developers": null,
+        "description": null,
+        "version": "26.1.0",
+        "developers": [
+            
+        ],
         "url": null,
         "year": null,
-        "license": "The Apache Software License",
-        "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        "licenses": [
+            {
+                "license": "The Apache Software License",
+                "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+        ]
     },
     {
         "project": "Design",
-        "developers": null,
+        "description": null,
+        "version": "26.1.0",
+        "developers": [
+            
+        ],
         "url": null,
         "year": null,
-        "license": "The Apache Software License",
-        "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        "licenses": [
+            {
+                "license": "The Apache Software License",
+                "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+        ]
     },
     {
         "project": "Support-annotations",
-        "developers": null,
+        "description": null,
+        "version": "26.1.0",
+        "developers": [
+            
+        ],
         "url": null,
         "year": null,
-        "license": "The Apache Software License",
-        "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        "licenses": [
+            {
+                "license": "The Apache Software License",
+                "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+        ]
     },
     {
         "project": "Support-v4",
-        "developers": null,
+        "description": null,
+        "version": "26.1.0",
+        "developers": [
+            
+        ],
         "url": null,
         "year": null,
-        "license": "The Apache Software License",
-        "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        "licenses": [
+            {
+                "license": "The Apache Software License",
+                "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+        ]
     }
 ]
 """.trim()
@@ -441,19 +505,35 @@ final class LicenseReportTaskAndroidSpec extends BaseAndroidSpecification {
 [
     {
         "project": "Android GIF Drawable Library",
-        "developers": "Karol Wr\\u00c3\\u00b3tniak",
-        "url": "https://github.com/koral--/android-gif-drawable.git",
+        "description": "Views and Drawable for displaying animated GIFs for Android",
+        "version": "1.2.3",
+        "developers": [
+            "Karol Wr\\u00c3\\u00b3tniak"
+        ],
+        "url": "https://github.com/koral--/android-gif-drawable",
         "year": null,
-        "license": "The MIT License",
-        "license_url": "http://opensource.org/licenses/MIT"
+        "licenses": [
+            {
+                "license": "The MIT License",
+                "license_url": "http://opensource.org/licenses/MIT"
+            }
+        ]
     },
     {
         "project": "Design",
-        "developers": null,
+        "description": null,
+        "version": "26.1.0",
+        "developers": [
+            
+        ],
         "url": null,
         "year": null,
-        "license": "The Apache Software License",
-        "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        "licenses": [
+            {
+                "license": "The Apache Software License",
+                "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+        ]
     }
 ]
 """.trim()
@@ -516,19 +596,35 @@ final class LicenseReportTaskAndroidSpec extends BaseAndroidSpecification {
 [
     {
         "project": "Appcompat-v7",
-        "developers": null,
+        "description": null,
+        "version": "26.1.0",
+        "developers": [
+            
+        ],
         "url": null,
         "year": null,
-        "license": "The Apache Software License",
-        "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        "licenses": [
+            {
+                "license": "The Apache Software License",
+                "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+        ]
     },
     {
         "project": "Design",
-        "developers": null,
+        "description": null,
+        "version": "26.1.0",
+        "developers": [
+            
+        ],
         "url": null,
         "year": null,
-        "license": "The Apache Software License",
-        "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        "licenses": [
+            {
+                "license": "The Apache Software License",
+                "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+        ]
     }
 ]
 """.trim()

--- a/src/test/groovy/com/jaredsburrows/license/LicenseReportTaskJavaSpec.groovy
+++ b/src/test/groovy/com/jaredsburrows/license/LicenseReportTaskJavaSpec.groovy
@@ -93,19 +93,35 @@ final class LicenseReportTaskJavaSpec extends BaseJavaSpecification {
 [
     {
         "project": "Appcompat-v7",
-        "developers": null,
+        "description": null,
+        "version": "26.1.0",
+        "developers": [
+            
+        ],
         "url": null,
         "year": null,
-        "license": "The Apache Software License",
-        "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        "licenses": [
+            {
+                "license": "The Apache Software License",
+                "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+        ]
     },
     {
         "project": "Design",
-        "developers": null,
+        "description": null,
+        "version": "26.1.0",
+        "developers": [
+            
+        ],
         "url": null,
         "year": null,
-        "license": "The Apache Software License",
-        "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        "licenses": [
+            {
+                "license": "The Apache Software License",
+                "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+        ]
     }
 ]
 """.trim()
@@ -204,21 +220,38 @@ final class LicenseReportTaskJavaSpec extends BaseJavaSpecification {
 [
     {
         "project": "Appcompat-v7",
-        "developers": null,
+        "description": null,
+        "version": "26.1.0",
+        "developers": [
+            
+        ],
         "url": null,
         "year": null,
-        "license": "The Apache Software License",
-        "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        "licenses": [
+            {
+                "license": "The Apache Software License",
+                "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+        ]
     },
     {
         "project": "Design",
-        "developers": null,
+        "description": null,
+        "version": "26.1.0",
+        "developers": [
+            
+        ],
         "url": null,
         "year": null,
-        "license": "The Apache Software License",
-        "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        "licenses": [
+            {
+                "license": "The Apache Software License",
+                "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+        ]
     }
 ]
+
 """.trim()
 
     then:
@@ -306,11 +339,19 @@ final class LicenseReportTaskJavaSpec extends BaseJavaSpecification {
 [
     {
         "project": "Fake dependency name",
-        "developers": "name",
-        "url": "https://github.com/user/repo.git",
+        "description": "Fake dependency description",
+        "version": "1.0.0",
+        "developers": [
+            "name"
+        ],
+        "url": "https://github.com/user/repo",
         "year": "2017",
-        "license": "Some license",
-        "license_url": "http://website.tld/"
+        "licenses": [
+            {
+                "license": "Some license",
+                "license_url": "http://website.tld/"
+            }
+        ]
     }
 ]
 """.trim()
@@ -360,11 +401,23 @@ final class LicenseReportTaskJavaSpec extends BaseJavaSpecification {
 [
     {
         "project": "Fake dependency name",
-        "developers": "name",
-        "url": "https://github.com/user/repo.git",
+        "description": "Fake dependency description",
+        "version": "1.0.0",
+        "developers": [
+            "name"
+        ],
+        "url": "https://github.com/user/repo",
         "year": "2017",
-        "license": "Some license",
-        "license_url": "http://website.tld/"
+        "licenses": [
+            {
+                "license": "Some license",
+                "license_url": "http://website.tld/"
+            },
+            {
+                "license": "Some license",
+                "license_url": "http://website.tld/"
+            }
+        ]
     }
 ]
 """.trim()
@@ -421,19 +474,35 @@ final class LicenseReportTaskJavaSpec extends BaseJavaSpecification {
 [
     {
         "project": "Fake dependency name",
-        "developers": "name",
-        "url": "https://github.com/user/repo.git",
+        "description": "Fake dependency description",
+        "version": null,
+        "developers": [
+            "name"
+        ],
+        "url": "https://github.com/user/repo",
         "year": "2017",
-        "license": "Some license",
-        "license_url": "http://website.tld/"
+        "licenses": [
+            {
+                "license": "Some license",
+                "license_url": "http://website.tld/"
+            }
+        ]
     },
     {
         "project": "Retrofit",
-        "developers": null,
+        "description": null,
+        "version": null,
+        "developers": [
+            
+        ],
         "url": null,
         "year": null,
-        "license": "Apache 2.0",
-        "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        "licenses": [
+            {
+                "license": "Apache 2.0",
+                "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+        ]
     }
 ]
 """.trim()

--- a/src/test/groovy/com/jaredsburrows/license/internal/pom/ProjectSpec.groovy
+++ b/src/test/groovy/com/jaredsburrows/license/internal/pom/ProjectSpec.groovy
@@ -8,8 +8,8 @@ import spock.lang.Specification
 final class ProjectSpec extends Specification {
   def developer = new Developer(name: "name")
   def developers = [developer, developer]
-  def license = new License(name: "name", url: "url")
-  def sut = new Project(name: "name", license: license, url: "url", developers: developers,
+  def licenses = [new License(name: "name", url: "url")]
+  def sut = new Project(name: "name", licenses: licenses, url: "url", developers: developers,
     year: "year")
 
   def "name"() {
@@ -18,10 +18,10 @@ final class ProjectSpec extends Specification {
     sut.getName() == "name"
   }
 
-  def "license"() {
+  def "licenses"() {
     expect:
-    sut.license == license
-    sut.getLicense() == license
+    sut.licenses == licenses
+    sut.getLicenses() == licenses
   }
 
   def "url"() {

--- a/src/test/groovy/com/jaredsburrows/license/internal/report/HtmlReportSpec.groovy
+++ b/src/test/groovy/com/jaredsburrows/license/internal/report/HtmlReportSpec.groovy
@@ -38,7 +38,7 @@ final class HtmlReportSpec extends Specification {
     def developer = new Developer(name: "name")
     def developers = [developer, developer]
     def license = new License(name: "name", url: "url")
-    def project = new Project(name: "name", license: license, url: "url", developers: developers,
+    def project = new Project(name: "name", licenses: [license], url: "url", developers: developers,
       year: "year")
     def projects = [project, project]
     def sut = new HtmlReport(projects)

--- a/src/test/groovy/com/jaredsburrows/license/internal/report/JsonReportSpec.groovy
+++ b/src/test/groovy/com/jaredsburrows/license/internal/report/JsonReportSpec.groovy
@@ -28,7 +28,7 @@ final class JsonReportSpec extends Specification {
   def "open source json - missing values"() {
     given:
     def license = new License(name: "name", url: "url")
-    def project = new Project(name: "name", license: license)
+    def project = new Project(name: "name", licenses: [license], developers: [])
     def projects = [project, project]
     def sut = new JsonReport(projects)
 
@@ -39,19 +39,35 @@ final class JsonReportSpec extends Specification {
 [
     {
         "project": "name",
-        "developers": null,
+        "description": null,
+        "version": null,
+        "developers": [
+            
+        ],
         "url": null,
         "year": null,
-        "license": "name",
-        "license_url": "url"
+        "licenses": [
+            {
+                "license": "name",
+                "license_url": "url"
+            }
+        ]
     },
     {
         "project": "name",
-        "developers": null,
+        "description": null,
+        "version": null,
+        "developers": [
+            
+        ],
         "url": null,
         "year": null,
-        "license": "name",
-        "license_url": "url"
+        "licenses": [
+            {
+                "license": "name",
+                "license_url": "url"
+            }
+        ]
     }
 ]
 """.trim()
@@ -65,7 +81,7 @@ final class JsonReportSpec extends Specification {
     def developer = new Developer(name: "name")
     def developers = [developer, developer]
     def license = new License(name: "name", url: "url")
-    def project = new Project(name: "name", license: license, url: "url", developers: developers,
+    def project = new Project(name: "name", description: "description", version: "1.0.0", licenses: [license], url: "url", developers: developers,
       year: "year")
     def projects = [project, project]
     def sut = new JsonReport(projects)
@@ -77,19 +93,37 @@ final class JsonReportSpec extends Specification {
 [
     {
         "project": "name",
-        "developers": "name, name",
+        "description": "description",
+        "version": "1.0.0",
+        "developers": [
+            "name",
+            "name"
+        ],
         "url": "url",
         "year": "year",
-        "license": "name",
-        "license_url": "url"
+        "licenses": [
+            {
+                "license": "name",
+                "license_url": "url"
+            }
+        ]
     },
     {
         "project": "name",
-        "developers": "name, name",
+        "description": "description",
+        "version": "1.0.0",
+        "developers": [
+            "name",
+            "name"
+        ],
         "url": "url",
         "year": "year",
-        "license": "name",
-        "license_url": "url"
+        "licenses": [
+            {
+                "license": "name",
+                "license_url": "url"
+            }
+        ]
     }
 ]
 """.trim()


### PR DESCRIPTION
Previously, only the direct parent POM was scanned for license information. In many cases, this is not sufficient.

This pull request changes this behavior so that all parent POMs are scanned recursively. In my case, this finds A LOT of licenses that weren't found before, like for various Apache-commons and Jetty libraries.