### PR TITLE
Use Gson for Json

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ Example `build.gradle`:
 
 ```groovy
 dependencies {
-  compile 'com.android.support:design:26.1.0'
-  compile 'pl.droidsonroids.gif:android-gif-drawable:1.2.3'
-  compile 'wsdl4j:wsdl4j:1.5.1' // Very old library with no license info available
+  implementation 'com.android.support:design:26.1.0'
+  implementation 'pl.droidsonroids.gif:android-gif-drawable:1.2.3'
+  implementation 'wsdl4j:wsdl4j:1.5.1' // Very old library with no license info available
 }
 ```
 
@@ -69,7 +69,10 @@ dependencies {
 ```html
 <html>
   <head>
-    <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }</style>
+    <style>
+      body { font-family: sans-serif } 
+      pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }
+    </style>
     <title>Open source licenses</title>
   </head>
   <body>
@@ -118,9 +121,7 @@ dependencies {
     "project": "Design",
     "description": null,
     "version": "26.1.0",
-    "developers": [
-        
-    ],
+    "developers": [],
     "url": null,
     "year": null,
     "licenses": [
@@ -135,14 +136,10 @@ dependencies {
     "project": "WSDL4J",
     "description": "Java stub generator for WSDL",
     "version": "1.5.1",
-    "developers": [
-
-    ],
+    "developers": [],
     "url": "http://sf.net/projects/wsdl4j",
     "year": null,
-    "licenses": [
-
-    ],
+    "licenses": [],
     "dependency": "wsdl4j:wsdl4j:1.5.1"
   }
 ]
@@ -161,12 +158,12 @@ To override the defaults, add the `licenseReport` configuration closure to the b
 apply plugin: "com.jaredsburrows.license"
 
 licenseReport {
-    generateHtmlReport = false
-    generateJsonReport = true
-    
-    // These options are ignored for Java projects
-    copyHtmlReportToAssets = true
-    copyJsonReportToAssets = false
+  generateHtmlReport = false
+  generateJsonReport = true
+  
+  // These options are ignored for Java projects
+  copyHtmlReportToAssets = true
+  copyJsonReportToAssets = false
 }
 ```
 
@@ -176,42 +173,50 @@ The `copyHtmlReportToAssets` option in the above example would have no effect si
 
 ### Create an open source dialog
 ```java
-public static class OpenSourceLicensesDialog extends DialogFragment {
+import android.app.Activity;
+import android.app.Dialog;
+import android.os.Bundle;
+import android.webkit.WebView;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
+import androidx.fragment.app.DialogFragment;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
+import androidx.fragment.app.FragmentTransaction;
+
+public class OpenSourceLicensesDialog extends DialogFragment {
 
   public OpenSourceLicensesDialog() {
   }
 
+  public static void showLicenses(Activity activity) {
+    FragmentManager fragmentManager = activity.getFragmentManager();
+    FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
+    Fragment previousFragment = fragmentManager.findFragmentByTag("dialog_licenses");
+    if (previousFragment != null) {
+      fragmentTransaction.remove(previousFragment);
+    }
+    fragmentTransaction.addToBackStack(null);
+
+    show(fragmentTransaction, "dialog_licenses");
+  }
+
   @Override public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
-    WebView webView = new WebView(getActivity());
+    WebView webView = new WebView(requireActivity());
     webView.loadUrl("file:///android_asset/open_source_licenses.html");
 
     return new AlertDialog.Builder(requireActivity())
       .setTitle("Open Source Licenses")
       .setView(webView)
-      .setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
-        @Override public void onClick(DialogInterface dialog, int which) {
-          dialog.dismiss();
-        }
-      }
-    )
-    .create();
+      .setPositiveButton(R.string.ok, (dialog, which) -> dialog.dismiss())
+      .create();
   }
 }
 ```
 
 ### How to use it
 ```java
-public static void showOpenSourceLicenses(Activity activity) {
-  FragmentManager fragmentManager = activity.getFragmentManager();
-  FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
-  Fragment previousFragment = fragmentManager.findFragmentByTag("dialog_licenses");
-  if (previousFragment != null) {
-    fragmentTransaction.remove(previousFragment);
-  }
-  fragmentTransaction.addToBackStack(null);
-
-  new OpenSourceLicensesDialog().show(fragmentTransaction, "dialog_licenses");
-}
+new OpenSourceLicensesDialog().showLicenses(fragmentTransaction, "dialog_licenses");
 ```
 
 Source: https://github.com/google/iosched/blob/2531cbdbe27e5795eb78bf47d27e8c1be494aad4/android/src/main/java/com/google/samples/apps/iosched/util/AboutUtils.java#L52

--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,8 @@ dependencies {
   implementation localGroovy()
   implementation deps.kotlin.stdlib.jdk
   implementation deps.kotlin.reflect
-  implementation deps.kotlinx.html.jvm
+  implementation deps.kotlinx.html
+  implementation deps.gson
 
   compileOnly deps.android.tools.build.gradle
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -14,11 +14,10 @@ ext.deps = [
     'reflect': "org.jetbrains.kotlin:kotlin-reflect:$versions.kotlin"
   ],
   'kotlinx': [
-    'html': [
-      'jvm': 'org.jetbrains.kotlinx:kotlinx-html-jvm:0.6.12'
-    ]
+    'html': 'org.jetbrains.kotlinx:kotlinx-html-jvm:0.6.12',
   ],
   'ktlint': 'com.github.shyiko:ktlint:0.29.0',
+  'gson': 'com.google.code.gson:gson:2.8.5',
   'android': [
     'tools': [
       'build': [

--- a/src/main/kotlin/com/jaredsburrows/license/internal/report/JsonReport.kt
+++ b/src/main/kotlin/com/jaredsburrows/license/internal/report/JsonReport.kt
@@ -1,7 +1,8 @@
 package com.jaredsburrows.license.internal.report
 
+import com.google.gson.GsonBuilder
+import com.google.gson.reflect.TypeToken
 import com.jaredsburrows.license.internal.pom.Project
-import groovy.json.JsonBuilder
 
 class JsonReport(private val projects: List<Project>) {
   companion object {
@@ -14,19 +15,23 @@ class JsonReport(private val projects: List<Project>) {
     private const val LICENSES = "licenses"
     private const val LICENSE = "license"
     private const val LICENSE_URL = "license_url"
-    private const val EMPTY_JSON_ARRAY = "[]"
+    private const val EMPTY_JSON = "[]"
     private const val DEPENDENCY = "dependency"
+    private val gson = GsonBuilder()
+      .setPrettyPrinting()
+      .serializeNulls()
+      .create()
   }
 
   /**
    * Return Json as a String.
    */
-  fun string(): String = if (projects.isEmpty()) EMPTY_JSON_ARRAY else jsonArray()
+  fun string(): String = if (projects.isEmpty()) EMPTY_JSON else json()
 
   /**
    * Json report when there are open source licenses.
    */
-  private fun jsonArray(): String {
+  private fun json(): String {
     val reportList = mutableListOf<Map<String, Any?>>()
     projects.forEach { project ->
       // Handle multiple licenses
@@ -57,6 +62,6 @@ class JsonReport(private val projects: List<Project>) {
       ))
     }
 
-    return JsonBuilder(reportList).toPrettyString()
+    return gson.toJson(reportList, object : TypeToken<MutableList<Map<String, Any?>>>() {}.type)
   }
 }

--- a/src/test/groovy/com/jaredsburrows/license/LicensePluginAndroidSpec.groovy
+++ b/src/test/groovy/com/jaredsburrows/license/LicensePluginAndroidSpec.groovy
@@ -1,7 +1,10 @@
 package com.jaredsburrows.license
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import static test.TestUtils.assertHtml
+import static test.TestUtils.assertJson
 import static test.TestUtils.getLicenseText
+import static test.TestUtils.gradleWithCommand
 
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
@@ -62,7 +65,7 @@ final class LicensePluginAndroidSpec extends Specification {
           applicationId 'com.example'
         }
       }
-      """.stripIndent().trim()
+      """
 
     when:
     def result = GradleRunner.create()
@@ -117,40 +120,38 @@ final class LicensePluginAndroidSpec extends Specification {
           applicationId 'com.example'
         }
       }
-      """.stripIndent().trim()
+      """
 
     when:
-    def result = GradleRunner.create()
-      .withProjectDir(testProjectDir.root)
-      .withArguments("${taskName}", '-s')
-      .build()
+    def result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
+    def actualHtml = new File("${reportFolder}/${taskName}.html").text
+    def expectedHtml =
+      """
+      <html>
+        <head>
+          <style>
+            body { font-family: sans-serif } 
+            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }
+          </style>
+          <title>Open source licenses</title>
+        </head>
+        <body>
+          <h3>None</h3>
+        </body>
+      </html>
+      """
+    def actualJson = new File("${reportFolder}/${taskName}.json").text
+    def expectedJson =
+      """
+      []
+      """
 
     then:
     result.task(":${taskName}").outcome == SUCCESS
     result.output.find("Wrote HTML report to .*${reportFolder}/${taskName}.html.")
     result.output.find("Wrote JSON report to .*${reportFolder}/${taskName}.json.")
-
-    def actualHtml = new File("${reportFolder}/${taskName}.html").text.stripIndent().trim()
-    def expectedHtml =
-"""
-<html>
-  <head>
-    <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }</style>
-    <title>Open source licenses</title>
-  </head>
-  <body>
-    <h3>None</h3>
-  </body>
-</html>
-""".stripIndent().trim()
-    def actualJson = new File("${reportFolder}/${taskName}.json").text.stripIndent().trim()
-    def expectedJson =
-"""
-[]
-""".stripIndent().trim()
-
-    actualHtml == expectedHtml
-    actualJson == expectedJson
+    assertHtml(expectedHtml, actualHtml)
+    assertJson(expectedJson, actualJson)
 
     where:
     taskName << ['licenseDebugReport', 'licenseReleaseReport']
@@ -194,85 +195,79 @@ final class LicensePluginAndroidSpec extends Specification {
         implementation 'com.android.support:appcompat-v7:26.1.0'
         implementation 'com.android.support:design:26.1.0'
       }
-      """.stripIndent().trim()
+      """
 
     when:
-    def result = GradleRunner.create()
-      .withProjectDir(testProjectDir.root)
-      .withArguments("${taskName}", '-s')
-      .build()
+    def result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
+    def actualHtml = new File("${reportFolder}/${taskName}.html").text
+    def expectedHtml =
+      """
+      <html>
+        <head>
+          <style>
+            body { font-family: sans-serif } 
+            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }
+          </style>
+          <title>Open source licenses</title>
+        </head>
+        <body>
+          <h3>Notice for packages:</h3>
+          <ul>
+            <li>
+              <a href="#314129783">appcompat-v7</a>
+            </li>
+            <li>
+              <a href="#314129783">design</a>
+            </li>
+            <a name="314129783" />
+            <pre>${getLicenseText('apache-2.0.txt')}</pre>
+          </ul>
+        </body>
+      </html>
+      """
+    def actualJson = new File("${reportFolder}/${taskName}.json").text
+    def expectedJson =
+      """
+      [
+        {
+          "project": "appcompat-v7",
+          "description": null,
+          "version": "26.1.0",
+          "developers": [],
+          "url": null,
+          "year": null,
+          "licenses": [
+            {
+              "license": "The Apache Software License",
+              "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+          ],
+          "dependency": "com.android.support:appcompat-v7:26.1.0"
+        },
+        {
+          "project": "design",
+          "description": null,
+          "version": "26.1.0",
+          "developers": [],
+          "url": null,
+          "year": null,
+          "licenses": [
+            {
+              "license": "The Apache Software License",
+              "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+          ],
+          "dependency": "com.android.support:design:26.1.0"
+        }
+      ]
+      """
 
     then:
     result.task(":${taskName}").outcome == SUCCESS
     result.output.find("Wrote HTML report to .*${reportFolder}/${taskName}.html.")
     result.output.find("Wrote JSON report to .*${reportFolder}/${taskName}.json.")
-
-    def actualHtml = new File("${reportFolder}/${taskName}.html").text.stripIndent().trim()
-    def expectedHtml =
-"""
-<html>
-  <head>
-    <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }</style>
-    <title>Open source licenses</title>
-  </head>
-  <body>
-    <h3>Notice for packages:</h3>
-    <ul>
-      <li>
-        <a href="#314129783">appcompat-v7</a>
-      </li>
-      <li>
-        <a href="#314129783">design</a>
-      </li>
-      <a name="314129783" />
-      <pre>${getLicenseText('apache-2.0.txt')}</pre>
-    </ul>
-  </body>
-</html>
-""".stripIndent().trim()
-    def actualJson = new File("${reportFolder}/${taskName}.json").text.stripIndent().trim()
-    def expectedJson =
-"""
-[
-    {
-        "project": "appcompat-v7",
-        "description": null,
-        "version": "26.1.0",
-        "developers": [
-            
-        ],
-        "url": null,
-        "year": null,
-        "licenses": [
-            {
-                "license": "The Apache Software License",
-                "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
-            }
-        ],
-        "dependency": "com.android.support:appcompat-v7:26.1.0"
-    },
-    {
-        "project": "design",
-        "description": null,
-        "version": "26.1.0",
-        "developers": [
-            
-        ],
-        "url": null,
-        "year": null,
-        "licenses": [
-            {
-                "license": "The Apache Software License",
-                "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
-            }
-        ],
-        "dependency": "com.android.support:design:26.1.0"
-    }
-]
-""".stripIndent().trim()
-
-    actualHtml == expectedHtml
-    actualJson == expectedJson
+    assertHtml(expectedHtml, actualHtml)
+    assertJson(expectedJson, actualJson)
 
     where:
     taskName << ['licenseDebugReport', 'licenseReleaseReport']
@@ -321,85 +316,79 @@ final class LicensePluginAndroidSpec extends Specification {
         debugImplementation 'com.android.support:design:26.1.0'
         releaseImplementation 'com.android.support:design:26.1.0'
       }
-      """.stripIndent().trim()
+      """
 
     when:
-    def result = GradleRunner.create()
-      .withProjectDir(testProjectDir.root)
-      .withArguments("${taskName}", '-s')
-      .build()
+    def result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
+    def actualHtml = new File("${reportFolder}/${taskName}.html").text
+    def expectedHtml =
+      """
+      <html>
+        <head>
+          <style>
+            body { font-family: sans-serif } 
+            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }
+          </style>
+          <title>Open source licenses</title>
+        </head>
+        <body>
+          <h3>Notice for packages:</h3>
+          <ul>
+            <li>
+              <a href="#314129783">appcompat-v7</a>
+            </li>
+            <li>
+              <a href="#314129783">design</a>
+            </li>
+            <a name="314129783" />
+            <pre>${getLicenseText('apache-2.0.txt')}</pre>
+          </ul>
+        </body>
+      </html>
+      """
+    def actualJson = new File("${reportFolder}/${taskName}.json").text
+    def expectedJson =
+      """
+      [
+        {
+          "project": "appcompat-v7",
+          "description": null,
+          "version": "26.1.0",
+          "developers": [],
+          "url": null,
+          "year": null,
+          "licenses": [
+            {
+              "license": "The Apache Software License",
+              "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+          ],
+          "dependency": "com.android.support:appcompat-v7:26.1.0"
+        },
+        {
+          "project": "design",
+          "description": null,
+          "version": "26.1.0",
+          "developers": [],
+          "url": null,
+          "year": null,
+          "licenses": [
+            {
+              "license": "The Apache Software License",
+              "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+          ],
+          "dependency": "com.android.support:design:26.1.0"
+        }
+      ]
+      """
 
     then:
     result.task(":${taskName}").outcome == SUCCESS
     result.output.find("Wrote HTML report to .*${reportFolder}/${taskName}.html.")
     result.output.find("Wrote JSON report to .*${reportFolder}/${taskName}.json.")
-
-    def actualHtml = new File("${reportFolder}/${taskName}.html").text.stripIndent().trim()
-    def expectedHtml =
-"""
-<html>
-  <head>
-    <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }</style>
-    <title>Open source licenses</title>
-  </head>
-  <body>
-    <h3>Notice for packages:</h3>
-    <ul>
-      <li>
-        <a href="#314129783">appcompat-v7</a>
-      </li>
-      <li>
-        <a href="#314129783">design</a>
-      </li>
-      <a name="314129783" />
-      <pre>${getLicenseText('apache-2.0.txt')}</pre>
-    </ul>
-  </body>
-</html>
-""".stripIndent().trim()
-    def actualJson = new File("${reportFolder}/${taskName}.json").text.stripIndent().trim()
-    def expectedJson =
-"""
-[
-    {
-        "project": "appcompat-v7",
-        "description": null,
-        "version": "26.1.0",
-        "developers": [
-            
-        ],
-        "url": null,
-        "year": null,
-        "licenses": [
-            {
-                "license": "The Apache Software License",
-                "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
-            }
-        ],
-        "dependency": "com.android.support:appcompat-v7:26.1.0"
-    },
-    {
-        "project": "design",
-        "description": null,
-        "version": "26.1.0",
-        "developers": [
-            
-        ],
-        "url": null,
-        "year": null,
-        "licenses": [
-            {
-                "license": "The Apache Software License",
-                "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
-            }
-        ],
-        "dependency": "com.android.support:design:26.1.0"
-    }
-]
-""".stripIndent().trim()
-
-    actualHtml == expectedHtml
-    actualJson == expectedJson
+    assertHtml(expectedHtml, actualHtml)
+    assertJson(expectedJson, actualJson)
 
     where:
     taskName << ['licenseDebugReport', 'licenseReleaseReport']
@@ -462,125 +451,115 @@ final class LicensePluginAndroidSpec extends Specification {
         flavor3Implementation 'com.android.support:support-annotations:26.1.0'
         flavor4Implementation 'com.android.support:support-annotations:26.1.0'
       }
-      """.stripIndent().trim()
+      """
 
     when:
-    def result = GradleRunner.create()
-      .withProjectDir(testProjectDir.root)
-      .withArguments("${taskName}", '-s')
-      .build()
+    def result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
+    def actualHtml = new File("${reportFolder}/${taskName}.html").text
+    def expectedHtml =
+      """
+      <html>
+        <head>
+          <style>
+            body { font-family: sans-serif } 
+            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }
+          </style>
+          <title>Open source licenses</title>
+        </head>
+        <body>
+          <h3>Notice for packages:</h3>
+          <ul>
+            <li>
+              <a href="#314129783">appcompat-v7</a>
+            </li>
+            <li>
+              <a href="#314129783">design</a>
+            </li>
+            <li>
+              <a href="#314129783">support-annotations</a>
+            </li>
+            <li>
+              <a href="#314129783">support-v4</a>
+            </li>
+            <a name="314129783" />
+            <pre>${getLicenseText('apache-2.0.txt')}</pre>
+          </ul>
+        </body>
+      </html>
+      """
+    def actualJson = new File("${reportFolder}/${taskName}.json").text
+    def expectedJson =
+      """
+      [
+        {
+          "project": "appcompat-v7",
+          "description": null,
+          "version": "26.1.0",
+          "developers": [],
+          "url": null,
+          "year": null,
+          "licenses": [
+            {
+              "license": "The Apache Software License",
+              "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+          ],
+          "dependency": "com.android.support:appcompat-v7:26.1.0"
+        },
+        {
+          "project": "design",
+          "description": null,
+          "version": "26.1.0",
+          "developers": [],
+          "url": null,
+          "year": null,
+          "licenses": [
+            {
+              "license": "The Apache Software License",
+              "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+          ],
+          "dependency": "com.android.support:design:26.1.0"
+        },
+        {
+          "project": "support-annotations",
+          "description": null,
+          "version": "26.1.0",
+          "developers": [],
+          "url": null,
+          "year": null,
+          "licenses": [
+            {
+              "license": "The Apache Software License",
+              "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+          ],
+          "dependency": "com.android.support:support-annotations:26.1.0"
+        },
+        {
+          "project": "support-v4",
+          "description": null,
+          "version": "26.1.0",
+          "developers": [],
+          "url": null,
+          "year": null,
+          "licenses": [
+            {
+              "license": "The Apache Software License",
+              "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+          ],
+          "dependency": "com.android.support:support-v4:26.1.0"
+        }
+      ]
+      """
 
     then:
     result.task(":${taskName}").outcome == SUCCESS
     result.output.find("Wrote HTML report to .*${reportFolder}/${taskName}.html.")
     result.output.find("Wrote JSON report to .*${reportFolder}/${taskName}.json.")
-
-    def actualHtml = new File("${reportFolder}/${taskName}.html").text.stripIndent().trim()
-    def expectedHtml =
-"""
-<html>
-  <head>
-    <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }</style>
-    <title>Open source licenses</title>
-  </head>
-  <body>
-    <h3>Notice for packages:</h3>
-    <ul>
-      <li>
-        <a href="#314129783">appcompat-v7</a>
-      </li>
-      <li>
-        <a href="#314129783">design</a>
-      </li>
-      <li>
-        <a href="#314129783">support-annotations</a>
-      </li>
-      <li>
-        <a href="#314129783">support-v4</a>
-      </li>
-      <a name="314129783" />
-      <pre>${getLicenseText('apache-2.0.txt')}</pre>
-    </ul>
-  </body>
-</html>
-""".stripIndent().trim()
-    def actualJson = new File("${reportFolder}/${taskName}.json").text.stripIndent().trim()
-    def expectedJson =
-"""
-[
-    {
-        "project": "appcompat-v7",
-        "description": null,
-        "version": "26.1.0",
-        "developers": [
-            
-        ],
-        "url": null,
-        "year": null,
-        "licenses": [
-            {
-                "license": "The Apache Software License",
-                "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
-            }
-        ],
-        "dependency": "com.android.support:appcompat-v7:26.1.0"
-    },
-    {
-        "project": "design",
-        "description": null,
-        "version": "26.1.0",
-        "developers": [
-            
-        ],
-        "url": null,
-        "year": null,
-        "licenses": [
-            {
-                "license": "The Apache Software License",
-                "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
-            }
-        ],
-        "dependency": "com.android.support:design:26.1.0"
-    },
-    {
-        "project": "support-annotations",
-        "description": null,
-        "version": "26.1.0",
-        "developers": [
-            
-        ],
-        "url": null,
-        "year": null,
-        "licenses": [
-            {
-                "license": "The Apache Software License",
-                "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
-            }
-        ],
-        "dependency": "com.android.support:support-annotations:26.1.0"
-    },
-    {
-        "project": "support-v4",
-        "description": null,
-        "version": "26.1.0",
-        "developers": [
-            
-        ],
-        "url": null,
-        "year": null,
-        "licenses": [
-            {
-                "license": "The Apache Software License",
-                "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
-            }
-        ],
-        "dependency": "com.android.support:support-v4:26.1.0"
-    }
-]
-""".stripIndent().trim()
-
-    actualHtml == expectedHtml
-    actualJson == expectedJson
+    assertHtml(expectedHtml, actualHtml)
+    assertJson(expectedJson, actualJson)
 
     where:
     taskName << ['licenseFlavor1Flavor3DebugReport', 'licenseFlavor1Flavor3ReleaseReport',
@@ -635,14 +614,12 @@ final class LicensePluginAndroidSpec extends Specification {
 
       dependencies {
       }
-      """.stripIndent().trim()
+      """
 
     when:
-    def result = GradleRunner.create()
-      .withProjectDir(testProjectDir.root)
-      .withArguments("licenseFlavor1Flavor3DebugReport", "licenseFlavor1Flavor3ReleaseReport",
-      "licenseFlavor2Flavor4DebugReport", "licenseFlavor2Flavor4ReleaseReport", '-s')
-      .build()
+    def result = gradleWithCommand(testProjectDir.root, 'licenseFlavor1Flavor3DebugReport',
+      'licenseFlavor1Flavor3ReleaseReport', 'licenseFlavor2Flavor4DebugReport',
+      'licenseFlavor2Flavor4ReleaseReport', '-s')
 
     then:
     result.task(":licenseFlavor1Flavor3DebugReport").outcome == SUCCESS
@@ -689,87 +666,83 @@ final class LicensePluginAndroidSpec extends Specification {
         releaseImplementation 'com.android.support:design:26.1.0'
         releaseImplementation 'pl.droidsonroids.gif:android-gif-drawable:1.2.3'
       }
-      """.stripIndent().trim()
+      """
 
     when:
-    def result = GradleRunner.create()
-      .withProjectDir(testProjectDir.root)
-      .withArguments("${taskName}", '-s')
-      .build()
+    def result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
+    def actualHtml = new File("${reportFolder}/${taskName}.html").text
+    def expectedHtml =
+      """
+      <html>
+        <head>
+          <style>
+            body { font-family: sans-serif } 
+            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }
+          </style>
+          <title>Open source licenses</title>
+        </head>
+        <body>
+          <h3>Notice for packages:</h3>
+          <ul>
+            <li>
+              <a href="#1068328410">Android GIF Drawable Library</a>
+            </li>
+            <a name="1068328410" />
+            <pre>${getLicenseText('mit.txt')}</pre>
+            <li>
+              <a href="#314129783">design</a>
+            </li>
+            <a name="314129783" />
+            <pre>${getLicenseText('apache-2.0.txt')}</pre>
+          </ul>
+        </body>
+      </html>
+      """
+    def actualJson = new File("${reportFolder}/${taskName}.json").text
+    def expectedJson =
+      """
+      [
+        {
+          "project":"Android GIF Drawable Library",
+          "description":"Views and Drawable for displaying animated GIFs for Android",
+          "version":"1.2.3",
+          "developers":[
+            "Karol Wr\\u00c3\\u00b3tniak"
+          ],
+          "url":"https://github.com/koral--/android-gif-drawable",
+          "year":null,
+          "licenses":[
+            {
+              "license":"The MIT License",
+              "license_url":"http://opensource.org/licenses/MIT"
+            }
+          ],
+          "dependency":"pl.droidsonroids.gif:android-gif-drawable:1.2.3"
+        },
+        {
+          "project":"design",
+          "description":null,
+          "version":"26.1.0",
+          "developers":[],
+          "url":null,
+          "year":null,
+          "licenses":[
+            {
+              "license":"The Apache Software License",
+              "license_url":"http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+          ],
+          "dependency":"com.android.support:design:26.1.0"
+        }
+      ]
+      """
 
     then:
     result.task(":${taskName}").outcome == SUCCESS
     result.output.find("Wrote HTML report to .*${reportFolder}/${taskName}.html.")
     result.output.find("Wrote JSON report to .*${reportFolder}/${taskName}.json.")
-
-    def actualHtml = new File("${reportFolder}/${taskName}.html").text.stripIndent().trim()
-    def expectedHtml =
-"""
-<html>
-  <head>
-    <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }</style>
-    <title>Open source licenses</title>
-  </head>
-  <body>
-    <h3>Notice for packages:</h3>
-    <ul>
-      <li>
-        <a href="#1068328410">Android GIF Drawable Library</a>
-      </li>
-      <a name="1068328410" />
-      <pre>${getLicenseText('mit.txt')}</pre>
-      <li>
-        <a href="#314129783">design</a>
-      </li>
-      <a name="314129783" />
-      <pre>${getLicenseText('apache-2.0.txt')}</pre>
-    </ul>
-  </body>
-</html>
-""".stripIndent().trim()
-    def actualJson = new File("${reportFolder}/${taskName}.json").text.stripIndent().trim()
-    def expectedJson =
-"""
-[
-    {
-        "project": "Android GIF Drawable Library",
-        "description": "Views and Drawable for displaying animated GIFs for Android",
-        "version": "1.2.3",
-        "developers": [
-            "Karol Wr\\u00c3\\u00b3tniak"
-        ],
-        "url": "https://github.com/koral--/android-gif-drawable",
-        "year": null,
-        "licenses": [
-            {
-                "license": "The MIT License",
-                "license_url": "http://opensource.org/licenses/MIT"
-            }
-        ],
-        "dependency": "pl.droidsonroids.gif:android-gif-drawable:1.2.3"
-    },
-    {
-        "project": "design",
-        "description": null,
-        "version": "26.1.0",
-        "developers": [
-            
-        ],
-        "url": null,
-        "year": null,
-        "licenses": [
-            {
-                "license": "The Apache Software License",
-                "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
-            }
-        ],
-        "dependency": "com.android.support:design:26.1.0"
-    }
-]
-""".stripIndent().trim()
-
-    actualHtml == expectedHtml
-    actualJson == expectedJson
+    assertHtml(expectedHtml, actualHtml)
+    assertJson(expectedJson, actualJson)
 
     where:
     taskName << ['licenseDebugReport', 'licenseReleaseReport']
@@ -813,60 +786,55 @@ final class LicensePluginAndroidSpec extends Specification {
       """
 
     when:
-    def result = GradleRunner.create()
-      .withProjectDir(testProjectDir.root)
-      .withArguments("${taskName}", '-s')
-      .build()
+    def result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
+    def actualHtml = new File("${reportFolder}/${taskName}.html").text
+    def expectedHtml =
+      """
+      <html>
+        <head>
+          <style>
+            body { font-family: sans-serif } 
+            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }
+          </style>
+          <title>Open source licenses</title>
+        </head>
+        <body>
+          <h3>Notice for packages:</h3>
+          <ul>
+            <li>
+              <a href="#0">Fake dependency name</a>
+            </li>
+            <a name="0" />
+            <pre>No license found</pre>
+          </ul>
+        </body>
+      </html>
+      """
+    def actualJson = new File("${reportFolder}/${taskName}.json").text
+    def expectedJson =
+      """
+      [
+        {
+          "project":"Fake dependency name",
+          "description":"Fake dependency description",
+          "version":"1.0.0",
+          "developers":[
+            "name"
+          ],
+          "url":"https://github.com/user/repo",
+          "year":"2017",
+          "licenses":[],
+          "dependency":"group:name4:1.0.0"
+        }
+      ]
+      """
 
     then:
     result.task(":${taskName}").outcome == SUCCESS
     result.output.find("Wrote HTML report to .*${reportFolder}/${taskName}.html.")
     result.output.find("Wrote JSON report to .*${reportFolder}/${taskName}.json.")
-
-    def actualHtml = new File("${reportFolder}/${taskName}.html").text.stripIndent().trim()
-    def expectedHtml =
-"""
-<html>
-  <head>
-    <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }</style>
-    <title>Open source licenses</title>
-  </head>
-  <body>
-    <h3>Notice for packages:</h3>
-    <ul>
-      <li>
-        <a href="#0">Fake dependency name</a>
-      </li>
-      <a name="0" />
-      <pre>No license found</pre>
-    </ul>
-  </body>
-</html>
-""".stripIndent().trim()
-    def actualJson = new File("${reportFolder}/${taskName}.json").text.stripIndent().trim()
-    def expectedJson =
-"""
-[
-    {
-        "project": "Fake dependency name",
-        "description": "Fake dependency description",
-        "version": "1.0.0",
-        "developers": [
-            "name"
-        ],
-        "url": "https://github.com/user/repo",
-        "year": "2017",
-        "licenses": [
-            
-        ],
-        "dependency": "group:name4:1.0.0"
-    }
-]
-""".stripIndent().trim()
-
-    then:
-    actualHtml == expectedHtml
-    actualJson == expectedJson
+    assertHtml(expectedHtml, actualHtml)
+    assertJson(expectedJson, actualJson)
 
     where:
     taskName << ['licenseDebugReport', 'licenseReleaseReport']
@@ -926,86 +894,81 @@ final class LicensePluginAndroidSpec extends Specification {
       """
 
     when:
-    def result = GradleRunner.create()
-      .withProjectDir(testProjectDir.root)
-      .withArguments("${taskName}", '-s')
-      .build()
+    def result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
+    def actualHtml = new File("${reportFolder}/${taskName}.html").text
+    def expectedHtml =
+      """
+      <html>
+        <head>
+          <style>
+            body { font-family: sans-serif } 
+            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }
+          </style>
+          <title>Open source licenses</title>
+        </head>
+        <body>
+          <h3>Notice for packages:</h3>
+          <ul>
+            <li>
+              <a href="#314129783">design</a>
+            </li>
+            <a name="314129783" />
+            <pre>${getLicenseText('apache-2.0.txt')}</pre>
+            <li>
+              <a href="#755498312">Fake dependency name</a>
+            </li>
+            <a name="755498312" />
+            <pre>Some license
+            <a href="http://website.tld/">http://website.tld/</a></pre>
+          </ul>
+        </body>
+      </html>
+      """
+    def actualJson = new File("${reportFolder}/${taskName}.json").text
+    def expectedJson =
+      """
+      [
+        {
+          "project":"design",
+          "description":null,
+          "version":"26.1.0",
+          "developers":[],
+          "url":null,
+          "year":null,
+          "licenses":[
+            {
+              "license":"The Apache Software License",
+              "license_url":"http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+          ],
+          "dependency":"com.android.support:design:26.1.0"
+        },
+        {
+          "project":"Fake dependency name",
+          "description":"Fake dependency description",
+          "version":"1.0.0",
+          "developers":[
+            "name"
+          ],
+          "url":"https://github.com/user/repo",
+          "year":"2017",
+          "licenses":[
+            {
+              "license":"Some license",
+              "license_url":"http://website.tld/"
+            }
+          ],
+          "dependency":"group:name:1.0.0"
+        }
+      ]
+      """
 
     then:
     result.task(":${taskName}").outcome == SUCCESS
     result.output.find("Wrote HTML report to .*${reportFolder}/${taskName}.html.")
     result.output.find("Wrote JSON report to .*${reportFolder}/${taskName}.json.")
-
-    def actualHtml = new File("${reportFolder}/${taskName}.html").text.stripIndent().trim()
-    def expectedHtml =
-"""
-<html>
-  <head>
-    <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }</style>
-    <title>Open source licenses</title>
-  </head>
-  <body>
-    <h3>Notice for packages:</h3>
-    <ul>
-      <li>
-        <a href="#314129783">design</a>
-      </li>
-      <a name="314129783" />
-      <pre>${getLicenseText('apache-2.0.txt')}</pre>
-      <li>
-        <a href="#755498312">Fake dependency name</a>
-      </li>
-      <a name="755498312" />
-      <pre>Some license
-<a href="http://website.tld/">http://website.tld/</a></pre>
-    </ul>
-  </body>
-</html>
-""".stripIndent().trim()
-    def actualJson = new File("${reportFolder}/${taskName}.json").text.stripIndent().trim()
-    def expectedJson =
-"""
-[
-    {
-        "project": "design",
-        "description": null,
-        "version": "26.1.0",
-        "developers": [
-            
-        ],
-        "url": null,
-        "year": null,
-        "licenses": [
-            {
-                "license": "The Apache Software License",
-                "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
-            }
-        ],
-        "dependency": "com.android.support:design:26.1.0"
-    },
-    {
-        "project": "Fake dependency name",
-        "description": "Fake dependency description",
-        "version": "1.0.0",
-        "developers": [
-            "name"
-        ],
-        "url": "https://github.com/user/repo",
-        "year": "2017",
-        "licenses": [
-            {
-                "license": "Some license",
-                "license_url": "http://website.tld/"
-            }
-        ],
-        "dependency": "group:name:1.0.0"
-    }
-]
-""".stripIndent().trim()
-
-    then:
-    actualHtml == expectedHtml
-    actualJson == expectedJson
+    assertHtml(expectedHtml, actualHtml)
+    assertJson(expectedJson, actualJson)
 
     where:
     taskName << ['licenseDebugReport', 'licenseReleaseReport']

--- a/src/test/groovy/com/jaredsburrows/license/LicensePluginJavaSpec.groovy
+++ b/src/test/groovy/com/jaredsburrows/license/LicensePluginJavaSpec.groovy
@@ -1,7 +1,10 @@
 package com.jaredsburrows.license
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import static test.TestUtils.assertHtml
+import static test.TestUtils.assertJson
 import static test.TestUtils.getLicenseText
+import static test.TestUtils.gradleWithCommand
 
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
@@ -67,38 +70,35 @@ final class LicensePluginJavaSpec extends Specification {
       """
 
     when:
-    def result = GradleRunner.create()
-      .withProjectDir(testProjectDir.root)
-      .withArguments('licenseReport', '-s')
-      .withPluginClasspath()
-      .build()
+    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    def actualHtml = new File("${reportFolder}/licenseReport.html").text
+    def expectedHtml =
+      """
+      <html>
+        <head>
+          <style>
+            body { font-family: sans-serif } 
+            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }
+          </style>
+          <title>Open source licenses</title>
+        </head>
+        <body>
+          <h3>None</h3>
+        </body>
+      </html>
+      """
+    def actualJson = new File("${reportFolder}/licenseReport.json").text
+    def expectedJson =
+      """
+      []
+      """
 
     then:
     result.task(':licenseReport').outcome == SUCCESS
     result.output.find("Wrote HTML report to .*${reportFolder}/licenseReport.html.")
     result.output.find("Wrote JSON report to .*${reportFolder}/licenseReport.json.")
-
-    def actualHtml = new File("${reportFolder}/licenseReport.html").text.stripIndent().trim()
-    def expectedHtml =
-"""
-<html>
-  <head>
-    <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }</style>
-    <title>Open source licenses</title>
-  </head>
-  <body>
-    <h3>None</h3>
-  </body>
-</html>
-""".stripIndent().trim()
-    def actualJson = new File("${reportFolder}/licenseReport.json").text.stripIndent().trim()
-    def expectedJson =
-"""
-[]
-""".stripIndent().trim()
-
-    actualHtml == expectedHtml
-    actualJson == expectedJson
+    assertHtml(expectedHtml, actualHtml)
+    assertJson(expectedJson, actualJson)
   }
 
   def 'licenseReport with no open source dependencies'() {
@@ -122,60 +122,53 @@ final class LicensePluginJavaSpec extends Specification {
       """
 
     when:
-    def result = GradleRunner.create()
-      .withProjectDir(testProjectDir.root)
-      .withArguments('licenseReport', '-s')
-      .withPluginClasspath()
-      .build()
+    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    def actualHtml = new File("${reportFolder}/licenseReport.html").text
+    def expectedHtml =
+      """
+      <html>
+        <head>
+          <style>
+            body { font-family: sans-serif } 
+            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }
+          </style>
+          <title>Open source licenses</title>
+        </head>
+        <body>
+          <h3>Notice for packages:</h3>
+          <ul>
+            <li>
+              <a href="#0">firebase-core</a>
+            </li>
+            <a name="0" />
+            <pre>No license found</pre>
+          </ul>
+        </body>
+      </html>
+      """
+    def actualJson = new File("${reportFolder}/licenseReport.json").text
+    def expectedJson =
+      """
+      [
+        {
+          "project":"firebase-core",
+          "description":null,
+          "version":"10.0.1",
+          "developers":[],
+          "url":null,
+          "year":null,
+          "licenses":[],
+          "dependency":"com.google.firebase:firebase-core:10.0.1"
+        }
+      ]
+      """
 
     then:
     result.task(':licenseReport').outcome == SUCCESS
     result.output.find("Wrote HTML report to .*${reportFolder}/licenseReport.html.")
     result.output.find("Wrote JSON report to .*${reportFolder}/licenseReport.json.")
-
-    def actualHtml = new File("${reportFolder}/licenseReport.html").text.stripIndent().trim()
-    def expectedHtml =
-"""
-<html>
-  <head>
-    <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }</style>
-    <title>Open source licenses</title>
-  </head>
-  <body>
-    <h3>Notice for packages:</h3>
-    <ul>
-      <li>
-        <a href="#0">firebase-core</a>
-      </li>
-      <a name="0" />
-      <pre>No license found</pre>
-    </ul>
-  </body>
-</html>
-""".stripIndent().trim()
-    def actualJson = new File("${reportFolder}/licenseReport.json").text.stripIndent().trim()
-    def expectedJson =
-"""
-[
-    {
-        "project": "firebase-core",
-        "description": null,
-        "version": "10.0.1",
-        "developers": [
-            
-        ],
-        "url": null,
-        "year": null,
-        "licenses": [
-            
-        ],
-        "dependency": "com.google.firebase:firebase-core:10.0.1"
-    }
-]
-""".stripIndent().trim()
-
-    actualHtml == expectedHtml
-    actualJson == expectedJson
+    assertHtml(expectedHtml, actualHtml)
+    assertJson(expectedJson, actualJson)
   }
 
   def 'licenseReport with duplicate dependencies'() {
@@ -201,83 +194,76 @@ final class LicensePluginJavaSpec extends Specification {
       """
 
     when:
-    def result = GradleRunner.create()
-      .withProjectDir(testProjectDir.root)
-      .withArguments('licenseReport', '-s')
-      .withPluginClasspath()
-      .build()
+    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    def actualHtml = new File("${reportFolder}/licenseReport.html").text
+    def expectedHtml =
+      """
+      <html>
+        <head>
+          <style>
+            body { font-family: sans-serif } 
+            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }
+          </style>
+          <title>Open source licenses</title>
+        </head>
+        <body>
+          <h3>Notice for packages:</h3>
+          <ul>
+            <li>
+              <a href="#314129783">appcompat-v7</a>
+            </li>
+            <li>
+              <a href="#314129783">design</a>
+            </li>
+            <a name="314129783" />
+            <pre>${getLicenseText('apache-2.0.txt')}</pre>
+          </ul>
+        </body>
+      </html>
+      """
+    def actualJson = new File("${reportFolder}/licenseReport.json").text
+    def expectedJson =
+      """
+      [
+        {
+          "project":"appcompat-v7",
+          "description":null,
+          "version":"26.1.0",
+          "developers":[],
+          "url":null,
+          "year":null,
+          "licenses":[
+            {
+              "license":"The Apache Software License",
+              "license_url":"http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+          ],
+          "dependency":"com.android.support:appcompat-v7:26.1.0"
+        },
+        {
+          "project":"design",
+          "description":null,
+          "version":"26.1.0",
+          "developers":[],
+          "url":null,
+          "year":null,
+          "licenses":[
+            {
+              "license":"The Apache Software License",
+              "license_url":"http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+          ],
+          "dependency":"com.android.support:design:26.1.0"
+        }
+      ]
+      """
 
     then:
     result.task(':licenseReport').outcome == SUCCESS
     result.output.find("Wrote HTML report to .*${reportFolder}/licenseReport.html.")
     result.output.find("Wrote JSON report to .*${reportFolder}/licenseReport.json.")
-
-    def actualHtml = new File("${reportFolder}/licenseReport.html").text.stripIndent().trim()
-    def expectedHtml =
-"""
-<html>
-  <head>
-    <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }</style>
-    <title>Open source licenses</title>
-  </head>
-  <body>
-    <h3>Notice for packages:</h3>
-    <ul>
-      <li>
-        <a href="#314129783">appcompat-v7</a>
-      </li>
-      <li>
-        <a href="#314129783">design</a>
-      </li>
-      <a name="314129783" />
-      <pre>${getLicenseText('apache-2.0.txt')}</pre>
-    </ul>
-  </body>
-</html>
-""".stripIndent().trim()
-    def actualJson = new File("${reportFolder}/licenseReport.json").text.stripIndent().trim()
-    def expectedJson =
-"""
-[
-    {
-        "project": "appcompat-v7",
-        "description": null,
-        "version": "26.1.0",
-        "developers": [
-            
-        ],
-        "url": null,
-        "year": null,
-        "licenses": [
-            {
-                "license": "The Apache Software License",
-                "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
-            }
-        ],
-        "dependency": "com.android.support:appcompat-v7:26.1.0"
-    },
-    {
-        "project": "design",
-        "description": null,
-        "version": "26.1.0",
-        "developers": [
-            
-        ],
-        "url": null,
-        "year": null,
-        "licenses": [
-            {
-                "license": "The Apache Software License",
-                "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
-            }
-        ],
-        "dependency": "com.android.support:design:26.1.0"
-    }
-]
-""".stripIndent().trim()
-
-    actualHtml == expectedHtml
-    actualJson == expectedJson
+    assertHtml(expectedHtml, actualHtml)
+    assertJson(expectedJson, actualJson)
   }
 
   def 'licenseReport with dependency with full pom with project name, developers, url, year, bad license'() {
@@ -301,38 +287,35 @@ final class LicensePluginJavaSpec extends Specification {
       """
 
     when:
-    def result = GradleRunner.create()
-      .withProjectDir(testProjectDir.root)
-      .withArguments('licenseReport', '-s')
-      .withPluginClasspath()
-      .build()
+    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    def actualHtml = new File("${reportFolder}/licenseReport.html").text
+    def expectedHtml =
+      """
+      <html>
+        <head>
+          <style>
+            body { font-family: sans-serif } 
+            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }
+          </style>
+          <title>Open source licenses</title>
+        </head>
+        <body>
+          <h3>None</h3>
+        </body>
+      </html>
+      """
+    def actualJson = new File("${reportFolder}/licenseReport.json").text
+    def expectedJson =
+      """
+      []
+      """
 
     then:
     result.task(':licenseReport').outcome == SUCCESS
     result.output.find("Wrote HTML report to .*${reportFolder}/licenseReport.html.")
     result.output.find("Wrote JSON report to .*${reportFolder}/licenseReport.json.")
-
-    def actualHtml = new File("${reportFolder}/licenseReport.html").text.stripIndent().trim()
-    def expectedHtml =
-"""
-<html>
-  <head>
-    <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }</style>
-    <title>Open source licenses</title>
-  </head>
-  <body>
-    <h3>None</h3>
-  </body>
-</html>
-""".stripIndent().trim()
-    def actualJson = new File("${reportFolder}/licenseReport.json").text.stripIndent().trim()
-    def expectedJson =
-"""
-[]
-""".stripIndent().trim()
-
-    actualHtml == expectedHtml
-    actualJson == expectedJson
+    assertHtml(expectedHtml, actualHtml)
+    assertJson(expectedJson, actualJson)
   }
 
   def 'licenseReport with dependency with full pom and project name, developers, url, year, single license'() {
@@ -356,64 +339,61 @@ final class LicensePluginJavaSpec extends Specification {
       """
 
     when:
-    def result = GradleRunner.create()
-      .withProjectDir(testProjectDir.root)
-      .withArguments('licenseReport', '-s')
-      .withPluginClasspath()
-      .build()
+    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    def actualHtml = new File("${reportFolder}/licenseReport.html").text
+    def expectedHtml =
+      """
+      <html>
+        <head>
+          <style>
+            body { font-family: sans-serif } 
+            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }
+          </style>
+          <title>Open source licenses</title>
+        </head>
+        <body>
+          <h3>Notice for packages:</h3>
+          <ul>
+            <li>
+              <a href="#755498312">Fake dependency name</a>
+            </li>
+            <a name="755498312" />
+            <pre>Some license
+            <a href="http://website.tld/">http://website.tld/</a></pre>
+          </ul>
+        </body>
+      </html>
+      """
+    def actualJson = new File("${reportFolder}/licenseReport.json").text
+    def expectedJson =
+      """
+      [
+        {
+          "project":"Fake dependency name",
+          "description":"Fake dependency description",
+          "version":"1.0.0",
+          "developers":[
+            "name"
+          ],
+          "url":"https://github.com/user/repo",
+          "year":"2017",
+          "licenses":[
+            {
+              "license":"Some license",
+              "license_url":"http://website.tld/"
+            }
+          ],
+          "dependency":"group:name:1.0.0"
+        }
+      ]
+      """
 
     then:
     result.task(':licenseReport').outcome == SUCCESS
     result.output.find("Wrote HTML report to .*${reportFolder}/licenseReport.html.")
     result.output.find("Wrote JSON report to .*${reportFolder}/licenseReport.json.")
-
-    def actualHtml = new File("${reportFolder}/licenseReport.html").text.stripIndent().trim()
-    def expectedHtml =
-"""
-<html>
-  <head>
-    <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }</style>
-    <title>Open source licenses</title>
-  </head>
-  <body>
-    <h3>Notice for packages:</h3>
-    <ul>
-      <li>
-        <a href="#755498312">Fake dependency name</a>
-      </li>
-      <a name="755498312" />
-      <pre>Some license
-<a href="http://website.tld/">http://website.tld/</a></pre>
-    </ul>
-  </body>
-</html>
-""".stripIndent().trim()
-    def actualJson = new File("${reportFolder}/licenseReport.json").text.stripIndent().trim()
-    def expectedJson =
-"""
-[
-    {
-        "project": "Fake dependency name",
-        "description": "Fake dependency description",
-        "version": "1.0.0",
-        "developers": [
-            "name"
-        ],
-        "url": "https://github.com/user/repo",
-        "year": "2017",
-        "licenses": [
-            {
-                "license": "Some license",
-                "license_url": "http://website.tld/"
-            }
-        ],
-        "dependency": "group:name:1.0.0"
-    }
-]
-""".stripIndent().trim()
-
-    actualHtml == expectedHtml
-    actualJson == expectedJson
+    assertHtml(expectedHtml, actualHtml)
+    assertJson(expectedJson, actualJson)
   }
 
   def 'licenseReport dependency with full pom - project name, multiple developers, url, year, multiple licenses'() {
@@ -437,68 +417,62 @@ final class LicensePluginJavaSpec extends Specification {
       """
 
     when:
-    def result = GradleRunner.create()
-      .withProjectDir(testProjectDir.root)
-      .withArguments('licenseReport', '-s')
-      .withPluginClasspath()
-      .build()
+    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    def actualHtml = new File("${reportFolder}/licenseReport.html").text
+    def expectedHtml =
+      """
+      <html>
+        <head>
+          <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }</style>
+          <title>Open source licenses</title>
+        </head>
+        <body>
+          <h3>Notice for packages:</h3>
+          <ul>
+            <li>
+              <a href="#755498312">Fake dependency name</a>
+            </li>
+            <a name="755498312" />
+            <pre>Some license
+            <a href="http://website.tld/">http://website.tld/</a></pre>
+          </ul>
+        </body>
+      </html>
+      """
+    def actualJson = new File("${reportFolder}/licenseReport.json").text
+    def expectedJson =
+      """
+      [
+        {
+          "project":"Fake dependency name",
+          "description":"Fake dependency description",
+          "version":"1.0.0",
+          "developers":[
+            "name"
+          ],
+          "url":"https://github.com/user/repo",
+          "year":"2017",
+          "licenses":[
+            {
+              "license":"Some license",
+              "license_url":"http://website.tld/"
+            },
+            {
+              "license":"Some license",
+              "license_url":"http://website.tld/"
+            }
+          ],
+          "dependency":"group:name2:1.0.0"
+        }
+      ]
+      """
 
     then:
     result.task(':licenseReport').outcome == SUCCESS
     result.output.find("Wrote HTML report to .*${reportFolder}/licenseReport.html.")
     result.output.find("Wrote JSON report to .*${reportFolder}/licenseReport.json.")
-
-    def actualHtml = new File("${reportFolder}/licenseReport.html").text.stripIndent().trim()
-    def expectedHtml =
-"""
-<html>
-  <head>
-    <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }</style>
-    <title>Open source licenses</title>
-  </head>
-  <body>
-    <h3>Notice for packages:</h3>
-    <ul>
-      <li>
-        <a href="#755498312">Fake dependency name</a>
-      </li>
-      <a name="755498312" />
-      <pre>Some license
-<a href="http://website.tld/">http://website.tld/</a></pre>
-    </ul>
-  </body>
-</html>
-""".stripIndent().trim()
-    def actualJson = new File("${reportFolder}/licenseReport.json").text.stripIndent().trim()
-    def expectedJson =
-"""
-[
-    {
-        "project": "Fake dependency name",
-        "description": "Fake dependency description",
-        "version": "1.0.0",
-        "developers": [
-            "name"
-        ],
-        "url": "https://github.com/user/repo",
-        "year": "2017",
-        "licenses": [
-            {
-                "license": "Some license",
-                "license_url": "http://website.tld/"
-            },
-            {
-                "license": "Some license",
-                "license_url": "http://website.tld/"
-            }
-        ],
-        "dependency": "group:name2:1.0.0"
-    }
-]
-""".stripIndent().trim()
-
-    actualHtml == expectedHtml
-    actualJson == expectedJson
+    assertHtml(expectedHtml, actualHtml)
+    assertJson(expectedJson, actualJson)
   }
 
   def 'licenseReport with dependency without license information that in parent pom'() {
@@ -523,86 +497,81 @@ final class LicensePluginJavaSpec extends Specification {
       """
 
     when:
-    def result = GradleRunner.create()
-      .withProjectDir(testProjectDir.root)
-      .withArguments('licenseReport', '-s')
-      .withPluginClasspath()
-      .build()
+    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    def actualHtml = new File("${reportFolder}/licenseReport.html").text
+    def expectedHtml =
+      """
+      <html>
+        <head>
+          <style>
+            body { font-family: sans-serif } 
+            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }
+          </style>
+          <title>Open source licenses</title>
+        </head>
+        <body>
+          <h3>Notice for packages:</h3>
+          <ul>
+            <li>
+              <a href="#314129783">Retrofit</a>
+            </li>
+            <a name="314129783" />
+            <pre>${getLicenseText('apache-2.0.txt')}</pre>
+            <li>
+              <a href="#755498312">Fake dependency name</a>
+            </li>
+            <a name="755498312" />
+            <pre>Some license
+            <a href="http://website.tld/">http://website.tld/</a></pre>
+          </ul>
+        </body>
+      </html>
+      """
+    def actualJson = new File("${reportFolder}/licenseReport.json").text
+    def expectedJson =
+      """
+      [
+        {
+          "project":"Fake dependency name",
+          "description":"Fake dependency description",
+          "version":"1.0.0",
+          "developers":[
+            "name"
+          ],
+          "url":"https://github.com/user/repo",
+          "year":"2017",
+          "licenses":[
+            {
+              "license":"Some license",
+              "license_url":"http://website.tld/"
+            }
+          ],
+          "dependency":"group:child:1.0.0"
+        },
+        {
+          "project":"Retrofit",
+          "description":null,
+          "version":"2.3.0",
+          "developers":[],
+          "url":null,
+          "year":null,
+          "licenses":[
+            {
+              "license":"Apache 2.0",
+              "license_url":"http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+          ],
+          "dependency":"com.squareup.retrofit2:retrofit:2.3.0"
+        }
+      ]
+      """
 
     then:
     result.task(':licenseReport').outcome == SUCCESS
     result.output.find("Wrote HTML report to .*${reportFolder}/licenseReport.html.")
     result.output.find("Wrote JSON report to .*${reportFolder}/licenseReport.json.")
-
-    def actualHtml = new File("${reportFolder}/licenseReport.html").text.stripIndent().trim()
-    def expectedHtml =
-"""
-<html>
-  <head>
-    <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }</style>
-    <title>Open source licenses</title>
-  </head>
-  <body>
-    <h3>Notice for packages:</h3>
-    <ul>
-      <li>
-        <a href="#314129783">Retrofit</a>
-      </li>
-      <a name="314129783" />
-      <pre>${getLicenseText('apache-2.0.txt')}</pre>
-      <li>
-        <a href="#755498312">Fake dependency name</a>
-      </li>
-      <a name="755498312" />
-      <pre>Some license
-<a href="http://website.tld/">http://website.tld/</a></pre>
-    </ul>
-  </body>
-</html>
-""".stripIndent().trim()
-    def actualJson = new File("${reportFolder}/licenseReport.json").text.stripIndent().trim()
-    def expectedJson =
-"""
-[
-    {
-        "project": "Fake dependency name",
-        "description": "Fake dependency description",
-        "version": "1.0.0",
-        "developers": [
-            "name"
-        ],
-        "url": "https://github.com/user/repo",
-        "year": "2017",
-        "licenses": [
-            {
-                "license": "Some license",
-                "license_url": "http://website.tld/"
-            }
-        ],
-        "dependency": "group:child:1.0.0"
-    },
-    {
-        "project": "Retrofit",
-        "description": null,
-        "version": "2.3.0",
-        "developers": [
-            
-        ],
-        "url": null,
-        "year": null,
-        "licenses": [
-            {
-                "license": "Apache 2.0",
-                "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
-            }
-        ],
-        "dependency": "com.squareup.retrofit2:retrofit:2.3.0"
-    }
-]
-""".stripIndent().trim()
-
-    actualHtml == expectedHtml
-    actualJson == expectedJson
+    assertHtml(expectedHtml, actualHtml)
+    assertJson(expectedJson, actualJson)
   }
 
   def 'licenseReport with project dependencies - multi java modules'() {
@@ -641,84 +610,76 @@ final class LicensePluginJavaSpec extends Specification {
       }
       """
     when:
-    def result = GradleRunner.create()
-      .withProjectDir(testProjectDir.root)
-      .withArguments('licenseReport', '-s')
-      .withPluginClasspath()
-      .build()
+    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    def actualHtml = new File("${reportFolder}/licenseReport.html").text
+    def expectedHtml =
+      """
+      <html>
+        <head>
+          <style>
+            body { font-family: sans-serif } 
+            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }
+          </style>
+          <title>Open source licenses</title>
+        </head>
+        <body>
+          <h3>Notice for packages:</h3>
+          <ul>
+            <li>
+              <a href="#314129783">appcompat-v7</a>
+            </li>
+            <li>
+              <a href="#314129783">design</a>
+            </li>
+            <a name="314129783" />
+            <pre>${getLicenseText('apache-2.0.txt')}</pre>
+          </ul>
+        </body>
+      </html>
+      """
+    def actualJson = new File("${reportFolder}/licenseReport.json").text
+    def expectedJson =
+      """
+      [
+        {
+          "project":"appcompat-v7",
+          "description":null,
+          "version":"26.1.0",
+          "developers":[],
+          "url":null,
+          "year":null,
+          "licenses":[
+            {
+              "license":"The Apache Software License",
+              "license_url":"http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+          ],
+          "dependency":"com.android.support:appcompat-v7:26.1.0"
+        },
+        {
+          "project":"design",
+          "description":null,
+          "version":"26.1.0",
+          "developers":[],
+          "url":null,
+          "year":null,
+          "licenses":[
+            {
+              "license":"The Apache Software License",
+              "license_url":"http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+          ],
+          "dependency":"com.android.support:design:26.1.0"
+        }
+      ]
+      """
 
     then:
     result.task(':licenseReport').outcome == SUCCESS
     result.output.find("Wrote HTML report to .*${reportFolder}/licenseReport.html.")
     result.output.find("Wrote JSON report to .*${reportFolder}/licenseReport.json.")
-
-    def actualHtml = new File("${reportFolder}/licenseReport.html").text.stripIndent().trim()
-    def expectedHtml =
-"""
-<html>
-  <head>
-    <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }</style>
-    <title>Open source licenses</title>
-  </head>
-  <body>
-    <h3>Notice for packages:</h3>
-    <ul>
-      <li>
-        <a href="#314129783">appcompat-v7</a>
-      </li>
-      <li>
-        <a href="#314129783">design</a>
-      </li>
-      <a name="314129783" />
-      <pre>${getLicenseText('apache-2.0.txt')}</pre>
-    </ul>
-  </body>
-</html>
-""".stripIndent().trim()
-    def actualJson = new File("${reportFolder}/licenseReport.json").text.stripIndent().trim()
-    def expectedJson =
-"""
-[
-    {
-        "project": "appcompat-v7",
-        "description": null,
-        "version": "26.1.0",
-        "developers": [
-            
-        ],
-        "url": null,
-        "year": null,
-        "licenses": [
-            {
-                "license": "The Apache Software License",
-                "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
-            }
-        ],
-        "dependency": "com.android.support:appcompat-v7:26.1.0"
-    },
-    {
-        "project": "design",
-        "description": null,
-        "version": "26.1.0",
-        "developers": [
-            
-        ],
-        "url": null,
-        "year": null,
-        "licenses": [
-            {
-                "license": "The Apache Software License",
-                "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
-            }
-        ],
-        "dependency": "com.android.support:design:26.1.0"
-    }
-]
-""".stripIndent().trim()
-
-    then:
-    actualHtml == expectedHtml
-    actualJson == expectedJson
+    assertHtml(expectedHtml, actualHtml)
+    assertJson(expectedJson, actualJson)
   }
 
   def 'licenseReport using api and implementation configurations with multi java modules'() {
@@ -757,83 +718,75 @@ final class LicensePluginJavaSpec extends Specification {
       }
       """
     when:
-    def result = GradleRunner.create()
-      .withProjectDir(testProjectDir.root)
-      .withArguments('licenseReport', '-s')
-      .withPluginClasspath()
-      .build()
+    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    def actualHtml = new File("${reportFolder}/licenseReport.html").text
+    def expectedHtml =
+      """
+      <html>
+        <head>
+          <style>
+            body { font-family: sans-serif } 
+            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }
+          </style>
+          <title>Open source licenses</title>
+        </head>
+        <body>
+          <h3>Notice for packages:</h3>
+          <ul>
+            <li>
+              <a href="#314129783">appcompat-v7</a>
+            </li>
+            <li>
+              <a href="#314129783">design</a>
+            </li>
+            <a name="314129783" />
+            <pre>${getLicenseText('apache-2.0.txt')}</pre>
+          </ul>
+        </body>
+      </html>
+      """
+    def actualJson = new File("${reportFolder}/licenseReport.json").text
+    def expectedJson =
+      """
+      [
+        {
+          "project":"appcompat-v7",
+          "description":null,
+          "version":"26.1.0",
+          "developers":[],
+          "url":null,
+          "year":null,
+          "licenses":[
+            {
+              "license":"The Apache Software License",
+              "license_url":"http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+          ],
+          "dependency":"com.android.support:appcompat-v7:26.1.0"
+        },
+        {
+          "project":"design",
+          "description":null,
+          "version":"26.1.0",
+          "developers":[],
+          "url":null,
+          "year":null,
+          "licenses":[
+            {
+              "license":"The Apache Software License",
+              "license_url":"http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+          ],
+          "dependency":"com.android.support:design:26.1.0"
+        }
+      ]
+      """
 
     then:
     result.task(':licenseReport').outcome == SUCCESS
     result.output.find("Wrote HTML report to .*${reportFolder}/licenseReport.html.")
     result.output.find("Wrote JSON report to .*${reportFolder}/licenseReport.json.")
-
-    def actualHtml = new File("${reportFolder}/licenseReport.html").text.stripIndent().trim()
-    def expectedHtml =
-"""
-<html>
-  <head>
-    <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }</style>
-    <title>Open source licenses</title>
-  </head>
-  <body>
-    <h3>Notice for packages:</h3>
-    <ul>
-      <li>
-        <a href="#314129783">appcompat-v7</a>
-      </li>
-      <li>
-        <a href="#314129783">design</a>
-      </li>
-      <a name="314129783" />
-      <pre>${getLicenseText('apache-2.0.txt')}</pre>
-    </ul>
-  </body>
-</html>
-""".stripIndent().trim()
-    def actualJson = new File("${reportFolder}/licenseReport.json").text.stripIndent().trim()
-    def expectedJson =
-"""
-[
-    {
-        "project": "appcompat-v7",
-        "description": null,
-        "version": "26.1.0",
-        "developers": [
-            
-        ],
-        "url": null,
-        "year": null,
-        "licenses": [
-            {
-                "license": "The Apache Software License",
-                "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
-            }
-        ],
-        "dependency": "com.android.support:appcompat-v7:26.1.0"
-    },
-    {
-        "project": "design",
-        "description": null,
-        "version": "26.1.0",
-        "developers": [
-            
-        ],
-        "url": null,
-        "year": null,
-        "licenses": [
-            {
-                "license": "The Apache Software License",
-                "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
-            }
-        ],
-        "dependency": "com.android.support:design:26.1.0"
-    }
-]
-""".stripIndent().trim()
-
-    then:
-    actualHtml == expectedHtml
-    actualJson == expectedJson
+    assertHtml(expectedHtml, actualHtml)
+    assertJson(expectedJson, actualJson)
   }
 }

--- a/src/test/groovy/com/jaredsburrows/license/internal/pom/DeveloperSpec.groovy
+++ b/src/test/groovy/com/jaredsburrows/license/internal/pom/DeveloperSpec.groovy
@@ -3,7 +3,9 @@ package com.jaredsburrows.license.internal.pom
 import spock.lang.Specification
 
 final class DeveloperSpec extends Specification {
-  def sut = new Developer(name: 'name')
+  def sut = new Developer(
+    name: 'name'
+  )
 
   def 'name'() {
     expect:

--- a/src/test/groovy/com/jaredsburrows/license/internal/pom/LicenseSpec.groovy
+++ b/src/test/groovy/com/jaredsburrows/license/internal/pom/LicenseSpec.groovy
@@ -3,7 +3,10 @@ package com.jaredsburrows.license.internal.pom
 import spock.lang.Specification
 
 final class LicenseSpec extends Specification {
-  def sut = new License(name: 'name', url: 'url')
+  def sut = new License(
+    name: 'name',
+    url: 'url'
+  )
 
   def 'get name'() {
     expect:
@@ -17,8 +20,14 @@ final class LicenseSpec extends Specification {
 
   def 'equals and hashcode'() {
     given:
-    def one = new License(name: 'name', url: 'url')
-    def two = new License(name: 'name', url: 'url')
+    def one = new License(
+      name: 'name',
+      url: 'url'
+    )
+    def two = new License(
+      name: 'name',
+      url: 'url'
+    )
 
     expect:
     one.name == two.name

--- a/src/test/groovy/com/jaredsburrows/license/internal/pom/ProjectSpec.groovy
+++ b/src/test/groovy/com/jaredsburrows/license/internal/pom/ProjectSpec.groovy
@@ -3,11 +3,21 @@ package com.jaredsburrows.license.internal.pom
 import spock.lang.Specification
 
 final class ProjectSpec extends Specification {
-  def developer = new Developer(name: 'name')
+  def developer = new Developer(
+    name: 'name'
+  )
   def developers = [developer, developer]
-  def licenses = [new License(name: 'name', url: 'url')]
-  def sut = new Project(name: 'name', licenses: licenses, url: 'url', developers: developers,
-    year: 'year')
+  def licenses = [new License(
+    name: 'name',
+    url: 'url'
+  )]
+  def sut = new Project(
+    name: 'name',
+    licenses: licenses,
+    url: 'url',
+    developers: developers,
+    year: 'year'
+  )
 
   def 'name'() {
     expect:

--- a/src/test/groovy/com/jaredsburrows/license/internal/report/HtmlReportSpec.groovy
+++ b/src/test/groovy/com/jaredsburrows/license/internal/report/HtmlReportSpec.groovy
@@ -1,10 +1,10 @@
 package com.jaredsburrows.license.internal.report
 
+import static test.TestUtils.assertHtml
+
 import com.jaredsburrows.license.internal.pom.Developer
 import com.jaredsburrows.license.internal.pom.License
 import com.jaredsburrows.license.internal.pom.Project
-import org.xmlunit.builder.DiffBuilder
-import org.xmlunit.builder.Input
 import spock.lang.Specification
 
 final class HtmlReportSpec extends Specification {
@@ -31,14 +31,8 @@ final class HtmlReportSpec extends Specification {
       </html>
       """
 
-    def diff = DiffBuilder.compare(Input.fromString(actual).build())
-      .withTest(Input.fromString(expected).build())
-      .normalizeWhitespace()
-      .ignoreWhitespace()
-      .build()
-
     then:
-    !diff.hasDifferences()
+    assertHtml(expected, actual)
   }
 
   def 'open source html'() {
@@ -98,13 +92,7 @@ final class HtmlReportSpec extends Specification {
       </html>
       """
 
-    def diff = DiffBuilder.compare(Input.fromString(actual).build())
-      .withTest(Input.fromString(expected).build())
-      .normalizeWhitespace()
-      .ignoreWhitespace()
-      .build()
-
     then:
-    !diff.hasDifferences()
+    assertHtml(expected, actual)
   }
 }

--- a/src/test/groovy/com/jaredsburrows/license/internal/report/JsonReportSpec.groovy
+++ b/src/test/groovy/com/jaredsburrows/license/internal/report/JsonReportSpec.groovy
@@ -1,5 +1,7 @@
 package com.jaredsburrows.license.internal.report
 
+import static test.TestUtils.assertJson
+
 import com.jaredsburrows.license.internal.pom.Developer
 import com.jaredsburrows.license.internal.pom.License
 import com.jaredsburrows.license.internal.pom.Project
@@ -12,117 +14,124 @@ final class JsonReportSpec extends Specification {
     def sut = new JsonReport(projects)
 
     when:
-    def actual = sut.string().stripIndent().trim()
+    def actual = sut.string()
     def expected =
-"""
-[]
-""".stripIndent().trim()
+      """
+      []
+      """
 
     then:
-    actual == expected
+    assertJson(expected, actual)
   }
 
   def 'open source json - missing values'() {
     given:
-    def project = new Project(name: 'name', developers: [], gav: 'foo:bar:1.2.3')
+    def project = new Project(
+      name: 'name',
+      developers: [],
+      gav: 'foo:bar:1.2.3'
+    )
     def projects = [project, project]
     def sut = new JsonReport(projects)
 
     when:
-    def actual = sut.string().stripIndent().trim()
+    def actual = sut.string()
     def expected =
-"""
-[
-    {
-        "project": "name",
-        "description": null,
-        "version": null,
-        "developers": [
-            
-        ],
-        "url": null,
-        "year": null,
-        "licenses": [
-            
-        ],
-        "dependency": "foo:bar:1.2.3"
-    },
-    {
-        "project": "name",
-        "description": null,
-        "version": null,
-        "developers": [
-            
-        ],
-        "url": null,
-        "year": null,
-        "licenses": [
-            
-        ],
-        "dependency": "foo:bar:1.2.3"
-    }
-]
-""".stripIndent().trim()
+      """
+      [
+        {
+          "project": "name",
+          "description": null,
+          "version": null,
+          "developers": [],
+          "url": null,
+          "year": null,
+          "licenses": [],
+          "dependency": "foo:bar:1.2.3"
+        },
+        {
+          "project": "name",
+          "description": null,
+          "version": null,
+          "developers": [],
+          "url": null,
+          "year": null,
+          "licenses": [],
+          "dependency": "foo:bar:1.2.3"
+        }
+      ]
+      """
 
     then:
-    actual == expected
+    assertJson(expected, actual)
   }
 
   def 'open source json - all values'() {
     given:
     def developer = new Developer(name: 'name')
     def developers = [developer, developer]
-    def license = new License(name: 'name', url: 'url')
-    def project = new Project(name: 'name', description: 'description', version: '1.0.0',
-      licenses: [license], url: 'url', developers: developers, year: 'year', gav: 'foo:bar:1.2.3')
+    def license = new License(
+      name: 'name',
+      url: 'url'
+    )
+    def project = new Project(
+      name: 'name',
+      description: 'description',
+      version: '1.0.0',
+      licenses: [license],
+      url: 'url',
+      developers: developers,
+      year: 'year',
+      gav: 'foo:bar:1.2.3'
+    )
     def projects = [project, project]
     def sut = new JsonReport(projects)
 
     when:
-    def actual = sut.string().stripIndent().trim()
+    def actual = sut.string()
     def expected =
-"""
-[
-    {
-        "project": "name",
-        "description": "description",
-        "version": "1.0.0",
-        "developers": [
+      """
+      [
+        {
+          "project": "name",
+          "description": "description",
+          "version": "1.0.0",
+          "developers": [
             "name",
             "name"
-        ],
-        "url": "url",
-        "year": "year",
-        "licenses": [
+          ],
+          "url": "url",
+          "year": "year",
+          "licenses": [
             {
-                "license": "name",
-                "license_url": "url"
+              "license": "name",
+              "license_url": "url"
             }
-        ],
-        "dependency": "foo:bar:1.2.3"
-    },
-    {
-        "project": "name",
-        "description": "description",
-        "version": "1.0.0",
-        "developers": [
+          ],
+          "dependency": "foo:bar:1.2.3"
+        },
+        {
+          "project": "name",
+          "description": "description",
+          "version": "1.0.0",
+          "developers": [
             "name",
             "name"
-        ],
-        "url": "url",
-        "year": "year",
-        "licenses": [
+          ],
+          "url": "url",
+          "year": "year",
+          "licenses": [
             {
-                "license": "name",
-                "license_url": "url"
+              "license": "name",
+              "license_url": "url"
             }
-        ],
-        "dependency": "foo:bar:1.2.3"
-    }
-]
-""".stripIndent().trim()
+          ],
+          "dependency": "foo:bar:1.2.3"
+        }
+      ]
+      """
 
     then:
-    actual == expected
+    assertJson(expected, actual)
   }
 }

--- a/src/test/groovy/test/TestUtils.groovy
+++ b/src/test/groovy/test/TestUtils.groovy
@@ -1,11 +1,39 @@
 package test
 
+import com.google.gson.JsonParser
+import org.gradle.testkit.runner.GradleRunner
+import org.xmlunit.builder.DiffBuilder
+import org.xmlunit.builder.Input
+
 final class TestUtils {
+  private static def parser = new JsonParser()
+
   private TestUtils() {
     throw new AssertionError('No instances')
   }
 
+  static def gradleWithCommand(def file, String... commands) {
+    return GradleRunner.create()
+      .withProjectDir(file)
+      .withArguments(commands)
+      .withPluginClasspath()
+      .build()
+  }
+
   static def getLicenseText(def fileName) {
     getClass().getResource("/license/${fileName}").text
+  }
+
+  static def assertJson(def expected, def actual) {
+    return parser.parse(actual) == parser.parse(expected)
+  }
+
+  static def assertHtml(def expected, def actual) {
+    return !DiffBuilder.compare(Input.fromString(actual).build())
+      .withTest(Input.fromString(expected).build())
+      .normalizeWhitespace()
+      .ignoreWhitespace()
+      .build()
+      .differences
   }
 }


### PR DESCRIPTION
- Fix HTML and JSON indentation in tests
- Fix HTML output
  - 2 space indent
  - Use of `"` instead of `'`
- Fix JSON output
  - 2 space indent
- Remove `trim()` and `stripIndent()`
- Compare JSON and HTML by validating and comparing the data and not the format