### PR TITLE
make any links to licenses clickable in preformatted text

### DIFF
--- a/src/main/groovy/com/jaredsburrows/license/internal/report/HtmlReport.groovy
+++ b/src/main/groovy/com/jaredsburrows/license/internal/report/HtmlReport.groovy
@@ -90,11 +90,11 @@ final class HtmlReport {
               pre(getLicenseText(licenseMap.get(entry.key.name)))
             } else {
               if (currentProject) {
-                def currentProjectName = currentProject.licenses[0].name.trim()
+                def currentLicenseName = currentProject.licenses[0].name.trim()
                 def currentUrl = currentProject.licenses[0].url.trim()
-                if (currentProjectName || currentUrl) {
+                if (currentLicenseName || currentUrl) {
                   pre {
-                    mkp.yield("$currentProjectName\n")
+                    mkp.yield("$currentLicenseName\n")
                     mkp.yieldUnescaped("<a href='$currentUrl'>$currentUrl</a>")
                   }
                 }

--- a/src/main/groovy/com/jaredsburrows/license/internal/report/HtmlReport.groovy
+++ b/src/main/groovy/com/jaredsburrows/license/internal/report/HtmlReport.groovy
@@ -89,8 +89,15 @@ final class HtmlReport {
               a(name: currentLicense)
               pre(getLicenseText(licenseMap.get(entry.key.name)))
             } else {
-              if (currentProject && (currentProject.licenses[0].name.trim() || currentProject.licenses[0].url.trim())) {
-                pre("${currentProject.licenses[0].name.trim()}\n${currentProject.licenses[0].url.trim()}")
+              if (currentProject) {
+                def currentProjectName = currentProject.licenses[0].name.trim()
+                def currentUrl = currentProject.licenses[0].url.trim()
+                if (currentProjectName || currentUrl) {
+                  pre {
+                    mkp.yield("$currentProjectName\n")
+                    mkp.yieldUnescaped("<a href='$currentUrl'>$currentUrl</a>")
+                  }
+                }
               } else {
                 pre(NO_LICENSE)
               }

--- a/src/test/groovy/com/jaredsburrows/license/LicenseReportTaskAndroidSpec.groovy
+++ b/src/test/groovy/com/jaredsburrows/license/LicenseReportTaskAndroidSpec.groovy
@@ -735,7 +735,7 @@ final class LicenseReportTaskAndroidSpec extends BaseAndroidSpecification {
         <a href='#755498312'>Fake dependency name</a>
       </li>
       <pre>Some license
-http://website.tld/</pre>
+<a href='http://website.tld/'>http://website.tld/</a></pre>
       <li>
         <a href='#1288284111'>Design</a>
       </li>

--- a/src/test/groovy/com/jaredsburrows/license/LicenseReportTaskJavaSpec.groovy
+++ b/src/test/groovy/com/jaredsburrows/license/LicenseReportTaskJavaSpec.groovy
@@ -333,7 +333,7 @@ final class LicenseReportTaskJavaSpec extends BaseJavaSpecification {
         <a href='#755498312'>Fake dependency name</a>
       </li>
       <pre>Some license
-http://website.tld/</pre>
+<a href='http://website.tld/'>http://website.tld/</a></pre>
     </ul>
   </body>
 </html>
@@ -395,7 +395,7 @@ http://website.tld/</pre>
         <a href='#755498312'>Fake dependency name</a>
       </li>
       <pre>Some license
-http://website.tld/</pre>
+<a href='http://website.tld/'>http://website.tld/</a></pre>
     </ul>
   </body>
 </html>
@@ -462,7 +462,7 @@ http://website.tld/</pre>
         <a href='#755498312'>Fake dependency name</a>
       </li>
       <pre>Some license
-http://website.tld/</pre>
+<a href='http://website.tld/'>http://website.tld/</a></pre>
       <li>
         <a href='#1288284111'>Retrofit</a>
       </li>

--- a/src/test/groovy/com/jaredsburrows/license/internal/report/HtmlReportSpec.groovy
+++ b/src/test/groovy/com/jaredsburrows/license/internal/report/HtmlReportSpec.groovy
@@ -65,7 +65,7 @@ final class HtmlReportSpec extends Specification {
         <a href='#116079'>name</a>
       </li>
       <pre>name
-url</pre>
+<a href='url'>url</a></pre>
     </ul>
   </body>
 </html>


### PR DESCRIPTION
This simply surrounds any links to license text with `<a href></a>` so that the user can click on them to follow the link and read the license.
