### PR TITLE
Add dark mode support for html

### DIFF
--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/internal/report/HtmlReport.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/internal/report/HtmlReport.kt
@@ -225,9 +225,17 @@ class HtmlReport(private val projects: List<Model>) : Report {
     const val DOCTYPE = "<!DOCTYPE html>"
     const val META = "<meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\">"
     const val CSS_STYLE =
-      "body { font-family: sans-serif } " +
+      // Default light theme styles
+      "body { font-family: sans-serif; background-color: #ffffff; color: #000000; } " +
+        "a { color: #0000EE; } " +
         "pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; " +
-        "word-break: break-word; display: inline-block }"
+        "word-break: break-word; display: inline-block; } " +
+
+        // Dark theme styles
+        "@media (prefers-color-scheme: dark) { " +
+        "body { background-color: #121212; color: #E0E0E0; } " +
+        "a { color: #BB86FC; } " +
+        "pre { background-color: #333333; color: #E0E0E0; } }"
     const val OPEN_SOURCE_LIBRARIES = "Open source licenses"
     const val NO_LIBRARIES = "None"
     const val NO_LICENSE = "No license found"

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginAndroidSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginAndroidSpec.groovy
@@ -77,7 +77,7 @@ final class LicensePluginAndroidSpec extends Specification {
       <html lang="en">
         <head>
           <meta http-equiv="content-type" content="text/html; charset=utf-8">
-          <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
+          <style>body { font-family: sans-serif; background-color: #ffffff; color: #000000; } a { color: #0000EE; } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block; } @media (prefers-color-scheme: dark) { body { background-color: #121212; color: #E0E0E0; } a { color: #BB86FC; } pre { background-color: #333333; color: #E0E0E0; } }</style>
           <title>Open source licenses</title>
         </head>
         <body>
@@ -157,7 +157,7 @@ final class LicensePluginAndroidSpec extends Specification {
       <html lang="en">
         <head>
           <meta http-equiv="content-type" content="text/html; charset=utf-8">
-          <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
+          <style>body { font-family: sans-serif; background-color: #ffffff; color: #000000; } a { color: #0000EE; } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block; } @media (prefers-color-scheme: dark) { body { background-color: #121212; color: #E0E0E0; } a { color: #BB86FC; } pre { background-color: #333333; color: #E0E0E0; } }</style>
           <title>Open source licenses</title>
         </head>
         <body>
@@ -369,7 +369,7 @@ final class LicensePluginAndroidSpec extends Specification {
       <html lang="en">
         <head>
           <meta http-equiv="content-type" content="text/html; charset=utf-8">
-          <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
+          <style>body { font-family: sans-serif; background-color: #ffffff; color: #000000; } a { color: #0000EE; } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block; } @media (prefers-color-scheme: dark) { body { background-color: #121212; color: #E0E0E0; } a { color: #BB86FC; } pre { background-color: #333333; color: #E0E0E0; } }</style>
           <title>Open source licenses</title>
         </head>
         <body>
@@ -519,7 +519,7 @@ final class LicensePluginAndroidSpec extends Specification {
       <html lang="en">
         <head>
           <meta http-equiv="content-type" content="text/html; charset=utf-8">
-          <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
+          <style>body { font-family: sans-serif; background-color: #ffffff; color: #000000; } a { color: #0000EE; } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block; } @media (prefers-color-scheme: dark) { body { background-color: #121212; color: #E0E0E0; } a { color: #BB86FC; } pre { background-color: #333333; color: #E0E0E0; } }</style>
           <title>Open source licenses</title>
         </head>
         <body>
@@ -748,7 +748,7 @@ final class LicensePluginAndroidSpec extends Specification {
       <html lang="en">
         <head>
           <meta http-equiv="content-type" content="text/html; charset=utf-8">
-          <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
+          <style>body { font-family: sans-serif; background-color: #ffffff; color: #000000; } a { color: #0000EE; } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block; } @media (prefers-color-scheme: dark) { body { background-color: #121212; color: #E0E0E0; } a { color: #BB86FC; } pre { background-color: #333333; color: #E0E0E0; } }</style>
           <title>Open source licenses</title>
         </head>
         <body>
@@ -894,7 +894,7 @@ final class LicensePluginAndroidSpec extends Specification {
       <html lang="en">
         <head>
           <meta http-equiv="content-type" content="text/html; charset=utf-8">
-          <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
+          <style>body { font-family: sans-serif; background-color: #ffffff; color: #000000; } a { color: #0000EE; } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block; } @media (prefers-color-scheme: dark) { body { background-color: #121212; color: #E0E0E0; } a { color: #BB86FC; } pre { background-color: #333333; color: #E0E0E0; } }</style>
           <title>Open source licenses</title>
         </head>
         <body>
@@ -1011,7 +1011,7 @@ final class LicensePluginAndroidSpec extends Specification {
       <html lang="en">
         <head>
           <meta http-equiv="content-type" content="text/html; charset=utf-8">
-          <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
+          <style>body { font-family: sans-serif; background-color: #ffffff; color: #000000; } a { color: #0000EE; } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block; } @media (prefers-color-scheme: dark) { body { background-color: #121212; color: #E0E0E0; } a { color: #BB86FC; } pre { background-color: #333333; color: #E0E0E0; } }</style>
           <title>Open source licenses</title>
         </head>
         <body>
@@ -1166,7 +1166,7 @@ final class LicensePluginAndroidSpec extends Specification {
       <html lang="en">
         <head>
           <meta http-equiv="content-type" content="text/html; charset=utf-8">
-          <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
+          <style>body { font-family: sans-serif; background-color: #ffffff; color: #000000; } a { color: #0000EE; } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block; } @media (prefers-color-scheme: dark) { body { background-color: #121212; color: #E0E0E0; } a { color: #BB86FC; } pre { background-color: #333333; color: #E0E0E0; } }</style>
           <title>Open source licenses</title>
         </head>
         <body>
@@ -1554,7 +1554,7 @@ final class LicensePluginAndroidSpec extends Specification {
       <html lang="en">
         <head>
           <meta http-equiv="content-type" content="text/html; charset=utf-8">
-          <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap;  word-break: break-word; display: inline-block }</style>
+          <style>body { font-family: sans-serif; background-color: #ffffff; color: #000000; } a { color: #0000EE; } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block; } @media (prefers-color-scheme: dark) { body { background-color: #121212; color: #E0E0E0; } a { color: #BB86FC; } pre { background-color: #333333; color: #E0E0E0; } }</style>
           <title>Open source licenses</title>
         </head>
         <body>
@@ -1667,7 +1667,7 @@ final class LicensePluginAndroidSpec extends Specification {
       <html lang="en">
         <head>
           <meta http-equiv="content-type" content="text/html; charset=utf-8">
-          <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
+          <style>body { font-family: sans-serif; background-color: #ffffff; color: #000000; } a { color: #0000EE; } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block; } @media (prefers-color-scheme: dark) { body { background-color: #121212; color: #E0E0E0; } a { color: #BB86FC; } pre { background-color: #333333; color: #E0E0E0; } }</style>
           <title>Open source licenses</title>
         </head>
         <body>
@@ -1769,7 +1769,7 @@ final class LicensePluginAndroidSpec extends Specification {
       <!DOCTYPE html>
       <html lang="en">
         <head><meta http-equiv="content-type" content="text/html; charset=utf-8">
-          <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
+          <style>body { font-family: sans-serif; background-color: #ffffff; color: #000000; } a { color: #0000EE; } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block; } @media (prefers-color-scheme: dark) { body { background-color: #121212; color: #E0E0E0; } a { color: #BB86FC; } pre { background-color: #333333; color: #E0E0E0; } }</style>
           <title>Open source licenses</title>
         </head>
         <body>
@@ -1863,7 +1863,7 @@ final class LicensePluginAndroidSpec extends Specification {
       <!DOCTYPE html>
       <html lang="en">
         <head><meta http-equiv="content-type" content="text/html; charset=utf-8">
-          <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
+          <style>body { font-family: sans-serif; background-color: #ffffff; color: #000000; } a { color: #0000EE; } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block; } @media (prefers-color-scheme: dark) { body { background-color: #121212; color: #E0E0E0; } a { color: #BB86FC; } pre { background-color: #333333; color: #E0E0E0; } }</style>
           <title>Open source licenses</title>
         </head>
         <body>
@@ -1929,7 +1929,7 @@ final class LicensePluginAndroidSpec extends Specification {
       <!DOCTYPE html>
       <html lang="en">
         <head><meta http-equiv="content-type" content="text/html; charset=utf-8">
-          <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
+          <style>body { font-family: sans-serif; background-color: #ffffff; color: #000000; } a { color: #0000EE; } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block; } @media (prefers-color-scheme: dark) { body { background-color: #121212; color: #E0E0E0; } a { color: #BB86FC; } pre { background-color: #333333; color: #E0E0E0; } }</style>
           <title>Open source licenses</title>
         </head>
         <body>
@@ -2023,7 +2023,7 @@ final class LicensePluginAndroidSpec extends Specification {
       <!DOCTYPE html>
       <html lang="en">
         <head><meta http-equiv="content-type" content="text/html; charset=utf-8">
-          <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
+          <style>body { font-family: sans-serif; background-color: #ffffff; color: #000000; } a { color: #0000EE; } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block; } @media (prefers-color-scheme: dark) { body { background-color: #121212; color: #E0E0E0; } a { color: #BB86FC; } pre { background-color: #333333; color: #E0E0E0; } }</style>
           <title>Open source licenses</title>
         </head>
         <body>
@@ -2090,7 +2090,7 @@ final class LicensePluginAndroidSpec extends Specification {
       <!DOCTYPE html>
       <html lang="en">
         <head><meta http-equiv="content-type" content="text/html; charset=utf-8">
-          <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
+          <style>body { font-family: sans-serif; background-color: #ffffff; color: #000000; } a { color: #0000EE; } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block; } @media (prefers-color-scheme: dark) { body { background-color: #121212; color: #E0E0E0; } a { color: #BB86FC; } pre { background-color: #333333; color: #E0E0E0; } }</style>
           <title>Open source licenses</title>
         </head>
         <body>
@@ -2186,7 +2186,7 @@ final class LicensePluginAndroidSpec extends Specification {
       <!DOCTYPE html>
       <html lang="en">
         <head><meta http-equiv="content-type" content="text/html; charset=utf-8">
-          <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
+          <style>body { font-family: sans-serif; background-color: #ffffff; color: #000000; } a { color: #0000EE; } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block; } @media (prefers-color-scheme: dark) { body { background-color: #121212; color: #E0E0E0; } a { color: #BB86FC; } pre { background-color: #333333; color: #E0E0E0; } }</style>
           <title>Open source licenses</title>
         </head>
         <body>
@@ -2280,7 +2280,7 @@ final class LicensePluginAndroidSpec extends Specification {
       <!DOCTYPE html>
       <html lang="en">
         <head><meta http-equiv="content-type" content="text/html; charset=utf-8">
-          <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
+          <style>body { font-family: sans-serif; background-color: #ffffff; color: #000000; } a { color: #0000EE; } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block; } @media (prefers-color-scheme: dark) { body { background-color: #121212; color: #E0E0E0; } a { color: #BB86FC; } pre { background-color: #333333; color: #E0E0E0; } }</style>
           <title>Open source licenses</title>
         </head>
         <body>

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJavaSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJavaSpec.groovy
@@ -45,7 +45,7 @@ final class LicensePluginJavaSpec extends Specification {
       <html lang="en">
         <head>
           <meta http-equiv="content-type" content="text/html; charset=utf-8">
-          <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
+          <style>body { font-family: sans-serif; background-color: #ffffff; color: #000000; } a { color: #0000EE; } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block; } @media (prefers-color-scheme: dark) { body { background-color: #121212; color: #E0E0E0; } a { color: #BB86FC; } pre { background-color: #333333; color: #E0E0E0; } }</style>
           <title>Open source licenses</title>
         </head>
         <body>
@@ -104,7 +104,7 @@ final class LicensePluginJavaSpec extends Specification {
       <html lang="en">
         <head>
           <meta http-equiv="content-type" content="text/html; charset=utf-8">
-          <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
+          <style>body { font-family: sans-serif; background-color: #ffffff; color: #000000; } a { color: #0000EE; } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block; } @media (prefers-color-scheme: dark) { body { background-color: #121212; color: #E0E0E0; } a { color: #BB86FC; } pre { background-color: #333333; color: #E0E0E0; } }</style>
           <title>Open source licenses</title>
         </head>
         <body>
@@ -188,7 +188,7 @@ final class LicensePluginJavaSpec extends Specification {
       <html lang="en">
         <head>
           <meta http-equiv="content-type" content="text/html; charset=utf-8">
-          <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
+          <style>body { font-family: sans-serif; background-color: #ffffff; color: #000000; } a { color: #0000EE; } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block; } @media (prefers-color-scheme: dark) { body { background-color: #121212; color: #E0E0E0; } a { color: #BB86FC; } pre { background-color: #333333; color: #E0E0E0; } }</style>
           <title>Open source licenses</title>
         </head>
         <body>
@@ -298,7 +298,7 @@ final class LicensePluginJavaSpec extends Specification {
       <html lang="en">
         <head>
           <meta http-equiv="content-type" content="text/html; charset=utf-8">
-          <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
+          <style>body { font-family: sans-serif; background-color: #ffffff; color: #000000; } a { color: #0000EE; } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block; } @media (prefers-color-scheme: dark) { body { background-color: #121212; color: #E0E0E0; } a { color: #BB86FC; } pre { background-color: #333333; color: #E0E0E0; } }</style>
           <title>Open source licenses</title>
         </head>
         <body>
@@ -357,7 +357,7 @@ final class LicensePluginJavaSpec extends Specification {
       <html lang="en">
         <head>
           <meta http-equiv="content-type" content="text/html; charset=utf-8">
-          <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
+          <style>body { font-family: sans-serif; background-color: #ffffff; color: #000000; } a { color: #0000EE; } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block; } @media (prefers-color-scheme: dark) { body { background-color: #121212; color: #E0E0E0; } a { color: #BB86FC; } pre { background-color: #333333; color: #E0E0E0; } }</style>
           <title>Open source licenses</title>
         </head>
         <body>
@@ -449,7 +449,7 @@ final class LicensePluginJavaSpec extends Specification {
       <html lang="en">
         <head>
           <meta http-equiv="content-type" content="text/html; charset=utf-8">
-          <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
+          <style>body { font-family: sans-serif; background-color: #ffffff; color: #000000; } a { color: #0000EE; } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block; } @media (prefers-color-scheme: dark) { body { background-color: #121212; color: #E0E0E0; } a { color: #BB86FC; } pre { background-color: #333333; color: #E0E0E0; } }</style>
           <title>Open source licenses</title>
         </head>
         <body>
@@ -550,7 +550,7 @@ final class LicensePluginJavaSpec extends Specification {
       <html lang="en">
         <head>
           <meta http-equiv="content-type" content="text/html; charset=utf-8">
-          <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
+          <style>body { font-family: sans-serif; background-color: #ffffff; color: #000000; } a { color: #0000EE; } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block; } @media (prefers-color-scheme: dark) { body { background-color: #121212; color: #E0E0E0; } a { color: #BB86FC; } pre { background-color: #333333; color: #E0E0E0; } }</style>
           <title>Open source licenses</title>
         </head>
         <body>
@@ -671,7 +671,7 @@ final class LicensePluginJavaSpec extends Specification {
       <html lang="en">
         <head>
           <meta http-equiv="content-type" content="text/html; charset=utf-8">
-          <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
+          <style>body { font-family: sans-serif; background-color: #ffffff; color: #000000; } a { color: #0000EE; } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block; } @media (prefers-color-scheme: dark) { body { background-color: #121212; color: #E0E0E0; } a { color: #BB86FC; } pre { background-color: #333333; color: #E0E0E0; } }</style>
           <title>Open source licenses</title>
         </head>
         <body>
@@ -812,7 +812,7 @@ final class LicensePluginJavaSpec extends Specification {
       <html lang="en">
         <head>
           <meta http-equiv="content-type" content="text/html; charset=utf-8">
-          <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
+          <style>body { font-family: sans-serif; background-color: #ffffff; color: #000000; } a { color: #0000EE; } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block; } @media (prefers-color-scheme: dark) { body { background-color: #121212; color: #E0E0E0; } a { color: #BB86FC; } pre { background-color: #333333; color: #E0E0E0; } }</style>
           <title>Open source licenses</title>
         </head>
         <body>
@@ -998,7 +998,7 @@ final class LicensePluginJavaSpec extends Specification {
       <html lang="en">
         <head>
           <meta http-equiv="content-type" content="text/html; charset=utf-8">
-          <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
+          <style>body { font-family: sans-serif; background-color: #ffffff; color: #000000; } a { color: #0000EE; } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block; } @media (prefers-color-scheme: dark) { body { background-color: #121212; color: #E0E0E0; } a { color: #BB86FC; } pre { background-color: #333333; color: #E0E0E0; } }</style>
           <title>Open source licenses</title>
         </head>
         <body>
@@ -1123,7 +1123,7 @@ final class LicensePluginJavaSpec extends Specification {
       <html lang="en">
         <head>
           <meta http-equiv="content-type" content="text/html; charset=utf-8">
-          <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
+          <style>body { font-family: sans-serif; background-color: #ffffff; color: #000000; } a { color: #0000EE; } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block; } @media (prefers-color-scheme: dark) { body { background-color: #121212; color: #E0E0E0; } a { color: #BB86FC; } pre { background-color: #333333; color: #E0E0E0; } }</style>
           <title>Open source licenses</title>
         </head>
         <body>

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/internal/report/HtmlReportSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/internal/report/HtmlReportSpec.groovy
@@ -21,7 +21,7 @@ final class HtmlReportSpec extends Specification {
       <html lang="en">
         <head>
           <meta http-equiv="content-type" content="text/html; charset=utf-8">
-          <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
+          <style>body { font-family: sans-serif; background-color: #ffffff; color: #000000; } a { color: #0000EE; } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block; } @media (prefers-color-scheme: dark) { body { background-color: #121212; color: #E0E0E0; } a { color: #BB86FC; } pre { background-color: #333333; color: #E0E0E0; } }</style>
           <title>Open source licenses</title>
         </head>
         <body>
@@ -75,7 +75,7 @@ final class HtmlReportSpec extends Specification {
       <html lang="en">
         <head>
           <meta http-equiv="content-type" content="text/html; charset=utf-8">
-          <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style>
+          <style>body { font-family: sans-serif; background-color: #ffffff; color: #000000; } a { color: #0000EE; } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block; } @media (prefers-color-scheme: dark) { body { background-color: #121212; color: #E0E0E0; } a { color: #BB86FC; } pre { background-color: #333333; color: #E0E0E0; } }</style>
           <title>Open source licenses</title>
         </head>
         <body>


### PR DESCRIPTION
Closes #457 

Validated by: https://validator.w3.org/nu/#textarea

<details close>
<summary>Sample HTML</summary>
<br>

```
<!DOCTYPE html>
<html lang="en">
  <head><meta http-equiv="content-type" content="text/html; charset=utf-8">
    <!-- <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block }</style> -->
    <style>
      body {
        font-family: sans-serif;
        background-color: #ffffff; /* Light background */
        color: #000000; /* Dark text */
      }
      a {
        color: #0000EE; /* Default blue for links */
      }
      pre {
        background-color: #eeeeee; /* Lighter background for preformatted text */
        color: #000000; /* Dark text for readability */
      }
      

      @media (prefers-color-scheme: dark) {
        body {
          background-color: #121212; /* Dark background */
          color: #E0E0E0; /* Light text */
        }
        a {
          color: #BB86FC; /* Light purple for links */
        }
        pre {
          background-color: #333333; /* Darker background for preformatted text */
          color: #E0E0E0; /* Light text for readability */
        }
      }
    </style>
    <title>Open source licenses</title>
  </head>
  <body>
    <h3>Notice for packages:</h3>
    <ul>
      <li><a href="#1934118923">Accompanist Drawable Painter library (0.34.0)</a>
        <dl>
          <dt>Copyright &copy; 20xx Google</dt>
          <dd></dd>
        </dl>
      </li>
      <li><a href="#1934118923">Accompanist SwipeRefresh library (0.34.0)</a>
        <dl>
          <dt>Copyright &copy; 20xx Google</dt>
          <dd></dd>
        </dl>
      </li>
      <li><a href="#1934118923">Activity (1.8.2)</a>
        <dl>
          <dt>Copyright &copy; 2018 The Android Open Source Project</dt>
          <dd></dd>
        </dl>
      </li>
      <li><a href="#1934118923">Activity Compose (1.8.2)</a>
        <dl>
          <dt>Copyright &copy; 2020 The Android Open Source Project</dt>
          <dd></dd>
        </dl>
      </li>
      <li><a href="#1934118923">Activity Kotlin Extensions (1.8.2)</a>
        <dl>
          <dt>Copyright &copy; 2018 The Android Open Source Project</dt>
          <dd></dd>
        </dl>
      </li>
      <li><a href="#1934118923">Android App Startup Runtime (1.1.1)</a>
        <dl>
          <dt>Copyright &copy; 2020 The Android Open Source Project</dt>
          <dd></dd>
        </dl>
      </li>
      <li><a href="#1934118923">Android AppCompat Library (1.6.1)</a>
        <dl>
          <dt>Copyright &copy; 2011 The Android Open Source Project</dt>
          <dd></dd>
        </dl>
      </li>
      <li><a href="#1934118923">Android Arch-Common (2.2.0)</a>
        <dl>
          <dt>Copyright &copy; 2017 The Android Open Source Project</dt>
          <dd></dd>
        </dl>
      </li>
      <li><a href="#1934118923">Android Arch-Runtime (2.2.0)</a>
        <dl>
          <dt>Copyright &copy; 2017 The Android Open Source Project</dt>
          <dd></dd>
        </dl>
      </li>
      <li><a href="#1934118923">Android ConstraintLayout (2.0.1)</a>
        <dl>
          <dt>Copyright &copy; 2007 The Android Open Source Project</dt>
          <dd></dd>
        </dl>
      </li>
      <li><a href="#1934118923">Android ConstraintLayout Solver (2.0.1)</a>
        <dl>
          <dt>Copyright &copy; 2007 The Android Open Source Project</dt>
          <dd></dd>
        </dl>
      </li>
  </body>
</html>
```
</details>

| Light | Dark |
| --- | --- |
| <img width="445" alt="Screenshot 2024-04-08 at 2 03 07 PM" src="https://github.com/jaredsburrows/gradle-license-plugin/assets/1739848/a46cd5b1-4180-4368-9da3-45f9a311e10c"> | <img width="453" alt="Screenshot 2024-04-08 at 2 03 18 PM" src="https://github.com/jaredsburrows/gradle-license-plugin/assets/1739848/187b393d-5ba5-47fc-bdf8-936250bf3e3c"> |

