### PR TITLE
Fix exponential execution time for resolving complex dependencies

### DIFF
--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
@@ -254,9 +254,16 @@ internal open class LicenseReportTask : DefaultTask() { // tasks can't be final
 
   private fun getResolvedArtifactsFromResolvedDependencies(
     resolvedDependencies: Set<ResolvedDependency>,
+    skipSet: MutableSet<ResolvedDependency> = hashSetOf<ResolvedDependency>(),
   ): Set<ResolvedArtifact> {
     val resolvedArtifacts = hashSetOf<ResolvedArtifact>()
     resolvedDependencies.forEach { resolvedDependency ->
+      if (skipSet.contains(resolvedDependency)) {
+        return@forEach
+      } else {
+        skipSet.add(resolvedDependency)
+      }
+
       try {
         when (resolvedDependency.moduleVersion) {
           /**
@@ -267,6 +274,7 @@ internal open class LicenseReportTask : DefaultTask() { // tasks can't be final
            */
           "unspecified" -> resolvedArtifacts += getResolvedArtifactsFromResolvedDependencies(
             resolvedDependency.children,
+            skipSet,
           )
 
           else -> resolvedArtifacts += resolvedDependency.allModuleArtifacts


### PR DESCRIPTION
Addresses issue #394.

This PR improves the performance of `getResolvedArtifactsFromResolvedDependencies` by recording the dependencies that have already been processed.
This allows the function that used to take exponential time in the worst case to now be done in linear time.
The test I wrote takes about 2 minutes on my machine before the patch is applied, but now takes only a few seconds after the patch is applied. 