### PR TITLE
Added configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,28 @@ dependencies {
 ]
 ```
 
+## Configuration
+The plugin can be configured to generate particular reports and for Android projects, automatically copy the reports to the assets directory. The default behaviours are: 
+- Java projects: Generate both the HTML report and the JSON report.
+- Android projects: Generate both the HTML report and the JSON report, and copy the HTML report to the assets directory.
+
+To override the defaults, add the `licenseReport` configuration closure to the build script.
+
+```groovy
+apply plugin: "com.jaredsburrows.license"
+
+reportLicense {
+    generateHtmlReport = false
+    generateJsonReport = true
+    
+    // These options are ignored for Java projects
+    copyHtmlReportToAssets = true
+    copyJsonReportToAssets = false
+}
+```
+
+The `copyHtmlReportToAssets` option in the above example would have no effect since the HTML report is disabled.
+
 ## Usage
 
 ### Create an open source dialog

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ To override the defaults, add the `licenseReport` configuration closure to the b
 ```groovy
 apply plugin: "com.jaredsburrows.license"
 
-reportLicense {
+licenseReport {
     generateHtmlReport = false
     generateJsonReport = true
     

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ dependencies {
 ```
 
 ## Configuration
-The plugin can be configured to generate particular reports and for Android projects, automatically copy the reports to the assets directory. The default behaviours are: 
+The plugin can be configured to generate specific reports and automatically copy the reports to the assets directory (Android projects only). The default behaviours are: 
 - Java projects: Generate both the HTML report and the JSON report.
 - Android projects: Generate both the HTML report and the JSON report, and copy the HTML report to the assets directory.
 

--- a/src/main/groovy/com/jaredsburrows/license/AndroidLicenseReportOptions.groovy
+++ b/src/main/groovy/com/jaredsburrows/license/AndroidLicenseReportOptions.groovy
@@ -1,0 +1,28 @@
+package com.jaredsburrows.license
+
+/**
+ * Configuration options for the gradle license plugin. This configuration should only be applied to Android projects.
+ *
+ * @author <a href="mailto:matthew.tamlin@icloud.com">Matthew Tamlin</a>
+ */
+class AndroidLicenseReportOptions {
+  /**
+   * Whether or not the HTML report should be generated.
+   */
+  boolean generateHtmlReport = true
+
+  /**
+   * Whether or not the HTML report should be copied to assets. Has no effect if the report is disabled.
+   */
+  boolean copyHtmlReportToAssets = true
+
+  /**
+   * Whether or not the JSON report should be generated.
+   */
+  boolean generateJsonReport = true
+
+  /**
+   * Whether or not the JSON report should be copied to assets. Has no effect if the report is disabled.
+   */
+  boolean copyJsonReportToAssets = false
+}

--- a/src/main/groovy/com/jaredsburrows/license/AndroidLicenseReportOptions.groovy
+++ b/src/main/groovy/com/jaredsburrows/license/AndroidLicenseReportOptions.groovy
@@ -1,7 +1,7 @@
 package com.jaredsburrows.license
 
 /**
- * Configuration options for the gradle license plugin. This configuration should only be applied to Android projects.
+ * Configuration options for the gradle license plugin.
  *
  * @author <a href="mailto:matthew.tamlin@icloud.com">Matthew Tamlin</a>
  */
@@ -12,7 +12,8 @@ class AndroidLicenseReportOptions {
   boolean generateHtmlReport = true
 
   /**
-   * Whether or not the HTML report should be copied to assets. Has no effect if the report is disabled.
+   * Whether or not the HTML report should be copied to the Android assets directory. Ignored if the project is not
+   * an Android project. Has no effect if the HTML report is disabled.
    */
   boolean copyHtmlReportToAssets = true
 
@@ -22,7 +23,8 @@ class AndroidLicenseReportOptions {
   boolean generateJsonReport = true
 
   /**
-   * Whether or not the JSON report should be copied to assets. Has no effect if the report is disabled.
+   * Whether or not the HTML report should be copied to the Android assets directory. Ignored if the project is not
+   * an Android project. Has no effect if the JSON report is disabled.
    */
   boolean copyJsonReportToAssets = false
 }

--- a/src/main/groovy/com/jaredsburrows/license/LicensePlugin.groovy
+++ b/src/main/groovy/com/jaredsburrows/license/LicensePlugin.groovy
@@ -30,6 +30,8 @@ final class LicensePlugin implements Plugin<Project> {
     // Get correct plugin - Check for android library, default to application variant for application/test plugin
     final variants = getAndroidVariants(project)
 
+    final configurationExtension = project.extensions.create("options", AndroidLicenseReportOptions)
+
     // Configure tasks for all variants
     variants.all { variant ->
       final variantName = variant.name.capitalize()
@@ -42,6 +44,10 @@ final class LicensePlugin implements Plugin<Project> {
       task.group = "Reporting"
       task.htmlFile = project.file(path + LicenseReportTask.HTML_EXT)
       task.jsonFile = project.file(path + LicenseReportTask.JSON_EXT)
+      task.generateHtmlReport = configurationExtension.generateHtmlReport
+      task.generateJsonReport = configurationExtension.generateJsonReport
+      task.copyHtmlReportToAssets = configurationExtension.copyHtmlReportToAssets
+      task.copyJsonReportToAssets = configurationExtension.copyJsonReportToAssets
       task.assetDirs = project.android.sourceSets.main.assets.srcDirs
       task.buildType = variant.buildType.name
       task.variant = variant.name
@@ -64,6 +70,10 @@ final class LicensePlugin implements Plugin<Project> {
     task.group = "Reporting"
     task.htmlFile = project.file(path + LicenseReportTask.HTML_EXT)
     task.jsonFile = project.file(path + LicenseReportTask.JSON_EXT)
+    task.generateHtmlReport = true
+    task.generateJsonReport = true
+    task.copyHtmlReportToAssets = false
+    task.copyJsonReportToAssets = false
     // Make sure update on each run
     task.outputs.upToDateWhen { false }
   }

--- a/src/main/groovy/com/jaredsburrows/license/LicensePlugin.groovy
+++ b/src/main/groovy/com/jaredsburrows/license/LicensePlugin.groovy
@@ -30,7 +30,7 @@ final class LicensePlugin implements Plugin<Project> {
     // Get correct plugin - Check for android library, default to application variant for application/test plugin
     final variants = getAndroidVariants(project)
 
-    final configuration = project.extensions.create("licenseReport", AndroidLicenseReportOptions)
+    final configuration = project.extensions.create("licenseReport", LicenseReportOptions)
 
     // Configure tasks for all variants
     variants.all { variant ->
@@ -64,7 +64,7 @@ final class LicensePlugin implements Plugin<Project> {
     final taskName = "licenseReport"
     final path = "${project.buildDir}/reports/licenses/$taskName"
 
-    final configuration = project.extensions.create("licenseReport", AndroidLicenseReportOptions)
+    final configuration = project.extensions.create("licenseReport", LicenseReportOptions)
 
     // Create tasks
     final LicenseReportTask task = project.tasks.create("$taskName", LicenseReportTask)

--- a/src/main/groovy/com/jaredsburrows/license/LicensePlugin.groovy
+++ b/src/main/groovy/com/jaredsburrows/license/LicensePlugin.groovy
@@ -30,7 +30,7 @@ final class LicensePlugin implements Plugin<Project> {
     // Get correct plugin - Check for android library, default to application variant for application/test plugin
     final variants = getAndroidVariants(project)
 
-    final configurationExtension = project.extensions.create("options", AndroidLicenseReportOptions)
+    final configuration = project.extensions.create("licenseReport", AndroidLicenseReportOptions)
 
     // Configure tasks for all variants
     variants.all { variant ->
@@ -44,10 +44,10 @@ final class LicensePlugin implements Plugin<Project> {
       task.group = "Reporting"
       task.htmlFile = project.file(path + LicenseReportTask.HTML_EXT)
       task.jsonFile = project.file(path + LicenseReportTask.JSON_EXT)
-      task.generateHtmlReport = configurationExtension.generateHtmlReport
-      task.generateJsonReport = configurationExtension.generateJsonReport
-      task.copyHtmlReportToAssets = configurationExtension.copyHtmlReportToAssets
-      task.copyJsonReportToAssets = configurationExtension.copyJsonReportToAssets
+      task.generateHtmlReport = configuration.generateHtmlReport
+      task.generateJsonReport = configuration.generateJsonReport
+      task.copyHtmlReportToAssets = configuration.copyHtmlReportToAssets
+      task.copyJsonReportToAssets = configuration.copyJsonReportToAssets
       task.assetDirs = project.android.sourceSets.main.assets.srcDirs
       task.buildType = variant.buildType.name
       task.variant = variant.name
@@ -64,14 +64,16 @@ final class LicensePlugin implements Plugin<Project> {
     final taskName = "licenseReport"
     final path = "${project.buildDir}/reports/licenses/$taskName"
 
+    final configuration = project.extensions.create("licenseReport", AndroidLicenseReportOptions)
+
     // Create tasks
     final LicenseReportTask task = project.tasks.create("$taskName", LicenseReportTask)
     task.description = "Outputs licenses report."
     task.group = "Reporting"
     task.htmlFile = project.file(path + LicenseReportTask.HTML_EXT)
     task.jsonFile = project.file(path + LicenseReportTask.JSON_EXT)
-    task.generateHtmlReport = true
-    task.generateJsonReport = true
+    task.generateHtmlReport = configuration.generateHtmlReport
+    task.generateJsonReport = configuration.generateJsonReport
     task.copyHtmlReportToAssets = false
     task.copyJsonReportToAssets = false
     // Make sure update on each run

--- a/src/main/groovy/com/jaredsburrows/license/LicenseReportOptions.groovy
+++ b/src/main/groovy/com/jaredsburrows/license/LicenseReportOptions.groovy
@@ -5,7 +5,7 @@ package com.jaredsburrows.license
  *
  * @author <a href="mailto:matthew.tamlin@icloud.com">Matthew Tamlin</a>
  */
-class AndroidLicenseReportOptions {
+class LicenseReportOptions {
   /**
    * Whether or not the HTML report should be generated.
    */

--- a/src/test/groovy/com/jaredsburrows/license/LicenseReportTaskAndroidSpec.groovy
+++ b/src/test/groovy/com/jaredsburrows/license/LicenseReportTaskAndroidSpec.groovy
@@ -655,10 +655,12 @@ final class LicenseReportTaskAndroidSpec extends BaseAndroidSpecification {
       compile DESIGN
     }
 
-    project.extensions.configure(AndroidLicenseReportOptions, {options -> options.generateHtmlReport = true})
-    project.extensions.configure(AndroidLicenseReportOptions, {options -> options.generateJsonReport = true})
-    project.extensions.configure(AndroidLicenseReportOptions, {options -> options.copyHtmlReportToAssets = copyEnabled})
-    project.extensions.configure(AndroidLicenseReportOptions, {options -> options.copyJsonReportToAssets = copyEnabled})
+    project.licenseReport {
+      generateHtmlReport = true
+      generateJsonReport = true
+      copyHtmlReportToAssets = copyEnabled
+      copyJsonReportToAssets = copyEnabled
+    }
 
     when:
     project.evaluate()
@@ -704,10 +706,12 @@ final class LicenseReportTaskAndroidSpec extends BaseAndroidSpecification {
       compile DESIGN
     }
 
-    project.extensions.configure(AndroidLicenseReportOptions, {options -> options.generateHtmlReport = false})
-    project.extensions.configure(AndroidLicenseReportOptions, {options -> options.generateJsonReport = false})
-    project.extensions.configure(AndroidLicenseReportOptions, {options -> options.copyHtmlReportToAssets = copyEnabled})
-    project.extensions.configure(AndroidLicenseReportOptions, {options -> options.copyJsonReportToAssets = copyEnabled})
+    project.licenseReport {
+      generateHtmlReport = false
+      generateJsonReport = false
+      copyHtmlReportToAssets = copyEnabled
+      copyJsonReportToAssets = copyEnabled
+    }
 
     when:
     project.evaluate()


### PR DESCRIPTION
Added configuration options to allow scripts to configure the following properties in Android projects:
- Enable/disable HTML report generation
- Enable/disable HTML report copying to assets
- Enable/disable JSON report generation
- Enable/disable JSON report copying to assets

Added tests to check that options are used by task.