### PR TITLE
Fix license report task in multi-project setups

### DIFF
--- a/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
+++ b/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
@@ -36,9 +36,9 @@ internal open class LicenseReportTask : BaseLicenseReportTask() { // tasks can't
   private var pomConfiguration = "poms"
   private var tempPomConfiguration = "tempPoms"
 
-  /** 
-   * Use a non-static parser instance to avoid errors with concurrent licenseReport tasks 
-   * in multi-project setups. See https://github.com/jaredsburrows/gradle-license-plugin/pull/191 
+  /**
+   * Use a non-static parser instance to avoid errors with concurrent licenseReport tasks
+   * in multi-project setups. See https://github.com/jaredsburrows/gradle-license-plugin/pull/191
    * for additional details.
    */
   private var xmlParser = XmlParser(false, false)

--- a/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
+++ b/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
@@ -35,6 +35,7 @@ internal open class LicenseReportTask : BaseLicenseReportTask() { // tasks can't
   var variantName: String? = null
   private var pomConfiguration = "poms"
   private var tempPomConfiguration = "tempPoms"
+  private var xmlParser = XmlParser(false, false)
 
   @TaskAction fun licenseReport() {
     setupEnvironment()
@@ -501,7 +502,6 @@ internal open class LicenseReportTask : BaseLicenseReportTask() { // tasks can't
   }
 
   internal companion object {
-    private val xmlParser = XmlParser(false, false)
     private const val ANDROID_SUPPORT_GROUP_ID = "com.android.support"
     private const val APACHE_LICENSE_NAME = "The Apache Software License"
     private const val APACHE_LICENSE_URL = "http://www.apache.org/licenses/LICENSE-2.0.txt"

--- a/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
+++ b/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
@@ -35,6 +35,12 @@ internal open class LicenseReportTask : BaseLicenseReportTask() { // tasks can't
   var variantName: String? = null
   private var pomConfiguration = "poms"
   private var tempPomConfiguration = "tempPoms"
+
+  /** 
+   * Use a non-static parser instance to avoid errors with concurrent licenseReport tasks 
+   * in multi-project setups. See https://github.com/jaredsburrows/gradle-license-plugin/pull/191 
+   * for additional details.
+   */
   private var xmlParser = XmlParser(false, false)
 
   @TaskAction fun licenseReport() {


### PR DESCRIPTION
Currently running the license report task in multi-project setups is frequently causing the task to fail with "FWK005 parse may not be called while parsing." This is caused by the fact that LicenseReportTask.kt uses a static (companion) parser object. If parsing is already in progress for one project, a second report task on another project will fail if it tries to parse at the same time. This can be resolved by using an instance local parser variable.