### PR TITLE
Fix recursion stack overflows

### DIFF
--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
@@ -390,7 +390,14 @@ internal open class LicenseReportTask : DefaultTask() { // tasks can't be final
     pomFile: File?,
     configurations: ConfigurationContainer,
     dependencies: DependencyHandler,
+    recursionDepth: Int = 0,
   ): List<License> {
+    if (recursionDepth == MAX_RECURSION_DEPTH) {
+      logger.warn("Failed to find license after $recursionDepth attempts: $pomFile")
+      return emptyList()
+    }
+
+    println("findLicenses $pomFile")
     if (pomFile.isNullOrEmpty()) {
       return mutableListOf()
     }
@@ -436,6 +443,7 @@ internal open class LicenseReportTask : DefaultTask() { // tasks can't be final
         getParentPomFile(model, configurations, dependencies),
         configurations,
         dependencies,
+        recursionDepth = recursionDepth + 1,
       )
     }
     return mutableListOf()
@@ -494,5 +502,6 @@ internal open class LicenseReportTask : DefaultTask() { // tasks can't be final
     private const val APACHE_LICENSE_NAME = "The Apache Software License"
     private const val APACHE_LICENSE_URL = "http://www.apache.org/licenses/LICENSE-2.0.txt"
     private const val OPEN_SOURCE_LICENSES = "open_source_licenses"
+    private const val MAX_RECURSION_DEPTH = 5
   }
 }

--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
@@ -356,7 +356,13 @@ internal open class LicenseReportTask : DefaultTask() { // tasks can't be final
     pomFile: File?,
     configurations: ConfigurationContainer,
     dependencies: DependencyHandler,
+    recursionDepth: Int = 0,
   ): String {
+    if (recursionDepth == MAX_RECURSION_DEPTH) {
+      logger.warn("Failed to find version after $recursionDepth attempts: $pomFile")
+      return ""
+    }
+
     if (pomFile.isNullOrEmpty()) {
       return ""
     }
@@ -380,6 +386,7 @@ internal open class LicenseReportTask : DefaultTask() { // tasks can't be final
         getParentPomFile(model, configurations, dependencies),
         configurations,
         dependencies,
+        recursionDepth = recursionDepth + 1,
       )
     }
     return ""


### PR DESCRIPTION
Addresses issue #283.

I applied an (arbitrary!) upper limit of 5 to recursion when finding licenses, but this is obviously subject to change if you reckon so.

Also applied the same patch to the `findVersion` method, since the same issues was possible there too.