### PR TITLE
Update html css to support word-breaking on long lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ dependencies {
   <head>
     <style>
       body { font-family: sans-serif } 
-      pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }
+      pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }
     </style>
     <title>Open source licenses</title>
   </head>

--- a/src/main/kotlin/com/jaredsburrows/license/internal/report/HtmlReport.kt
+++ b/src/main/kotlin/com/jaredsburrows/license/internal/report/HtmlReport.kt
@@ -23,7 +23,7 @@ import java.io.File
 
 class HtmlReport(private val projects: List<Project>) {
   companion object {
-    const val CSS_STYLE = "body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }"
+    const val CSS_STYLE = "body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }"
     const val OPEN_SOURCE_LIBRARIES = "Open source licenses"
     const val NO_LIBRARIES = "None"
     const val NO_LICENSE = "No license found"

--- a/src/test/groovy/com/jaredsburrows/license/LicensePluginAndroidSpec.groovy
+++ b/src/test/groovy/com/jaredsburrows/license/LicensePluginAndroidSpec.groovy
@@ -128,7 +128,7 @@ final class LicensePluginAndroidSpec extends Specification {
         <head>
           <style>
             body { font-family: sans-serif } 
-            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }
+            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }
           </style>
           <title>Open source licenses</title>
         </head>
@@ -198,7 +198,7 @@ final class LicensePluginAndroidSpec extends Specification {
         <head>
           <style>
             body { font-family: sans-serif } 
-            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }
+            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }
           </style>
           <title>Open source licenses</title>
         </head>
@@ -314,7 +314,7 @@ final class LicensePluginAndroidSpec extends Specification {
         <head>
           <style>
             body { font-family: sans-serif } 
-            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }
+            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }
           </style>
           <title>Open source licenses</title>
         </head>
@@ -444,7 +444,7 @@ final class LicensePluginAndroidSpec extends Specification {
         <head>
           <style>
             body { font-family: sans-serif } 
-            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }
+            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }
           </style>
           <title>Open source licenses</title>
         </head>
@@ -649,7 +649,7 @@ final class LicensePluginAndroidSpec extends Specification {
         <head>
           <style>
             body { font-family: sans-serif } 
-            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }
+            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }
           </style>
           <title>Open source licenses</title>
         </head>
@@ -761,7 +761,7 @@ final class LicensePluginAndroidSpec extends Specification {
         <head>
           <style>
             body { font-family: sans-serif } 
-            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }
+            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }
           </style>
           <title>Open source licenses</title>
         </head>
@@ -864,7 +864,7 @@ final class LicensePluginAndroidSpec extends Specification {
         <head>
           <style>
             body { font-family: sans-serif } 
-            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }
+            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }
           </style>
           <title>Open source licenses</title>
         </head>

--- a/src/test/groovy/com/jaredsburrows/license/LicensePluginJavaSpec.groovy
+++ b/src/test/groovy/com/jaredsburrows/license/LicensePluginJavaSpec.groovy
@@ -78,7 +78,7 @@ final class LicensePluginJavaSpec extends Specification {
         <head>
           <style>
             body { font-family: sans-serif } 
-            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }
+            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }
           </style>
           <title>Open source licenses</title>
         </head>
@@ -130,7 +130,7 @@ final class LicensePluginJavaSpec extends Specification {
         <head>
           <style>
             body { font-family: sans-serif } 
-            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }
+            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }
           </style>
           <title>Open source licenses</title>
         </head>
@@ -202,7 +202,7 @@ final class LicensePluginJavaSpec extends Specification {
         <head>
           <style>
             body { font-family: sans-serif } 
-            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }
+            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }
           </style>
           <title>Open source licenses</title>
         </head>
@@ -295,7 +295,7 @@ final class LicensePluginJavaSpec extends Specification {
         <head>
           <style>
             body { font-family: sans-serif } 
-            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }
+            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }
           </style>
           <title>Open source licenses</title>
         </head>
@@ -347,7 +347,7 @@ final class LicensePluginJavaSpec extends Specification {
         <head>
           <style>
             body { font-family: sans-serif } 
-            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }
+            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }
           </style>
           <title>Open source licenses</title>
         </head>
@@ -423,7 +423,7 @@ final class LicensePluginJavaSpec extends Specification {
       """
       <html>
         <head>
-          <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }</style>
+          <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
           <title>Open source licenses</title>
         </head>
         <body>
@@ -505,7 +505,7 @@ final class LicensePluginJavaSpec extends Specification {
         <head>
           <style>
             body { font-family: sans-serif } 
-            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }
+            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }
           </style>
           <title>Open source licenses</title>
         </head>
@@ -618,7 +618,7 @@ final class LicensePluginJavaSpec extends Specification {
         <head>
           <style>
             body { font-family: sans-serif } 
-            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }
+            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }
           </style>
           <title>Open source licenses</title>
         </head>
@@ -726,7 +726,7 @@ final class LicensePluginJavaSpec extends Specification {
         <head>
           <style>
             body { font-family: sans-serif } 
-            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }
+            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }
           </style>
           <title>Open source licenses</title>
         </head>

--- a/src/test/groovy/com/jaredsburrows/license/internal/report/HtmlReportSpec.groovy
+++ b/src/test/groovy/com/jaredsburrows/license/internal/report/HtmlReportSpec.groovy
@@ -21,7 +21,7 @@ final class HtmlReportSpec extends Specification {
         <head>
           <style>
             body { font-family: sans-serif } 
-            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }
+            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }
           </style>
           <title>Open source licenses</title>
         </head>
@@ -66,7 +66,7 @@ final class HtmlReportSpec extends Specification {
         <head>
           <style>
             body { font-family: sans-serif } 
-            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }
+            pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }
           </style>
           <title>Open source licenses</title>
         </head>


### PR DESCRIPTION
# Reason
Some long URL's fail to break into multiple lines forcing the resulting HTML page to turn on horizontal scrolling on small screens.

# Solution
A minor update to the HTML CSS to add `word-break: break-word` to preformatted blocks, ensuring no long lines will push the page beyond the viewport.

Thanks for your work on this plugin!