### PR TITLE
Escape paths written to local.properties file for Android unit tests,…

### DIFF
--- a/src/test/groovy/test/BaseAndroidSpecification.groovy
+++ b/src/test/groovy/test/BaseAndroidSpecification.groovy
@@ -1,6 +1,7 @@
 package test
 
 import com.android.build.gradle.internal.SdkHandler
+import groovy.json.StringEscapeUtils
 
 class BaseAndroidSpecification extends BaseJavaSpecification {
   def COMPILE_SDK_VERSION = 26
@@ -21,6 +22,6 @@ class BaseAndroidSpecification extends BaseJavaSpecification {
     // Set mock test sdk, we only need to test the plugins tasks
     def testAndroidSdk = new File(TEST_ANDROID_SDK)
     SdkHandler.sTestSdkFolder = testAndroidSdk
-    new File (testProjectDir.root, "local.properties") << "sdk.dir=${testAndroidSdk.path}"
+    new File (testProjectDir.root, "local.properties") << "sdk.dir=${StringEscapeUtils.escapeJava(testAndroidSdk.path)}"
   }
 }


### PR DESCRIPTION
… to fix test failures when running on Windows due to unescaped backslashes.

Fixes #45.