### PR TITLE
Re-run the license task on the project configurations/dependencies ch…

### DIFF
--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
@@ -16,6 +16,7 @@ import org.gradle.api.artifacts.ResolvedArtifact
 import org.gradle.api.artifacts.ResolvedDependency
 import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import java.io.File
@@ -30,6 +31,10 @@ internal open class LicenseReportTask : BaseLicenseReportTask() { // tasks can't
 
   @Input var assetDirs = emptyList<File>()
   @Optional @Input var variantName: String? = null
+  // This input is used by the task indirectly via some project properties (such as "configurations" and "dependencies")
+  // that affect the task's outcome. When the mentioned project properties change the task should re-run the next time
+  // it is requested and should *not* be marked as UP-TO-DATE.
+  @InputFile var buildFile: File? = null
 
   private val projects = mutableListOf<Model>()
   private var pomConfiguration = "poms"

--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/projectAndroid.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/projectAndroid.kt
@@ -96,6 +96,7 @@ private fun Project.configureVariant(
         .srcDirs
         .toList()
       it.variantName = variant.name
+      it.buildFile = buildFile
     }
   }
 }

--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/projectJava.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/projectJava.kt
@@ -18,5 +18,7 @@ internal fun Project.isJavaProject(): Boolean {
  * All of these plugins will apply the JavaPlugin(relies on JavaBasePlugin) or JavaPlatformPlugin.
  */
 internal fun Project.configureJavaProject() {
-  tasks.register("licenseReport", LicenseReportTask::class.java)
+  tasks.register("licenseReport", LicenseReportTask::class.java) {
+    it.buildFile = buildFile
+  }
 }


### PR DESCRIPTION
…anges

The idea is simple - as the license task depends on the Gradle build script itself
let's mark the build script as the task input.

A slight drawback of this approach is that the license task will re-run after every
build script change, i.e. it will be UP-TO-DATE less often. But changing the build
script should not happen that often compared to the code changes and Gradle would
need to re-configure the project anyway during the next build so re-running the license
task should be acceptable.

An alternative approach could be to declare *all* project properties that affect
the task outcome as inputs to the task.

Closes #212.