### PR TITLE
Add another official spelling of the MIT License URL.

### DIFF
--- a/src/main/kotlin/com/jaredsburrows/license/internal/LicenseHelper.kt
+++ b/src/main/kotlin/com/jaredsburrows/license/internal/LicenseHelper.kt
@@ -80,6 +80,7 @@ object LicenseHelper {
     "MIT License" to "mit.txt",
     "http://opensource.org/licenses/MIT" to "mit.txt",
     "https://opensource.org/licenses/MIT" to "mit.txt",
+    "http://www.opensource.org/licenses/mit-license.php" to "mit.txt",
 
     // Mozilla Public License 2.0
     // https://github.com/github/choosealicense.com/blob/gh-pages/_licenses/mpl-2.0.txt


### PR DESCRIPTION
You asked that the additional spelling of the MIT License (.php extension) be a separate pull request, so here it is. I ran across this in an actual library I'm using. It's a one-line addition.