### PR TITLE
validate html

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ plugins {
   alias(libs.plugins.maven.publish) apply false
   alias(libs.plugins.plugin.publish) apply false
   alias(libs.plugins.versions)
+  alias(libs.plugins.license)
   id 'java-gradle-plugin'
   id 'java-library'
   id 'groovy'

--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/internal/ConsoleRenderer.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/internal/ConsoleRenderer.kt
@@ -9,7 +9,7 @@ import java.net.URISyntaxException
 /**
  * Renders information in a format suitable for logging to the console.
  *
- * Taken from: https://github.com/gradle/gradle/blob/master/subprojects/logging/src/main/java/org/gradle/internal/logging/ConsoleRenderer.java
+ * Taken from: https://github.com/gradle/gradle/blob/f3828bbb3350292dcbea7f505464eb5d30cb9d44/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/ConsoleRenderer.java
  */
 class ConsoleRenderer {
 
@@ -29,7 +29,7 @@ class ConsoleRenderer {
 /**
  * Wraps a checked exception. Carries no other context.
  *
- * Taken from: https://github.com/gradle/gradle/blob/master/subprojects/base-services/src/main/java/org/gradle/internal/UncheckedException.java
+ * Taken from: https://github.com/gradle/gradle/blob/f3828bbb3350292dcbea7f505464eb5d30cb9d44/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/UncheckedException.java
  */
 private class UncheckedException : RuntimeException {
   constructor(cause: Throwable) : super(cause)

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginAndroidSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginAndroidSpec.groovy
@@ -76,7 +76,7 @@ final class LicensePluginAndroidSpec extends Specification {
       <!DOCTYPE html>
       <html lang="en">
         <head>
-          <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+          <meta http-equiv="content-type" content="text/html; charset=utf-8">
           <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
           <title>Open source licenses</title>
         </head>
@@ -156,7 +156,7 @@ final class LicensePluginAndroidSpec extends Specification {
       <!DOCTYPE html>
       <html lang="en">
         <head>
-          <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+          <meta http-equiv="content-type" content="text/html; charset=utf-8">
           <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
           <title>Open source licenses</title>
         </head>
@@ -167,19 +167,21 @@ final class LicensePluginAndroidSpec extends Specification {
               <a href="#1934118923">appcompat-v7 (26.1.0)</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
+                <dd></dd>
               </dl>
             </li>
             <li>
               <a href="#1934118923">design (26.1.0)</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
+                <dd></dd>
               </dl>
             </li>
-            <a name="1934118923"></a>
-            <pre>${getLicenseText('apache-2.0.txt')}</pre>
-            <br>
-            <hr>
           </ul>
+          <a id="1934118923"></a>
+          <pre>${getLicenseText('apache-2.0.txt')}</pre>
+          <br>
+          <hr>
         </body>
       </html>
       """
@@ -366,7 +368,7 @@ final class LicensePluginAndroidSpec extends Specification {
       <!DOCTYPE html>
       <html lang="en">
         <head>
-          <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+          <meta http-equiv="content-type" content="text/html; charset=utf-8">
           <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
           <title>Open source licenses</title>
         </head>
@@ -377,19 +379,21 @@ final class LicensePluginAndroidSpec extends Specification {
               <a href="#1934118923">appcompat-v7 (26.1.0)</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
+                <dd></dd>
               </dl>
             </li>
             <li>
               <a href="#1934118923">design (26.1.0)</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
+                <dd></dd>
               </dl>
             </li>
-            <a name="1934118923"></a>
-            <pre>${getLicenseText('apache-2.0.txt')}</pre>
-            <br>
-            <hr>
           </ul>
+          <a id="1934118923"></a>
+          <pre>${getLicenseText('apache-2.0.txt')}</pre>
+          <br>
+          <hr>
         </body>
       </html>
       """
@@ -514,7 +518,7 @@ final class LicensePluginAndroidSpec extends Specification {
       <!DOCTYPE html>
       <html lang="en">
         <head>
-          <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+          <meta http-equiv="content-type" content="text/html; charset=utf-8">
           <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
           <title>Open source licenses</title>
         </head>
@@ -524,28 +528,32 @@ final class LicensePluginAndroidSpec extends Specification {
             <li><a href="#1934118923">appcompat-v7 (26.1.0)</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
+                <dd></dd>
               </dl>
             </li>
             <li><a href="#1934118923">design (26.1.0)</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
+                <dd></dd>
               </dl>
             </li>
             <li><a href="#1934118923">support-annotations (26.1.0)</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
+                <dd></dd>
               </dl>
             </li>
             <li><a href="#1934118923">support-v4 (26.1.0)</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
+                <dd></dd>
               </dl>
             </li>
-            <a name="1934118923"></a>
-            <pre>${getLicenseText('apache-2.0.txt')}</pre>
-            <br>
-            <hr>
           </ul>
+          <a id="1934118923"></a>
+          <pre>${getLicenseText('apache-2.0.txt')}</pre>
+          <br>
+          <hr>
         </body>
       </html>
       """
@@ -739,7 +747,7 @@ final class LicensePluginAndroidSpec extends Specification {
       <!DOCTYPE html>
       <html lang="en">
         <head>
-          <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+          <meta http-equiv="content-type" content="text/html; charset=utf-8">
           <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
           <title>Open source licenses</title>
         </head>
@@ -749,22 +757,26 @@ final class LicensePluginAndroidSpec extends Specification {
             <li><a href="#1934118923">design (26.1.0)</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
+                <dd></dd>
               </dl>
             </li>
-            <a name="1934118923"></a>
-            <pre>${getLicenseText('apache-2.0.txt')}</pre>
-            <br>
-            <hr>
+          </ul>
+          <a id="1934118923"></a>
+          <pre>${getLicenseText('apache-2.0.txt')}</pre>
+          <br>
+          <hr>
+          <ul>
             <li><a href="#1783810846">Android GIF Drawable Library (1.2.3)</a>
               <dl>
                 <dt>Copyright &copy; 20xx Karol WrXXtniak</dt>
+                <dd></dd>
               </dl>
             </li>
-            <a name="1783810846"></a>
-            <pre>${getLicenseText('mit.txt')}</pre>
-            <br>
-            <hr>
           </ul>
+          <a id="1783810846"></a>
+          <pre>${getLicenseText('mit.txt')}</pre>
+          <br>
+          <hr>
         </body>
       </html>
       """
@@ -881,7 +893,7 @@ final class LicensePluginAndroidSpec extends Specification {
       <!DOCTYPE html>
       <html lang="en">
         <head>
-          <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+          <meta http-equiv="content-type" content="text/html; charset=utf-8">
           <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
           <title>Open source licenses</title>
         </head>
@@ -891,12 +903,13 @@ final class LicensePluginAndroidSpec extends Specification {
             <li><a href="#0">Fake dependency name (1.0.0)</a>
               <dl>
                 <dt>Copyright &copy; 2017 name</dt>
+                <dd></dd>
               </dl>
             </li>
-            <a name="0"></a>
-            <pre>No license found</pre>
-            <hr>
           </ul>
+          <a id="0"></a>
+          <pre>No license found</pre>
+          <hr>
         </body>
       </html>
       """
@@ -997,7 +1010,7 @@ final class LicensePluginAndroidSpec extends Specification {
       <!DOCTYPE html>
       <html lang="en">
         <head>
-          <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+          <meta http-equiv="content-type" content="text/html; charset=utf-8">
           <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
           <title>Open source licenses</title>
         </head>
@@ -1007,23 +1020,27 @@ final class LicensePluginAndroidSpec extends Specification {
             <li><a href="#1934118923">design (26.1.0)</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
+                <dd></dd>
               </dl>
             </li>
-            <a name="1934118923"></a>
-            <pre>${getLicenseText('apache-2.0.txt')}</pre>
-            <br>
-            <hr>
+          </ul>
+          <a id="1934118923"></a>
+          <pre>${getLicenseText('apache-2.0.txt')}</pre>
+          <br>
+          <hr>
+          <ul>
             <li><a href="#-296292112">Fake dependency name (1.0.0)</a>
               <dl>
                 <dt>Copyright &copy; 2017 name</dt>
+                <dd></dd>
               </dl>
             </li>
-            <a name="-296292112"></a>
-            <pre>Some license
-            <a href="http://website.tld/">http://website.tld/</a></pre>
-            <br>
-            <hr>
           </ul>
+          <a id="-296292112"></a>
+          <pre>Some license
+          <a href="http://website.tld/">http://website.tld/</a></pre>
+          <br>
+          <hr>
         </body>
       </html>
       """
@@ -1148,7 +1165,7 @@ final class LicensePluginAndroidSpec extends Specification {
       <!DOCTYPE html>
       <html lang="en">
         <head>
-          <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+          <meta http-equiv="content-type" content="text/html; charset=utf-8">
           <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
           <title>Open source licenses</title>
         </head>
@@ -1159,25 +1176,29 @@ final class LicensePluginAndroidSpec extends Specification {
               <a href="#1934118923">design (26.1.0)</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
+                <dd></dd>
               </dl>
             </li>
-            <a name="1934118923"></a>
-            <pre>${getLicenseText('apache-2.0.txt')}</pre>
-            <br>
-            <hr>
+          </ul>
+          <a id="1934118923"></a>
+          <pre>${getLicenseText('apache-2.0.txt')}</pre>
+          <br>
+          <hr>
+          <ul>
             <li>
               <a href="#-296292112">Fake dependency name (1.0.0)</a>
               <dl>
                 <dt>Copyright &copy; 2017 name</dt>
+                <dd></dd>
               </dl>
             </li>
-            <a name="-296292112"></a>
-            <pre>Some license
-              <a href="http://website.tld/">http://website.tld/</a>
-            </pre>
-            <br>
-            <hr>
           </ul>
+          <a id="-296292112"></a>
+          <pre>Some license
+            <a href="http://website.tld/">http://website.tld/</a>
+          </pre>
+          <br>
+          <hr>
         </body>
       </html>
       """
@@ -1532,7 +1553,7 @@ final class LicensePluginAndroidSpec extends Specification {
       <!DOCTYPE html>
       <html lang="en">
         <head>
-          <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+          <meta http-equiv="content-type" content="text/html; charset=utf-8">
           <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap;  word-break: break-word; display: inline-block }</style>
           <title>Open source licenses</title>
         </head>
@@ -1543,13 +1564,14 @@ final class LicensePluginAndroidSpec extends Specification {
               <a href="#1934118923">design (26.1.0)</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
+                <dd></dd>
               </dl>
             </li>
-            <a name="1934118923"></a>
-            <pre>${getLicenseText('apache-2.0.txt')}</pre>
-            <br>
-            <hr>
           </ul>
+          <a id="1934118923"></a>
+          <pre>${getLicenseText('apache-2.0.txt')}</pre>
+          <br>
+          <hr>
         </body>
       </html>
       """
@@ -1644,7 +1666,7 @@ final class LicensePluginAndroidSpec extends Specification {
       <!DOCTYPE html>
       <html lang="en">
         <head>
-          <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+          <meta http-equiv="content-type" content="text/html; charset=utf-8">
           <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
           <title>Open source licenses</title>
         </head>
@@ -1655,13 +1677,14 @@ final class LicensePluginAndroidSpec extends Specification {
               <a href="#1934118923">design (26.1.0)</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
+                <dd></dd>
               </dl>
             </li>
-            <a name="1934118923"></a>
-            <pre>${getLicenseText('apache-2.0.txt')}</pre>
-            <br>
-            <hr>
           </ul>
+          <a id="1934118923"></a>
+          <pre>${getLicenseText('apache-2.0.txt')}</pre>
+          <br>
+          <hr>
         </body>
       </html>
       """
@@ -1745,7 +1768,7 @@ final class LicensePluginAndroidSpec extends Specification {
       """
       <!DOCTYPE html>
       <html lang="en">
-        <head><meta http-equiv="content-type" content="text/html; charset=utf-8" />
+        <head><meta http-equiv="content-type" content="text/html; charset=utf-8">
           <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
           <title>Open source licenses</title>
         </head>
@@ -1755,13 +1778,14 @@ final class LicensePluginAndroidSpec extends Specification {
             <li><a href="#1934118923">design (26.1.0)</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
+                <dd></dd>
               </dl>
             </li>
-            <a name="1934118923"></a>
-            <pre>${getLicenseText('apache-2.0.txt')}</pre>
-            <br>
-            <hr>
           </ul>
+          <a id="1934118923"></a>
+          <pre>${getLicenseText('apache-2.0.txt')}</pre>
+          <br>
+          <hr>
         </body>
       </html>
       """
@@ -1838,7 +1862,7 @@ final class LicensePluginAndroidSpec extends Specification {
       """
       <!DOCTYPE html>
       <html lang="en">
-        <head><meta http-equiv="content-type" content="text/html; charset=utf-8" />
+        <head><meta http-equiv="content-type" content="text/html; charset=utf-8">
           <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
           <title>Open source licenses</title>
         </head>
@@ -1904,7 +1928,7 @@ final class LicensePluginAndroidSpec extends Specification {
       """
       <!DOCTYPE html>
       <html lang="en">
-        <head><meta http-equiv="content-type" content="text/html; charset=utf-8" />
+        <head><meta http-equiv="content-type" content="text/html; charset=utf-8">
           <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
           <title>Open source licenses</title>
         </head>
@@ -1914,13 +1938,14 @@ final class LicensePluginAndroidSpec extends Specification {
             <li><a href="#1934118923">design (26.1.0)</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
+                <dd></dd>
               </dl>
             </li>
-            <a name="1934118923"></a>
-            <pre>${getLicenseText('apache-2.0.txt')}</pre>
-            <br>
-            <hr>
           </ul>
+          <a id="1934118923"></a>
+          <pre>${getLicenseText('apache-2.0.txt')}</pre>
+          <br>
+          <hr>
         </body>
       </html>
       """
@@ -1997,7 +2022,7 @@ final class LicensePluginAndroidSpec extends Specification {
       """
       <!DOCTYPE html>
       <html lang="en">
-        <head><meta http-equiv="content-type" content="text/html; charset=utf-8" />
+        <head><meta http-equiv="content-type" content="text/html; charset=utf-8">
           <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
           <title>Open source licenses</title>
         </head>
@@ -2064,7 +2089,7 @@ final class LicensePluginAndroidSpec extends Specification {
       """
       <!DOCTYPE html>
       <html lang="en">
-        <head><meta http-equiv="content-type" content="text/html; charset=utf-8" />
+        <head><meta http-equiv="content-type" content="text/html; charset=utf-8">
           <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
           <title>Open source licenses</title>
         </head>
@@ -2074,13 +2099,14 @@ final class LicensePluginAndroidSpec extends Specification {
             <li><a href="#1783810846">Android GIF Drawable Library (1.2.3)</a>
               <dl>
                 <dt>Copyright &copy; 20xx Karol WrXXtniak</dt>
+                <dd></dd>
               </dl>
             </li>
-            <a name="1783810846"></a>
-            <pre>${getLicenseText('mit.txt')}</pre>
-            <br>
-            <hr>
           </ul>
+          <a id="1783810846"></a>
+          <pre>${getLicenseText('mit.txt')}</pre>
+          <br>
+          <hr>
         </body>
       </html>
       """
@@ -2159,7 +2185,7 @@ final class LicensePluginAndroidSpec extends Specification {
       """
       <!DOCTYPE html>
       <html lang="en">
-        <head><meta http-equiv="content-type" content="text/html; charset=utf-8" />
+        <head><meta http-equiv="content-type" content="text/html; charset=utf-8">
           <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
           <title>Open source licenses</title>
         </head>
@@ -2169,13 +2195,14 @@ final class LicensePluginAndroidSpec extends Specification {
             <li><a href="#1934118923">design (26.1.0)</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
+                <dd></dd>
               </dl>
             </li>
-            <a name="1934118923"></a>
-            <pre>${getLicenseText('apache-2.0.txt')}</pre>
-            <br>
-            <hr>
           </ul>
+          <a id="1934118923"></a>
+          <pre>${getLicenseText('apache-2.0.txt')}</pre>
+          <br>
+          <hr>
         </body>
       </html>
       """
@@ -2252,7 +2279,7 @@ final class LicensePluginAndroidSpec extends Specification {
       """
       <!DOCTYPE html>
       <html lang="en">
-        <head><meta http-equiv="content-type" content="text/html; charset=utf-8" />
+        <head><meta http-equiv="content-type" content="text/html; charset=utf-8">
           <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
           <title>Open source licenses</title>
         </head>
@@ -2262,13 +2289,14 @@ final class LicensePluginAndroidSpec extends Specification {
             <li><a href="#1934118923">design (26.1.0)</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
+                <dd></dd>
               </dl>
             </li>
-            <a name="1934118923"></a>
-            <pre>${getLicenseText('apache-2.0.txt')}</pre>
-            <br>
-            <hr>
           </ul>
+          <a id="1934118923"></a>
+          <pre>${getLicenseText('apache-2.0.txt')}</pre>
+          <br>
+          <hr>
         </body>
       </html>
       """

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJavaSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJavaSpec.groovy
@@ -45,7 +45,7 @@ final class LicensePluginJavaSpec extends Specification {
       <!DOCTYPE html>
       <html lang="en">
         <head>
-          <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+          <meta http-equiv="content-type" content="text/html; charset=utf-8">
           <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
           <title>Open source licenses</title>
         </head>
@@ -104,7 +104,7 @@ final class LicensePluginJavaSpec extends Specification {
       <!DOCTYPE html>
       <html lang="en">
         <head>
-          <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+          <meta http-equiv="content-type" content="text/html; charset=utf-8">
           <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
           <title>Open source licenses</title>
         </head>
@@ -115,12 +115,13 @@ final class LicensePluginJavaSpec extends Specification {
               <a href="#0">firebase-core (10.0.1)</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
+                <dd></dd>
               </dl>
             </li>
-            <a name="0"></a>
-            <pre>No license found</pre>
-            <hr>
           </ul>
+          <a id="0"></a>
+          <pre>No license found</pre>
+          <hr>
         </body>
       </html>
       """
@@ -187,7 +188,7 @@ final class LicensePluginJavaSpec extends Specification {
       <!DOCTYPE html>
       <html lang="en">
         <head>
-          <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+          <meta http-equiv="content-type" content="text/html; charset=utf-8">
           <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
           <title>Open source licenses</title>
         </head>
@@ -198,19 +199,21 @@ final class LicensePluginJavaSpec extends Specification {
               <a href="#1934118923">appcompat-v7 (26.1.0)</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
+                <dd></dd>
               </dl>
             </li>
             <li>
               <a href="#1934118923">design (26.1.0)</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
+                <dd></dd>
               </dl>
             </li>
-            <a name="1934118923"></a>
-            <pre>${getLicenseText('apache-2.0.txt')}</pre>
-            <br>
-            <hr>
           </ul>
+          <a id="1934118923"></a>
+          <pre>${getLicenseText('apache-2.0.txt')}</pre>
+          <br>
+          <hr>
         </body>
       </html>
       """
@@ -295,7 +298,7 @@ final class LicensePluginJavaSpec extends Specification {
       <!DOCTYPE html>
       <html lang="en">
         <head>
-          <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+          <meta http-equiv="content-type" content="text/html; charset=utf-8">
           <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
           <title>Open source licenses</title>
         </head>
@@ -354,7 +357,7 @@ final class LicensePluginJavaSpec extends Specification {
       <!DOCTYPE html>
       <html lang="en">
         <head>
-          <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+          <meta http-equiv="content-type" content="text/html; charset=utf-8">
           <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
           <title>Open source licenses</title>
         </head>
@@ -365,15 +368,16 @@ final class LicensePluginJavaSpec extends Specification {
               <a href="#-296292112">Fake dependency name (1.0.0)</a>
               <dl>
                 <dt>Copyright &copy; 2017 name</dt>
+                <dd></dd>
               </dl>
             </li>
-            <a name="-296292112"></a>
-            <pre>Some license
-              <a href="http://website.tld/">http://website.tld/</a>
-            </pre>
-            <br>
-            <hr>
           </ul>
+          <a id="-296292112"></a>
+          <pre>Some license
+            <a href="http://website.tld/">http://website.tld/</a>
+          </pre>
+          <br>
+          <hr>
         </body>
       </html>
       """
@@ -445,7 +449,7 @@ final class LicensePluginJavaSpec extends Specification {
       <!DOCTYPE html>
       <html lang="en">
         <head>
-          <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+          <meta http-equiv="content-type" content="text/html; charset=utf-8">
           <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
           <title>Open source licenses</title>
         </head>
@@ -456,19 +460,20 @@ final class LicensePluginJavaSpec extends Specification {
               <a href="#1195092182">Fake dependency name (1.0.0)</a>
               <dl>
                 <dt>Copyright &copy; 2017 name</dt>
+                <dd></dd>
               </dl>
             </li>
-            <a name="1195092182"></a>
-            <pre>Some license
-              <a href="http://website.tld/">http://website.tld/</a>
-            </pre>
-            <br>
-            <pre>Some license
-              <a href="http://website.tld/">http://website.tld/</a>
-            </pre>
-            <br>
-            <hr>
           </ul>
+          <a id="1195092182"></a>
+          <pre>Some license
+            <a href="http://website.tld/">http://website.tld/</a>
+          </pre>
+          <br>
+          <pre>Some license
+            <a href="http://website.tld/">http://website.tld/</a>
+          </pre>
+          <br>
+          <hr>
         </body>
       </html>
       """
@@ -545,7 +550,7 @@ final class LicensePluginJavaSpec extends Specification {
       <!DOCTYPE html>
       <html lang="en">
         <head>
-          <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+          <meta http-equiv="content-type" content="text/html; charset=utf-8">
           <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
           <title>Open source licenses</title>
         </head>
@@ -556,25 +561,29 @@ final class LicensePluginJavaSpec extends Specification {
               <a href="#1934118923">Retrofit (2.3.0)</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
+                <dd></dd>
               </dl>
             </li>
-            <a name="1934118923"></a>
-            <pre>${getLicenseText('apache-2.0.txt')}</pre>
-            <br>
-            <hr>
+          </ul>
+          <a id="1934118923"></a>
+          <pre>${getLicenseText('apache-2.0.txt')}</pre>
+          <br>
+          <hr>
+          <ul>
             <li>
               <a href="#-296292112">Fake dependency name (1.0.0)</a>
               <dl>
                 <dt>Copyright &copy; 2017 name</dt>
+                <dd></dd>
               </dl>
             </li>
-            <a name="-296292112"></a>
-            <pre>Some license
-              <a href="http://website.tld/">http://website.tld/</a>
-            </pre>
-            <br>
-            <hr>
           </ul>
+          <a id="-296292112"></a>
+          <pre>Some license
+            <a href="http://website.tld/">http://website.tld/</a>
+          </pre>
+          <br>
+          <hr>
         </body>
       </html>
       """
@@ -676,7 +685,7 @@ final class LicensePluginJavaSpec extends Specification {
       <!DOCTYPE html>
       <html lang="en">
         <head>
-          <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+          <meta http-equiv="content-type" content="text/html; charset=utf-8">
           <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
           <title>Open source licenses</title>
         </head>
@@ -687,19 +696,21 @@ final class LicensePluginJavaSpec extends Specification {
               <a href="#1934118923">appcompat-v7 (26.1.0)</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
+                <dd></dd>
               </dl>
             </li>
             <li>
               <a href="#1934118923">design (26.1.0)</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
+                <dd></dd>
               </dl>
             </li>
-            <a name="1934118923"></a>
-            <pre>${getLicenseText('apache-2.0.txt')}</pre>
-            <br>
-            <hr>
           </ul>
+          <a id="1934118923"></a>
+          <pre>${getLicenseText('apache-2.0.txt')}</pre>
+          <br>
+          <hr>
         </body>
       </html>
       """
@@ -860,7 +871,7 @@ final class LicensePluginJavaSpec extends Specification {
       <!DOCTYPE html>
       <html lang="en">
         <head>
-          <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+          <meta http-equiv="content-type" content="text/html; charset=utf-8">
           <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
           <title>Open source licenses</title>
         </head>
@@ -871,19 +882,21 @@ final class LicensePluginJavaSpec extends Specification {
               <a href="#1934118923">appcompat-v7 (26.1.0)</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
+                <dd></dd>
               </dl>
             </li>
             <li>
               <a href="#1934118923">design (26.1.0)</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
+                <dd></dd>
               </dl>
             </li>
-            <a name="1934118923"></a>
-            <pre>${getLicenseText('apache-2.0.txt')}</pre>
-            <br>
-            <hr>
           </ul>
+          <a id="1934118923"></a>
+          <pre>${getLicenseText('apache-2.0.txt')}</pre>
+          <br>
+          <hr>
         </body>
       </html>
       """
@@ -983,7 +996,7 @@ final class LicensePluginJavaSpec extends Specification {
       <!DOCTYPE html>
       <html lang="en">
         <head>
-          <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+          <meta http-equiv="content-type" content="text/html; charset=utf-8">
           <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
           <title>Open source licenses</title>
         </head>
@@ -994,19 +1007,21 @@ final class LicensePluginJavaSpec extends Specification {
               <a href="#1934118923">appcompat-v7 (26.1.0)</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
+                <dd></dd>
               </dl>
             </li>
             <li>
               <a href="#1934118923">design (26.1.0)</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
+                <dd></dd>
               </dl>
             </li>
-            <a name="1934118923"></a>
-            <pre>${getLicenseText('apache-2.0.txt')}</pre>
-            <br>
-            <hr>
           </ul>
+          <a id="1934118923"></a>
+          <pre>${getLicenseText('apache-2.0.txt')}</pre>
+          <br>
+          <hr>
         </body>
       </html>
       """

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/internal/report/HtmlReportSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/internal/report/HtmlReportSpec.groovy
@@ -20,7 +20,7 @@ final class HtmlReportSpec extends Specification {
       <!DOCTYPE html>
       <html lang="en">
         <head>
-          <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+          <meta http-equiv="content-type" content="text/html; charset=utf-8">
           <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
           <title>Open source licenses</title>
         </head>
@@ -74,7 +74,7 @@ final class HtmlReportSpec extends Specification {
       <!DOCTYPE html>
       <html lang="en">
         <head>
-          <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+          <meta http-equiv="content-type" content="text/html; charset=utf-8">
           <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
           <title>Open source licenses</title>
         </head>
@@ -85,32 +85,40 @@ final class HtmlReportSpec extends Specification {
               <a href="#87638953">name (1.2.3)</a>
               <dl>
                 <dt>Copyright &copy; year name</dt>
+                <dd></dd>
                 <dt>Copyright &copy; year name</dt>
+                <dd></dd>
               </dl>
             </li>
             <li>
               <a href="#87638953">name (1.2.3)</a>
               <dl>
                 <dt>Copyright &copy; year name</dt>
+                <dd></dd>
                 <dt>Copyright &copy; year name</dt>
+                <dd></dd>
               </dl>
             </li>
-            <a name="87638953"></a>
-            <pre>name
-            <a href="url">url</a></pre>
-            <br>
-            <hr>
+          </ul>
+          <a id="87638953"></a>
+          <pre>name
+          <a href="url">url</a></pre>
+          <br>
+          <hr>
+          <ul>
             <li>
               <a href="#0">name (1.2.3)</a>
               <dl>
                 <dt>Copyright &copy; 20xx name</dt>
+                <dd></dd>
                 <dt>Copyright &copy; 20xx name</dt>
+                <dd></dd>
               </dl>
             </li>
-            <a name="0"></a>
-            <pre>No license found</pre>
-            <hr>
           </ul>
+          <a id="0"></a>
+          <pre>No license found</pre>
+          <hr>
         </body>
       </html>
       """

--- a/gradle-license-plugin/src/test/groovy/test/TestUtils.groovy
+++ b/gradle-license-plugin/src/test/groovy/test/TestUtils.groovy
@@ -64,6 +64,7 @@ final class TestUtils {
     text = text.replaceAll('<br>', '<br/>')
     text = text.replaceAll('<hr>', '<hr/>')
     text = text.replaceAll('&copy;', '(c)')
+    text = text.replaceAll('<meta http-equiv="content-type" content="text/html; charset=utf-8">', '<meta http-equiv="content-type" content="text/html; charset=utf-8" />')
     // Unicode code points being transformed strangely - normalize
     text = text.replaceAll('Karol Wr.*niak', 'Karol WrXXniak')
     return text

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ ktlint = { id = "org.jlleitschuh.gradle.ktlint", version = "11.6.1" }
 maven-publish = { id = "com.vanniktech.maven.publish", version = "0.27.0" }
 plugin-publish = { id = "com.gradle.plugin-publish", version = "1.2.1" }
 versions = { id = "com.github.ben-manes.versions", version = "0.51.0" }
+license = { id = "com.jaredsburrows.license", version = "0.9.4" }
 
 [libraries]
 android-plugin = { module = "com.android.tools.build:gradle", version = "3.6.4" }


### PR DESCRIPTION
Validate and fix HTML errors - https://validator.w3.org/#validate_by_input

 - Trailing slash on void elements [has no effect](https://github.com/validator/validator/wiki/Markup-%C2%BB-Void-elements#trailing-slashes-in-void-element-start-tags-do-not-mark-the-start-tags-as-self-closing) and [interacts badly with unquoted attribute values](https://github.com/validator/validator/wiki/Markup-%C2%BB-Void-elements#trailing-slashes-directly-preceded-by-unquoted-attribute-values).
 - Element [dl](https://html.spec.whatwg.org/multipage/#the-dl-element) is missing a required instance of child element dd.
 - The name attribute is obsolete. Consider putting an id attribute on the nearest container instead.
 - Element [pre](https://html.spec.whatwg.org/multipage/#the-pre-element) not allowed as child of element [ul](https://html.spec.whatwg.org/multipage/#the-ul-element) in this context.
 - Element [br](https://html.spec.whatwg.org/multipage/#the-br-element) not allowed as child of element [ul](https://html.spec.whatwg.org/multipage/#the-ul-element) in this context.
 - Element [hr](https://html.spec.whatwg.org/multipage/#the-hr-element) not allowed as child of element [ul](https://html.spec.whatwg.org/multipage/#the-ul-element) in this context.

Closes https://github.com/jaredsburrows/gradle-license-plugin/issues/149