### PR TITLE
Extra report info

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Example `build.gradle`:
 dependencies {
   compile "com.android.support:design:26.1.0"
   compile "pl.droidsonroids.gif:android-gif-drawable:1.2.3"
+  compile "wsdl4j:wsdl4j:1.5.1" // Very old library with no license info available
 }
 ```
 
@@ -74,6 +75,10 @@ dependencies {
   <body>
     <h3>Notice for packages:</h3>
     <ul>
+	  <li>
+        <a href='#76480'>WSDL4J</a>
+      </li>
+      <pre>No license found</pre>
       <li>
         <a href='#-989315363'>Android GIF Drawable Library</a>
       </li>
@@ -106,7 +111,8 @@ dependencies {
         "license": "The MIT License",
         "license_url": "http://opensource.org/licenses/MIT"
       }
-    ]
+    ],
+    "dependency": "pl.droidsonroids.gif:android-gif-drawable:1.2.3"
   },
   {
     "project": "Design",
@@ -122,10 +128,27 @@ dependencies {
         "license": "The Apache Software License",
         "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
       }
-    ]
+    ],
+    "dependency": "com.android.support:design:26.1.0"
+  },
+  {
+	"project": "WSDL4J",
+	"description": "Java stub generator for WSDL",
+	"version": "1.5.1",
+	"developers": [
+		
+	],
+	"url": "http://sf.net/projects/wsdl4j",
+	"year": null,
+	"licenses": [
+		
+	],
+	"dependency": "wsdl4j:wsdl4j:1.5.1"
   }
 ]
 ```
+
+Note, if no license information is found for a component, the `licenses` element in the JSON output will be an empty array.
 
 ## Configuration
 The plugin can be configured to generate specific reports and automatically copy the reports to the assets directory (Android projects only). The default behaviours are: 

--- a/README.md
+++ b/README.md
@@ -132,18 +132,18 @@ dependencies {
     "dependency": "com.android.support:design:26.1.0"
   },
   {
-	"project": "WSDL4J",
-	"description": "Java stub generator for WSDL",
-	"version": "1.5.1",
-	"developers": [
+    "project": "WSDL4J",
+    "description": "Java stub generator for WSDL",
+    "version": "1.5.1",
+    "developers": [
 		
-	],
-	"url": "http://sf.net/projects/wsdl4j",
-	"year": null,
-	"licenses": [
+    ],
+    "url": "http://sf.net/projects/wsdl4j",
+    "year": null,
+    "licenses": [
 		
-	],
-	"dependency": "wsdl4j:wsdl4j:1.5.1"
+    ],
+    "dependency": "wsdl4j:wsdl4j:1.5.1"
   }
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ dependencies {
   <body>
     <h3>Notice for packages:</h3>
     <ul>
-	  <li>
+      <li>
         <a href='#76480'>WSDL4J</a>
       </li>
       <pre>No license found</pre>

--- a/src/main/groovy/com/jaredsburrows/license/LicenseReportTask.groovy
+++ b/src/main/groovy/com/jaredsburrows/license/LicenseReportTask.groovy
@@ -151,7 +151,7 @@ class LicenseReportTask extends DefaultTask {
       def licenses = findLicenses(pomFile)
       if (!licenses) {
         logger.log(LogLevel.WARN, "${name} dependency does not have a license.")
-        return
+        licenses = []
       }
 
       // Store the information that we need
@@ -162,7 +162,8 @@ class LicenseReportTask extends DefaultTask {
         developers: developers,
         licenses: licenses,
         url: url,
-        year: year
+        year: year,
+        dependencyString: pom.owner
       )
 
       projects << project

--- a/src/main/groovy/com/jaredsburrows/license/LicenseReportTask.groovy
+++ b/src/main/groovy/com/jaredsburrows/license/LicenseReportTask.groovy
@@ -163,7 +163,7 @@ class LicenseReportTask extends DefaultTask {
         licenses: licenses,
         url: url,
         year: year,
-        dependencyString: pom.owner
+        gav: pom.owner
       )
 
       projects << project

--- a/src/main/groovy/com/jaredsburrows/license/internal/pom/Project.groovy
+++ b/src/main/groovy/com/jaredsburrows/license/internal/pom/Project.groovy
@@ -8,4 +8,5 @@ final class Project {
   String url
   List<Developer> developers
   String year
+  String dependencyString
 }

--- a/src/main/groovy/com/jaredsburrows/license/internal/pom/Project.groovy
+++ b/src/main/groovy/com/jaredsburrows/license/internal/pom/Project.groovy
@@ -8,5 +8,5 @@ final class Project {
   String url
   List<Developer> developers
   String year
-  String dependencyString
+  String gav // Group/artifact/version
 }

--- a/src/main/groovy/com/jaredsburrows/license/internal/report/HtmlReport.groovy
+++ b/src/main/groovy/com/jaredsburrows/license/internal/report/HtmlReport.groovy
@@ -11,6 +11,7 @@ final class HtmlReport {
   final static def CSS_STYLE = BODY_CSS + " " + PRE_CSS
   final static def OPEN_SOURCE_LIBRARIES = "Open source licenses"
   final static def NO_LIBRARIES = "None"
+  final static def NO_LICENSE = "No license found"
   final static def NOTICE_LIBRARIES = "Notice for packages:"
   final List<Project> projects
 
@@ -35,7 +36,12 @@ final class HtmlReport {
 
     // Store packages by license
     projects.each { project ->
-      def key = project.licenses[0]
+      def key = new License(name: "No license found", url: "N/A")
+
+      if (project.licenses.size > 0) {
+        key = project.licenses[0]
+      }
+
       if (!projectsMap.containsKey(key)) {
         projectsMap.put(key, [])
       }
@@ -73,7 +79,9 @@ final class HtmlReport {
             // Display associated license with libraries
             // Try to find license by URL, name and then default to whatever is listed in the POM.xml
             def licenseMap = LicenseHelper.LICENSE_MAP
-            if (licenseMap.containsKey(entry.key.url)) {
+            if (currentProject.licenses.size == 0) {
+              pre(NO_LICENSE)
+            } else if (licenseMap.containsKey(entry.key.url)) {
               a(name: currentLicense)
               pre(getLicenseText(licenseMap.get(entry.key.url)))
             } else if (licenseMap.containsKey(entry.key.name)) {
@@ -83,7 +91,7 @@ final class HtmlReport {
               if (currentProject && (currentProject.licenses[0].name.trim() || currentProject.licenses[0].url.trim())) {
                 pre("${currentProject.licenses[0].name.trim()}\n${currentProject.licenses[0].url.trim()}")
               } else {
-                pre(NO_LIBRARIES)
+                pre(NO_LICENSE)
               }
             }
           }

--- a/src/main/groovy/com/jaredsburrows/license/internal/report/HtmlReport.groovy
+++ b/src/main/groovy/com/jaredsburrows/license/internal/report/HtmlReport.groovy
@@ -13,6 +13,7 @@ final class HtmlReport {
   final static def NO_LIBRARIES = "None"
   final static def NO_LICENSE = "No license found"
   final static def NOTICE_LIBRARIES = "Notice for packages:"
+  final static def NO_URL = "N/A"
   final List<Project> projects
 
   HtmlReport(def projects) {
@@ -36,7 +37,7 @@ final class HtmlReport {
 
     // Store packages by license
     projects.each { project ->
-      def key = new License(name: "No license found", url: "N/A")
+      def key = new License(name: NO_LICENSE, url: NO_URL)
 
       if (project.licenses && project.licenses.size > 0) {
         key = project.licenses[0]

--- a/src/main/groovy/com/jaredsburrows/license/internal/report/HtmlReport.groovy
+++ b/src/main/groovy/com/jaredsburrows/license/internal/report/HtmlReport.groovy
@@ -38,7 +38,7 @@ final class HtmlReport {
     projects.each { project ->
       def key = new License(name: "No license found", url: "N/A")
 
-      if (project.licenses.size > 0) {
+      if (project.licenses && project.licenses.size > 0) {
         key = project.licenses[0]
       }
 
@@ -79,7 +79,7 @@ final class HtmlReport {
             // Display associated license with libraries
             // Try to find license by URL, name and then default to whatever is listed in the POM.xml
             def licenseMap = LicenseHelper.LICENSE_MAP
-            if (currentProject.licenses.size == 0) {
+            if (!currentProject.licenses || currentProject.licenses.size == 0) {
               pre(NO_LICENSE)
             } else if (licenseMap.containsKey(entry.key.url)) {
               a(name: currentLicense)

--- a/src/main/groovy/com/jaredsburrows/license/internal/report/JsonReport.groovy
+++ b/src/main/groovy/com/jaredsburrows/license/internal/report/JsonReport.groovy
@@ -15,6 +15,7 @@ final class JsonReport {
   private final static def LICENSE = "license"
   private final static def LICENSE_URL = "license_url"
   private final static def EMPTY_JSON_ARRAY = "[]"
+  private final static def DEPENDENCY_STRING = "dependency_string"
   private final List<Project> projects
 
   JsonReport(projects) {
@@ -45,7 +46,8 @@ final class JsonReport {
         "$DEVELOPERS" : project.developers*.name,
         "$URL"        : project.url ? project.url : null,
         "$YEAR"       : project.year ? project.year : null,
-        "$LICENSES"   : licensesJson
+        "$LICENSES"   : licensesJson,
+        "$DEPENDENCY_STRING": project.dependencyString
       ]
     })
   }

--- a/src/main/groovy/com/jaredsburrows/license/internal/report/JsonReport.groovy
+++ b/src/main/groovy/com/jaredsburrows/license/internal/report/JsonReport.groovy
@@ -15,7 +15,7 @@ final class JsonReport {
   private final static def LICENSE = "license"
   private final static def LICENSE_URL = "license_url"
   private final static def EMPTY_JSON_ARRAY = "[]"
-  private final static def DEPENDENCY_STRING = "dependency_string"
+  private final static def DEPENDENCY = "dependency"
   private final List<Project> projects
 
   JsonReport(projects) {
@@ -47,7 +47,7 @@ final class JsonReport {
         "$URL"        : project.url ? project.url : null,
         "$YEAR"       : project.year ? project.year : null,
         "$LICENSES"   : licensesJson,
-        "$DEPENDENCY_STRING": project.dependencyString
+        "$DEPENDENCY" : project.gav
       ]
     })
   }

--- a/src/test/groovy/com/jaredsburrows/license/LicenseReportTaskAndroidSpec.groovy
+++ b/src/test/groovy/com/jaredsburrows/license/LicenseReportTaskAndroidSpec.groovy
@@ -129,7 +129,7 @@ final class LicenseReportTaskAndroidSpec extends BaseAndroidSpecification {
         "licenses": [
             
         ],
-        "dependency_string": "com.google.firebase:firebase-core:10.0.1"
+        "dependency": "com.google.firebase:firebase-core:10.0.1"
     }
 ]
 """.stripIndent().trim()
@@ -208,7 +208,7 @@ final class LicenseReportTaskAndroidSpec extends BaseAndroidSpecification {
                 "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
             }
         ],
-        "dependency_string": "com.android.support:appcompat-v7:26.1.0"
+        "dependency": "com.android.support:appcompat-v7:26.1.0"
     },
     {
         "project": "Design",
@@ -225,7 +225,7 @@ final class LicenseReportTaskAndroidSpec extends BaseAndroidSpecification {
                 "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
             }
         ],
-        "dependency_string": "com.android.support:design:26.1.0"
+        "dependency": "com.android.support:design:26.1.0"
     }
 ]
 """.stripIndent().trim()
@@ -309,7 +309,7 @@ final class LicenseReportTaskAndroidSpec extends BaseAndroidSpecification {
                 "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
             }
         ],
-        "dependency_string": "com.android.support:appcompat-v7:26.1.0"
+        "dependency": "com.android.support:appcompat-v7:26.1.0"
     },
     {
         "project": "Design",
@@ -326,7 +326,7 @@ final class LicenseReportTaskAndroidSpec extends BaseAndroidSpecification {
                 "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
             }
         ],
-        "dependency_string": "com.android.support:design:26.1.0"
+        "dependency": "com.android.support:design:26.1.0"
     }
 ]
 """.stripIndent().trim()
@@ -430,7 +430,7 @@ final class LicenseReportTaskAndroidSpec extends BaseAndroidSpecification {
                 "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
             }
         ],
-        "dependency_string": "com.android.support:appcompat-v7:26.1.0"
+        "dependency": "com.android.support:appcompat-v7:26.1.0"
     },
     {
         "project": "Design",
@@ -447,7 +447,7 @@ final class LicenseReportTaskAndroidSpec extends BaseAndroidSpecification {
                 "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
             }
         ],
-        "dependency_string": "com.android.support:design:26.1.0"
+        "dependency": "com.android.support:design:26.1.0"
     },
     {
         "project": "Support-annotations",
@@ -464,7 +464,7 @@ final class LicenseReportTaskAndroidSpec extends BaseAndroidSpecification {
                 "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
             }
         ],
-        "dependency_string": "com.android.support:support-annotations:26.1.0"
+        "dependency": "com.android.support:support-annotations:26.1.0"
     },
     {
         "project": "Support-v4",
@@ -481,7 +481,7 @@ final class LicenseReportTaskAndroidSpec extends BaseAndroidSpecification {
                 "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
             }
         ],
-        "dependency_string": "com.android.support:support-v4:26.1.0"
+        "dependency": "com.android.support:support-v4:26.1.0"
     }
 ]
 """.stripIndent().trim()
@@ -563,7 +563,7 @@ final class LicenseReportTaskAndroidSpec extends BaseAndroidSpecification {
                 "license_url": "http://opensource.org/licenses/MIT"
             }
         ],
-        "dependency_string": "pl.droidsonroids.gif:android-gif-drawable:1.2.3"
+        "dependency": "pl.droidsonroids.gif:android-gif-drawable:1.2.3"
     },
     {
         "project": "Design",
@@ -580,7 +580,7 @@ final class LicenseReportTaskAndroidSpec extends BaseAndroidSpecification {
                 "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
             }
         ],
-        "dependency_string": "com.android.support:design:26.1.0"
+        "dependency": "com.android.support:design:26.1.0"
     }
 ]
 """.stripIndent().trim()
@@ -764,7 +764,7 @@ http://website.tld/</pre>
                 "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
             }
         ],
-        "dependency_string": "com.android.support:design:26.1.0"
+        "dependency": "com.android.support:design:26.1.0"
     },
     {
         "project": "Fake dependency name",
@@ -781,7 +781,7 @@ http://website.tld/</pre>
                 "license_url": "http://website.tld/"
             }
         ],
-        "dependency_string": "group:name:1.0.0"
+        "dependency": "group:name:1.0.0"
     }
 ]
 """.stripIndent().trim()

--- a/src/test/groovy/com/jaredsburrows/license/LicenseReportTaskAndroidSpec.groovy
+++ b/src/test/groovy/com/jaredsburrows/license/LicenseReportTaskAndroidSpec.groovy
@@ -103,14 +103,35 @@ final class LicenseReportTaskAndroidSpec extends BaseAndroidSpecification {
     <title>Open source licenses</title>
   </head>
   <body>
-    <h3>None</h3>
+    <h3>Notice for packages:</h3>
+    <ul>
+      <li>
+        <a href='#76480'>Firebase-core</a>
+      </li>
+      <pre>No license found</pre>
+    </ul>
   </body>
 </html>
 """.stripIndent().trim()
     def actualJson = task.jsonFile.text.stripIndent().trim()
     def expectedJson =
       """
-[]
+[
+    {
+        "project": "Firebase-core",
+        "description": null,
+        "version": "10.0.1",
+        "developers": [
+            
+        ],
+        "url": null,
+        "year": null,
+        "licenses": [
+            
+        ],
+        "dependency_string": "com.google.firebase:firebase-core:10.0.1"
+    }
+]
 """.stripIndent().trim()
 
     then:
@@ -186,7 +207,8 @@ final class LicenseReportTaskAndroidSpec extends BaseAndroidSpecification {
                 "license": "The Apache Software License",
                 "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
             }
-        ]
+        ],
+        "dependency_string": "com.android.support:appcompat-v7:26.1.0"
     },
     {
         "project": "Design",
@@ -202,7 +224,8 @@ final class LicenseReportTaskAndroidSpec extends BaseAndroidSpecification {
                 "license": "The Apache Software License",
                 "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
             }
-        ]
+        ],
+        "dependency_string": "com.android.support:design:26.1.0"
     }
 ]
 """.stripIndent().trim()
@@ -285,7 +308,8 @@ final class LicenseReportTaskAndroidSpec extends BaseAndroidSpecification {
                 "license": "The Apache Software License",
                 "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
             }
-        ]
+        ],
+        "dependency_string": "com.android.support:appcompat-v7:26.1.0"
     },
     {
         "project": "Design",
@@ -301,7 +325,8 @@ final class LicenseReportTaskAndroidSpec extends BaseAndroidSpecification {
                 "license": "The Apache Software License",
                 "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
             }
-        ]
+        ],
+        "dependency_string": "com.android.support:design:26.1.0"
     }
 ]
 """.stripIndent().trim()
@@ -404,7 +429,8 @@ final class LicenseReportTaskAndroidSpec extends BaseAndroidSpecification {
                 "license": "The Apache Software License",
                 "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
             }
-        ]
+        ],
+        "dependency_string": "com.android.support:appcompat-v7:26.1.0"
     },
     {
         "project": "Design",
@@ -420,7 +446,8 @@ final class LicenseReportTaskAndroidSpec extends BaseAndroidSpecification {
                 "license": "The Apache Software License",
                 "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
             }
-        ]
+        ],
+        "dependency_string": "com.android.support:design:26.1.0"
     },
     {
         "project": "Support-annotations",
@@ -436,7 +463,8 @@ final class LicenseReportTaskAndroidSpec extends BaseAndroidSpecification {
                 "license": "The Apache Software License",
                 "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
             }
-        ]
+        ],
+        "dependency_string": "com.android.support:support-annotations:26.1.0"
     },
     {
         "project": "Support-v4",
@@ -452,7 +480,8 @@ final class LicenseReportTaskAndroidSpec extends BaseAndroidSpecification {
                 "license": "The Apache Software License",
                 "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
             }
-        ]
+        ],
+        "dependency_string": "com.android.support:support-v4:26.1.0"
     }
 ]
 """.stripIndent().trim()
@@ -533,7 +562,8 @@ final class LicenseReportTaskAndroidSpec extends BaseAndroidSpecification {
                 "license": "The MIT License",
                 "license_url": "http://opensource.org/licenses/MIT"
             }
-        ]
+        ],
+        "dependency_string": "pl.droidsonroids.gif:android-gif-drawable:1.2.3"
     },
     {
         "project": "Design",
@@ -549,7 +579,8 @@ final class LicenseReportTaskAndroidSpec extends BaseAndroidSpecification {
                 "license": "The Apache Software License",
                 "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
             }
-        ]
+        ],
+        "dependency_string": "com.android.support:design:26.1.0"
     }
 ]
 """.stripIndent().trim()
@@ -732,7 +763,8 @@ http://website.tld/</pre>
                 "license": "The Apache Software License",
                 "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
             }
-        ]
+        ],
+        "dependency_string": "com.android.support:design:26.1.0"
     },
     {
         "project": "Fake dependency name",
@@ -748,7 +780,8 @@ http://website.tld/</pre>
                 "license": "Some license",
                 "license_url": "http://website.tld/"
             }
-        ]
+        ],
+        "dependency_string": "group:name:1.0.0"
     }
 ]
 """.stripIndent().trim()

--- a/src/test/groovy/com/jaredsburrows/license/LicenseReportTaskJavaSpec.groovy
+++ b/src/test/groovy/com/jaredsburrows/license/LicenseReportTaskJavaSpec.groovy
@@ -98,7 +98,7 @@ final class LicenseReportTaskJavaSpec extends BaseJavaSpecification {
                 "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
             }
         ],
-        "dependency_string": "com.android.support:appcompat-v7:26.1.0"
+        "dependency": "com.android.support:appcompat-v7:26.1.0"
     },
     {
         "project": "Design",
@@ -115,7 +115,7 @@ final class LicenseReportTaskJavaSpec extends BaseJavaSpecification {
                 "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
             }
         ],
-        "dependency_string": "com.android.support:design:26.1.0"
+        "dependency": "com.android.support:design:26.1.0"
     }
 ]
 """.stripIndent().trim()
@@ -173,7 +173,7 @@ final class LicenseReportTaskJavaSpec extends BaseJavaSpecification {
         "licenses": [
             
         ],
-        "dependency_string": "com.google.firebase:firebase-core:10.0.1"
+        "dependency": "com.google.firebase:firebase-core:10.0.1"
     }
 ]
 """.stripIndent().trim()
@@ -241,7 +241,7 @@ final class LicenseReportTaskJavaSpec extends BaseJavaSpecification {
                 "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
             }
         ],
-        "dependency_string": "com.android.support:appcompat-v7:26.1.0"
+        "dependency": "com.android.support:appcompat-v7:26.1.0"
     },
     {
         "project": "Design",
@@ -258,7 +258,7 @@ final class LicenseReportTaskJavaSpec extends BaseJavaSpecification {
                 "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
             }
         ],
-        "dependency_string": "com.android.support:design:26.1.0"
+        "dependency": "com.android.support:design:26.1.0"
     }
 ]
 """.stripIndent().trim()
@@ -357,7 +357,7 @@ http://website.tld/</pre>
                 "license_url": "http://website.tld/"
             }
         ],
-        "dependency_string": "group:name:1.0.0"
+        "dependency": "group:name:1.0.0"
     }
 ]
 """.stripIndent().trim()
@@ -423,7 +423,7 @@ http://website.tld/</pre>
                 "license_url": "http://website.tld/"
             }
         ],
-        "dependency_string": "group:name2:1.0.0"
+        "dependency": "group:name2:1.0.0"
     }
 ]
 """.stripIndent().trim()
@@ -491,7 +491,7 @@ http://website.tld/</pre>
                 "license_url": "http://website.tld/"
             }
         ],
-        "dependency_string": "group:child:1.0.0"
+        "dependency": "group:child:1.0.0"
     },
     {
         "project": "Retrofit",
@@ -508,7 +508,7 @@ http://website.tld/</pre>
                 "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
             }
         ],
-        "dependency_string": "com.squareup.retrofit2:retrofit:2.3.0"
+        "dependency": "com.squareup.retrofit2:retrofit:2.3.0"
     }
 ]
 """.stripIndent().trim()
@@ -579,7 +579,7 @@ http://website.tld/</pre>
                 "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
             }
         ],
-        "dependency_string": "com.android.support:appcompat-v7:26.1.0"
+        "dependency": "com.android.support:appcompat-v7:26.1.0"
     },
     {
         "project": "Design",
@@ -596,7 +596,7 @@ http://website.tld/</pre>
                 "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
             }
         ],
-        "dependency_string": "com.android.support:design:26.1.0"
+        "dependency": "com.android.support:design:26.1.0"
     }
 ]
 """.stripIndent().trim()

--- a/src/test/groovy/com/jaredsburrows/license/LicenseReportTaskJavaSpec.groovy
+++ b/src/test/groovy/com/jaredsburrows/license/LicenseReportTaskJavaSpec.groovy
@@ -97,7 +97,8 @@ final class LicenseReportTaskJavaSpec extends BaseJavaSpecification {
                 "license": "The Apache Software License",
                 "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
             }
-        ]
+        ],
+        "dependency_string": "com.android.support:appcompat-v7:26.1.0"
     },
     {
         "project": "Design",
@@ -113,7 +114,8 @@ final class LicenseReportTaskJavaSpec extends BaseJavaSpecification {
                 "license": "The Apache Software License",
                 "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
             }
-        ]
+        ],
+        "dependency_string": "com.android.support:design:26.1.0"
     }
 ]
 """.stripIndent().trim()
@@ -145,14 +147,35 @@ final class LicenseReportTaskJavaSpec extends BaseJavaSpecification {
     <title>Open source licenses</title>
   </head>
   <body>
-    <h3>None</h3>
+    <h3>Notice for packages:</h3>
+    <ul>
+      <li>
+        <a href='#76480'>Firebase-core</a>
+      </li>
+      <pre>No license found</pre>
+    </ul>
   </body>
 </html>
 """.stripIndent().trim()
     def actualJson = task.jsonFile.text.stripIndent().trim()
     def expectedJson =
       """
-[]
+[
+    {
+        "project": "Firebase-core",
+        "description": null,
+        "version": "10.0.1",
+        "developers": [
+            
+        ],
+        "url": null,
+        "year": null,
+        "licenses": [
+            
+        ],
+        "dependency_string": "com.google.firebase:firebase-core:10.0.1"
+    }
+]
 """.stripIndent().trim()
 
     then:
@@ -217,7 +240,8 @@ final class LicenseReportTaskJavaSpec extends BaseJavaSpecification {
                 "license": "The Apache Software License",
                 "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
             }
-        ]
+        ],
+        "dependency_string": "com.android.support:appcompat-v7:26.1.0"
     },
     {
         "project": "Design",
@@ -233,7 +257,8 @@ final class LicenseReportTaskJavaSpec extends BaseJavaSpecification {
                 "license": "The Apache Software License",
                 "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
             }
-        ]
+        ],
+        "dependency_string": "com.android.support:design:26.1.0"
     }
 ]
 """.stripIndent().trim()
@@ -331,7 +356,8 @@ http://website.tld/</pre>
                 "license": "Some license",
                 "license_url": "http://website.tld/"
             }
-        ]
+        ],
+        "dependency_string": "group:name:1.0.0"
     }
 ]
 """.stripIndent().trim()
@@ -396,7 +422,8 @@ http://website.tld/</pre>
                 "license": "Some license",
                 "license_url": "http://website.tld/"
             }
-        ]
+        ],
+        "dependency_string": "group:name2:1.0.0"
     }
 ]
 """.stripIndent().trim()
@@ -463,7 +490,8 @@ http://website.tld/</pre>
                 "license": "Some license",
                 "license_url": "http://website.tld/"
             }
-        ]
+        ],
+        "dependency_string": "group:child:1.0.0"
     },
     {
         "project": "Retrofit",
@@ -479,7 +507,8 @@ http://website.tld/</pre>
                 "license": "Apache 2.0",
                 "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
             }
-        ]
+        ],
+        "dependency_string": "com.squareup.retrofit2:retrofit:2.3.0"
     }
 ]
 """.stripIndent().trim()
@@ -549,7 +578,8 @@ http://website.tld/</pre>
                 "license": "The Apache Software License",
                 "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
             }
-        ]
+        ],
+        "dependency_string": "com.android.support:appcompat-v7:26.1.0"
     },
     {
         "project": "Design",
@@ -565,7 +595,8 @@ http://website.tld/</pre>
                 "license": "The Apache Software License",
                 "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
             }
-        ]
+        ],
+        "dependency_string": "com.android.support:design:26.1.0"
     }
 ]
 """.stripIndent().trim()

--- a/src/test/groovy/com/jaredsburrows/license/internal/report/HtmlReportSpec.groovy
+++ b/src/test/groovy/com/jaredsburrows/license/internal/report/HtmlReportSpec.groovy
@@ -37,7 +37,9 @@ final class HtmlReportSpec extends Specification {
     def license = new License(name: "name", url: "url")
     def project = new Project(name: "name", licenses: [license], url: "url", developers: developers,
       year: "year")
-    def projects = [project, project]
+    def missingLicensesproject = new Project(name: "name", url: "url", developers: developers,
+      year: "year")
+    def projects = [project, project, missingLicensesproject]
     def sut = new HtmlReport(projects)
 
     when:
@@ -52,6 +54,10 @@ final class HtmlReportSpec extends Specification {
   <body>
     <h3>Notice for packages:</h3>
     <ul>
+      <li>
+        <a href='#76480'>name</a>
+      </li>
+      <pre>No license found</pre>
       <li>
         <a href='#116079'>name</a>
       </li>

--- a/src/test/groovy/com/jaredsburrows/license/internal/report/JsonReportSpec.groovy
+++ b/src/test/groovy/com/jaredsburrows/license/internal/report/JsonReportSpec.groovy
@@ -24,7 +24,7 @@ final class JsonReportSpec extends Specification {
 
   def "open source json - missing values"() {
     given:
-    def project = new Project(name: "name", developers: [], dependencyString: "foo:bar:1.2.3")
+    def project = new Project(name: "name", developers: [], gav: "foo:bar:1.2.3")
     def projects = [project, project]
     def sut = new JsonReport(projects)
 
@@ -45,7 +45,7 @@ final class JsonReportSpec extends Specification {
         "licenses": [
             
         ],
-        "dependency_string": "foo:bar:1.2.3"
+        "dependency": "foo:bar:1.2.3"
     },
     {
         "project": "name",
@@ -59,7 +59,7 @@ final class JsonReportSpec extends Specification {
         "licenses": [
             
         ],
-        "dependency_string": "foo:bar:1.2.3"
+        "dependency": "foo:bar:1.2.3"
     }
 ]
 """.stripIndent().trim()
@@ -74,7 +74,7 @@ final class JsonReportSpec extends Specification {
     def developers = [developer, developer]
     def license = new License(name: "name", url: "url")
     def project = new Project(name: "name", description: "description", version: "1.0.0",
-      licenses: [license], url: "url", developers: developers, year: "year", dependencyString: "foo:bar:1.2.3")
+      licenses: [license], url: "url", developers: developers, year: "year", gav: "foo:bar:1.2.3")
     def projects = [project, project]
     def sut = new JsonReport(projects)
 
@@ -99,7 +99,7 @@ final class JsonReportSpec extends Specification {
                 "license_url": "url"
             }
         ],
-        "dependency_string": "foo:bar:1.2.3"
+        "dependency": "foo:bar:1.2.3"
     },
     {
         "project": "name",
@@ -117,7 +117,7 @@ final class JsonReportSpec extends Specification {
                 "license_url": "url"
             }
         ],
-        "dependency_string": "foo:bar:1.2.3"
+        "dependency": "foo:bar:1.2.3"
     }
 ]
 """.stripIndent().trim()

--- a/src/test/groovy/com/jaredsburrows/license/internal/report/JsonReportSpec.groovy
+++ b/src/test/groovy/com/jaredsburrows/license/internal/report/JsonReportSpec.groovy
@@ -24,8 +24,7 @@ final class JsonReportSpec extends Specification {
 
   def "open source json - missing values"() {
     given:
-    def license = new License(name: "name", url: "url")
-    def project = new Project(name: "name", licenses: [license], developers: [])
+    def project = new Project(name: "name", developers: [], dependencyString: "foo:bar:1.2.3")
     def projects = [project, project]
     def sut = new JsonReport(projects)
 
@@ -44,11 +43,9 @@ final class JsonReportSpec extends Specification {
         "url": null,
         "year": null,
         "licenses": [
-            {
-                "license": "name",
-                "license_url": "url"
-            }
-        ]
+            
+        ],
+        "dependency_string": "foo:bar:1.2.3"
     },
     {
         "project": "name",
@@ -60,11 +57,9 @@ final class JsonReportSpec extends Specification {
         "url": null,
         "year": null,
         "licenses": [
-            {
-                "license": "name",
-                "license_url": "url"
-            }
-        ]
+            
+        ],
+        "dependency_string": "foo:bar:1.2.3"
     }
 ]
 """.stripIndent().trim()
@@ -79,7 +74,7 @@ final class JsonReportSpec extends Specification {
     def developers = [developer, developer]
     def license = new License(name: "name", url: "url")
     def project = new Project(name: "name", description: "description", version: "1.0.0",
-      licenses: [license], url: "url", developers: developers, year: "year")
+      licenses: [license], url: "url", developers: developers, year: "year", dependencyString: "foo:bar:1.2.3")
     def projects = [project, project]
     def sut = new JsonReport(projects)
 
@@ -103,7 +98,8 @@ final class JsonReportSpec extends Specification {
                 "license": "name",
                 "license_url": "url"
             }
-        ]
+        ],
+        "dependency_string": "foo:bar:1.2.3"
     },
     {
         "project": "name",
@@ -120,7 +116,8 @@ final class JsonReportSpec extends Specification {
                 "license": "name",
                 "license_url": "url"
             }
-        ]
+        ],
+        "dependency_string": "foo:bar:1.2.3"
     }
 ]
 """.stripIndent().trim()


### PR DESCRIPTION
I needed to add some extra info into the JSON report for my own purposes. If you feel this is useful for others too, then please consider merging.

There are two related changes here:

1. Add dependencies for which no licenses were found into the reports, with an empty licenses array in the JSON report. The HTML report adds dependencies with no licenses in a "no licenses found" section.

2. Add the original gradle dependency string (group:name:version string) into the JSON report - makes it easier to track down a dependency if the description is not enough.