### PR TITLE
Fix copyCsvReportToAssets in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ licenseReport {
   generateJsonReport = true
   
   // These options are ignored for Java projects
-  copyHtmlReportToAssets = false
+  copyCsvReportToAssets = false
   copyHtmlReportToAssets = true
   copyJsonReportToAssets = false
 }


### PR DESCRIPTION
copyHtmlReportToAssets was twice in the example configuration