### PR TITLE
POM artifact resolution

### DIFF
--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
@@ -225,7 +225,7 @@ internal open class LicenseReportTask : DefaultTask() {
         val model = mavenReader.read(ReaderFactory.newXmlReader(pomFile), false)
 
         // Search for licenses
-        var licenses = findLicenses(mavenReader, pomFile, configurations, dependencies)
+        var licenses = findLicenses(mavenReader, pomFile, dependencies)
         if (licenses.isEmpty()) {
           logger.warn("Dependency '${artifact.name}' does not have a license.")
           licenses = mutableListOf()
@@ -237,7 +237,7 @@ internal open class LicenseReportTask : DefaultTask() {
           Model().apply {
             this.groupId = module.group.trim()
             this.artifactId = module.name.trim()
-            this.version = model.pomVersion(mavenReader, pomFile, configurations, dependencies)
+            this.version = model.pomVersion(mavenReader, pomFile, dependencies)
             this.name = model.pomName()
             this.description = model.pomDescription()
             this.url = model.pomUrl()
@@ -289,7 +289,6 @@ internal open class LicenseReportTask : DefaultTask() {
   /** Use Parent POM information when individual dependency license information is missing. */
   private fun getParentPomFile(
     model: Model,
-    configurations: ConfigurationContainer,
     dependencies: DependencyHandler,
   ): File? {
     // Get parent POM information
@@ -373,7 +372,6 @@ internal open class LicenseReportTask : DefaultTask() {
   private fun findVersion(
     mavenReader: MavenXpp3Reader,
     pomFile: File?,
-    configurations: ConfigurationContainer,
     dependencies: DependencyHandler,
   ): String {
     if (pomFile.isNullOrEmpty()) {
@@ -396,8 +394,7 @@ internal open class LicenseReportTask : DefaultTask() {
     if (model.parent.artifactId.orEmpty().trim().isNotEmpty()) {
       return findVersion(
         mavenReader,
-        getParentPomFile(model, configurations, dependencies),
-        configurations,
+        getParentPomFile(model, dependencies),
         dependencies,
       )
     }
@@ -407,7 +404,6 @@ internal open class LicenseReportTask : DefaultTask() {
   private fun findLicenses(
     mavenReader: MavenXpp3Reader,
     pomFile: File?,
-    configurations: ConfigurationContainer,
     dependencies: DependencyHandler,
   ): List<License> {
     if (pomFile.isNullOrEmpty()) {
@@ -440,7 +436,7 @@ internal open class LicenseReportTask : DefaultTask() {
     }.ifEmpty {
       logger.info("Project, $name, has no license in POM file.")
       model.parent?.artifactId.orEmpty().trim().takeIf { it.isNotEmpty() }?.let {
-        findLicenses(mavenReader, getParentPomFile(model, configurations, dependencies), configurations, dependencies)
+        findLicenses(mavenReader, getParentPomFile(model, dependencies), dependencies)
       } ?: emptyList()
     }
   }
@@ -459,9 +455,8 @@ internal open class LicenseReportTask : DefaultTask() {
   private fun Model.pomVersion(
     mavenReader: MavenXpp3Reader,
     pomFile: File?,
-    configurations: ConfigurationContainer,
     dependencies: DependencyHandler,
-  ): String = version.orEmpty().trim().ifEmpty { findVersion(mavenReader, pomFile, configurations, dependencies) }
+  ): String = version.orEmpty().trim().ifEmpty { findVersion(mavenReader, pomFile, dependencies) }
 
   private fun Model.pomName(): String = name.orEmpty().trim().ifEmpty { artifactId.orEmpty().trim() }
 

--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
@@ -28,7 +28,6 @@ import org.gradle.maven.MavenPomArtifact
 import java.io.File
 import java.net.URL
 import java.util.Locale
-import java.util.UUID
 
 /** A [org.gradle.api.Task] that creates HTML and JSON reports of the current projects dependencies. */
 internal open class LicenseReportTask : DefaultTask() {
@@ -149,7 +148,7 @@ internal open class LicenseReportTask : DefaultTask() {
 
   /** Setup configurations to collect dependencies. */
   private fun setupEnvironment(configurations: ConfigurationContainer) {
-    pomConfiguration += variantName.orEmpty() + UUID.randomUUID()
+    pomConfiguration += variantName.orEmpty() + name
 
     // Create temporary configuration in order to store POM information
     configurations.apply {

--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
@@ -81,7 +81,6 @@ internal open class LicenseReportTask : DefaultTask() {
 
   private val projects = mutableListOf<Model>()
   private var pomConfiguration = "poms"
-  private var tempPomConfiguration = "tempPoms"
 
   init {
     // From DefaultTask
@@ -151,7 +150,6 @@ internal open class LicenseReportTask : DefaultTask() {
   /** Setup configurations to collect dependencies. */
   private fun setupEnvironment(configurations: ConfigurationContainer) {
     pomConfiguration += variantName.orEmpty() + UUID.randomUUID()
-    tempPomConfiguration += variantName.orEmpty() + UUID.randomUUID()
 
     // Create temporary configuration in order to store POM information
     configurations.apply {

--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
@@ -298,17 +298,18 @@ internal open class LicenseReportTask : DefaultTask() {
     val version = parent?.version.orEmpty()
     val dependency = "$groupId:$artifactId:$version@pom"
 
-    val result = dependencies.createArtifactResolutionQuery()
-      .forModule(groupId, artifactId, version)
-      .withArtifacts(MavenModule::class.java, MavenPomArtifact::class.java)
-      .execute()
+    val result =
+      dependencies.createArtifactResolutionQuery()
+        .forModule(groupId, artifactId, version)
+        .withArtifacts(MavenModule::class.java, MavenPomArtifact::class.java)
+        .execute()
 
     var pomFile: File? = null
     for (component in result.resolvedComponents) {
       for (artifact in component.getArtifacts(MavenPomArtifact::class.java)) {
         if (artifact is ResolvedArtifactResult) {
           if (pomFile != null) {
-            logger.error("Parent POM ${dependency} resolved to multiple artifacts")
+            logger.error("Parent POM $dependency resolved to multiple artifacts")
             return null
           }
           pomFile = artifact.file
@@ -317,7 +318,7 @@ internal open class LicenseReportTask : DefaultTask() {
     }
 
     if (pomFile == null) {
-      logger.warn("Parent POM ${dependency} not found")
+      logger.warn("Parent POM $dependency not found")
     }
     return pomFile
   }

--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
@@ -428,11 +428,13 @@ internal open class LicenseReportTask : DefaultTask() {
     }
 
     // License information found
-    return model.licenses.orEmpty().filter { it.url.orEmpty().trim().isUrlValid() }.map { license ->
+    return model.licenses.orEmpty().map { license ->
       License().apply {
         this.name = license.name.orEmpty().trim()
         this.url = license.url.orEmpty().trim()
       }
+    }.filter {
+      it.name.isNotEmpty() || it.url.isUrlValid()
     }.ifEmpty {
       logger.info("Project, $name, has no license in POM file.")
       model.parent?.artifactId.orEmpty().trim().takeIf { it.isNotEmpty() }?.let {


### PR DESCRIPTION
This PR improves the parent POM resolution adressing the build cache issues mentioned at https://github.com/jaredsburrows/gradle-license-plugin/issues/338#issuecomment-1943218463 by
- using an [artifact resolution query](https://docs.gradle.org/current/dsl/org.gradle.api.artifacts.query.ArtifactResolutionQuery.html) instead of a temporary configuration repeatedly modified
- avoids appending a random value to POM configuration generated by using the task name instead
- prefers the license named by the original author even if the URL happens to be invalid