### PR TITLE
Sort project group order in HTML report using license keys

### DIFF
--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/internal/report/HtmlReport.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/internal/report/HtmlReport.kt
@@ -66,12 +66,12 @@ class HtmlReport(private val projects: List<Model>) : Report {
       (projectsMap[key] as MutableList).add(project)
     }
 
-    val sortedProjectsList = 
+    val sortedProjectsList =
       projectsMap.entries.map { (key, projects) ->
-        Pair(key, projects.sortedWith(
-          compareBy(String.CASE_INSENSITIVE_ORDER) { it.name },
-        ))
+        Pair(key, projects.sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.name }))
       }.sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { (key, license) -> key })
+
+    sortedProjectsList.forEach { (key, _) -> println(key) }
 
     return buildString {
       appendLine(DOCTYPE) // createHTMLDocument() add doctype and meta

--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/internal/report/HtmlReport.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/internal/report/HtmlReport.kt
@@ -39,7 +39,7 @@ class HtmlReport(private val projects: List<Model>) : Report {
   override fun report(): String = if (projects.isEmpty()) emptyReport() else fullReport()
 
   override fun fullReport(): String {
-    val projectsMap = hashMapOf<String?, List<Model>>()
+    val projectsMap = hashMapOf<String, List<Model>>()
     val licenseMap = LicenseHelper.licenseMap
 
     // Store packages by licenses: build a composite key of all the licenses, sorted in the (probably vain)
@@ -66,6 +66,13 @@ class HtmlReport(private val projects: List<Model>) : Report {
       (projectsMap[key] as MutableList).add(project)
     }
 
+    val sortedProjectsList = 
+      projectsMap.entries.map { (key, projects) ->
+        Pair(key, projects.sortedWith(
+          compareBy(String.CASE_INSENSITIVE_ORDER) { it.name },
+        ))
+      }.sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { (key, license) -> key })
+
     return buildString {
       appendLine(DOCTYPE) // createHTMLDocument() add doctype and meta
       appendHTML()
@@ -83,20 +90,14 @@ class HtmlReport(private val projects: List<Model>) : Report {
             h3 {
               +NOTICE_LIBRARIES
             }
-
-            projectsMap.entries.forEach { entry ->
+            sortedProjectsList.forEach { (key, sortedProjects) ->
               var currentProject: Model? = null
               var currentLicense: Int? = null
 
               ul {
-                val sortedProjects =
-                  entry.value.sortedWith(
-                    compareBy(String.CASE_INSENSITIVE_ORDER) { it.name },
-                  )
-
                 sortedProjects.forEach { project ->
                   currentProject = project
-                  currentLicense = entry.key.hashCode()
+                  currentLicense = key.hashCode()
 
                   // Display libraries
                   li {

--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/internal/report/HtmlReport.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/internal/report/HtmlReport.kt
@@ -69,7 +69,7 @@ class HtmlReport(private val projects: List<Model>) : Report {
     val sortedProjectsList =
       projectsMap.entries.map { (key, projects) ->
         Pair(key, projects.sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.name }))
-      }.sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { (key, license) -> key })
+      }.sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.first })
 
     sortedProjectsList.forEach { (key, _) -> println(key) }
 
@@ -143,7 +143,7 @@ class HtmlReport(private val projects: List<Model>) : Report {
                 val sortedKeysAndLicenses =
                   licenses.map { license ->
                     Pair(getLicenseKey(license), license)
-                  }.sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { (key, license) -> key })
+                  }.sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.first })
 
                 sortedKeysAndLicenses.forEach { (key, license) ->
                   if (key.isNotEmpty() && licenseMap.values.contains(key)) {

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/internal/report/HtmlReportSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/internal/report/HtmlReportSpec.groovy
@@ -82,6 +82,20 @@ final class HtmlReportSpec extends Specification {
           <h3>Notice for packages:</h3>
           <ul>
             <li>
+              <a href="#0">name (1.2.3)</a>
+              <dl>
+                <dt>Copyright &copy; 20xx name</dt>
+                <dd></dd>
+                <dt>Copyright &copy; 20xx name</dt>
+                <dd></dd>
+              </dl>
+            </li>
+          </ul>
+          <a id="0"></a>
+          <pre>No license found</pre>
+          <hr>
+          <ul>
+            <li>
               <a href="#87638953">name (1.2.3)</a>
               <dl>
                 <dt>Copyright &copy; year name</dt>
@@ -104,20 +118,6 @@ final class HtmlReportSpec extends Specification {
           <pre>name
           <a href="url">url</a></pre>
           <br>
-          <hr>
-          <ul>
-            <li>
-              <a href="#0">name (1.2.3)</a>
-              <dl>
-                <dt>Copyright &copy; 20xx name</dt>
-                <dd></dd>
-                <dt>Copyright &copy; 20xx name</dt>
-                <dd></dd>
-              </dl>
-            </li>
-          </ul>
-          <a id="0"></a>
-          <pre>No license found</pre>
           <hr>
         </body>
       </html>


### PR DESCRIPTION
Closes https://github.com/jaredsburrows/gradle-license-plugin/issues/409.

This PR introduces the stable order of project groups in HTML report.
It makes it less likely that changes in dependencies will result in large diffs of output.

Project groups are sorted by their respective license keys.
A real-world example will looks like this:
```
(no licenses)
[apache-2.0.txt, https://github.com/facebook/facebook-android-sdk/blob/main/LICENSE.txt, https://www.facebook.com/legal/audience_network_beta_sdk_terms]
[apache-2.0.txt]
[bsd-2-clause.txt]
[bsd-3-clause.txt]
[epl-2.0.txt]
[https://developer.android.com/guide/playcore/license]
[https://developer.android.com/studio/terms.html]
[https://github.com/facebook/facebook-android-sdk/blob/main/LICENSE.txt]
[mit.txt]
```