### PR TITLE
Defer dependency resolution out of the configuration phase

### DIFF
--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
@@ -32,10 +32,8 @@ internal abstract class LicenseReportTask
   constructor(
     objectFactory: ObjectFactory,
   ) : DefaultTask() {
-    // Value properties (never file collections, whose providers Gradle resolves while computing
-    // task dependencies during scheduling) so that the dependency graph is only resolved when the
-    // value is first queried, at execution time (or configuration cache store time) - never while
-    // the task is configured or scheduled.
+    // Never file collections: Gradle resolves their providers during scheduling, which is still
+    // configuration time (#804).
     @get:Input
     val rootCoordinates: ListProperty<String> = objectFactory.listProperty(String::class.java)
 
@@ -43,9 +41,8 @@ internal abstract class LicenseReportTask
     val pomCoordinatesToFile: MapProperty<String, String> =
       objectFactory.mapProperty(String::class.java, String::class.java)
 
-    // Never read by the task action; declared as an input in place of the POM files themselves so
-    // that a POM whose content changes at a stable path (e.g. in a mavenLocal or other file-based
-    // repository) still re-runs the task.
+    // Never read by the action; re-runs the task when POM content changes at a stable path
+    // (e.g. mavenLocal).
     @get:Input
     val pomContentHashes: MapProperty<String, String> =
       objectFactory.mapProperty(String::class.java, String::class.java)

--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
@@ -12,14 +12,12 @@ import org.apache.maven.model.Model
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader
 import org.codehaus.plexus.util.ReaderFactory
 import org.gradle.api.DefaultTask
-import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.MapProperty
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
-import org.gradle.api.tasks.PathSensitive
-import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.work.DisableCachingByDefault
 import java.io.File
@@ -34,15 +32,23 @@ internal abstract class LicenseReportTask
   constructor(
     objectFactory: ObjectFactory,
   ) : DefaultTask() {
-    @get:InputFiles
-    @get:PathSensitive(PathSensitivity.RELATIVE)
-    val pomFiles: ConfigurableFileCollection = objectFactory.fileCollection()
+    // Value properties (never file collections, whose providers Gradle resolves while computing
+    // task dependencies during scheduling) so that the dependency graph is only resolved when the
+    // value is first queried, at execution time (or configuration cache store time) - never while
+    // the task is configured or scheduled.
+    @get:Input
+    val rootCoordinates: ListProperty<String> = objectFactory.listProperty(String::class.java)
 
-    @Input
-    var rootCoordinates: List<String> = emptyList()
+    @get:Input
+    val pomCoordinatesToFile: MapProperty<String, String> =
+      objectFactory.mapProperty(String::class.java, String::class.java)
 
-    @Input
-    var pomCoordinatesToFile: Map<String, String> = emptyMap()
+    // Never read by the task action; declared as an input in place of the POM files themselves so
+    // that a POM whose content changes at a stable path (e.g. in a mavenLocal or other file-based
+    // repository) still re-runs the task.
+    @get:Input
+    val pomContentHashes: MapProperty<String, String> =
+      objectFactory.mapProperty(String::class.java, String::class.java)
 
     @Input
     var assetDirs = emptyList<File>()
@@ -158,10 +164,11 @@ internal abstract class LicenseReportTask
       loggedMissingParentPomCoordinates: MutableSet<String>,
     ) {
       rootCoordinates
+        .get()
         .asSequence()
         .distinct()
         .mapNotNull { coordinate ->
-          val pomFilePath = pomCoordinatesToFile[coordinate] ?: return@mapNotNull null
+          val pomFilePath = pomCoordinatesToFile.get()[coordinate] ?: return@mapNotNull null
           coordinate to File(pomFilePath)
         }.filter { (coordinate, _) ->
           ignoredPatterns.none { coordinate.contains(it) }
@@ -519,7 +526,7 @@ internal abstract class LicenseReportTask
       }
 
       val coordinate = "$groupId:$artifactId:$version"
-      val pomFilePath = pomCoordinatesToFile[coordinate]
+      val pomFilePath = pomCoordinatesToFile.get()[coordinate]
       if (pomFilePath == null) {
         if (loggedMissingParentPomCoordinates.add(coordinate)) {
           logger.warn("Parent POM $groupId:$artifactId:$version@pom not found")

--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/Project.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/Project.kt
@@ -6,21 +6,21 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.artifacts.result.ResolvedArtifactResult
-import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.reporting.ReportingExtension
 import org.gradle.maven.MavenModule
 import org.gradle.maven.MavenPomArtifact
 import java.io.File
+import java.security.MessageDigest
 
 /** Returns true if plugin exists in project. */
 internal fun Project.hasPlugin(list: List<String>): Boolean = list.any { plugins.hasPlugin(it) }
 
 private fun Project.includeParentPomFilesRecursively(
   mavenReader: MavenXpp3Reader,
-  fileCollection: ConfigurableFileCollection,
+  rootPomFiles: List<File>,
   coordinateToFile: MutableMap<String, String>,
 ) {
-  var pomFilesToInspect = fileCollection.files.toList()
+  var pomFilesToInspect = rootPomFiles
   val visitedParentCoordinates = hashSetOf<String>()
 
   while (pomFilesToInspect.isNotEmpty()) {
@@ -57,7 +57,6 @@ private fun Project.includeParentPomFilesRecursively(
     val nextPomFiles = mutableListOf<File>()
     resolvePomFiles(parentCoordinates).forEach { (coordinate, pomFile) ->
       coordinateToFile[coordinate] = pomFile.absolutePath
-      fileCollection.from(pomFile)
       nextPomFiles += pomFile
     }
     pomFilesToInspect = nextPomFiles
@@ -100,7 +99,17 @@ internal fun Project.configureCommon(
   val reportingExtension = extensions.getByType(ReportingExtension::class.java)
   val licenseExtension = extensions.getByType(LicenseReportExtension::class.java)
 
-  val pomInput = buildPomInput(configurationNames)
+  // Dependency resolution must not run while the task is being configured: realizing the task
+  // during the configuration phase would resolve the (variant) classpath configurations, which AGP
+  // reports as "Configuration '...' was resolved during configuration time" (issue #804). Computing
+  // the POM input lazily (and at most once) defers the graph resolution, the POM artifact queries
+  // and the parent POM walk until these providers are first queried - when Gradle fingerprints the
+  // task inputs at execution time, or at configuration cache store time once the task graph is
+  // ready.
+  val pomInput = lazy { buildPomInput(configurationNames) }
+  val rootCoordinatesProvider = provider { pomInput.value.rootCoordinates }
+  val coordinateToFileProvider = provider { pomInput.value.coordinateToFile }
+  val contentHashesProvider = provider { pomInput.value.contentHashes }
 
   task.apply {
     outputDir =
@@ -109,10 +118,9 @@ internal fun Project.configureCommon(
         .get()
         .asFile
 
-    pomFiles.from(pomInput.files.files)
-    pomFiles.disallowChanges()
-    rootCoordinates = pomInput.rootCoordinates
-    pomCoordinatesToFile = pomInput.coordinateToFile
+    rootCoordinates.set(rootCoordinatesProvider)
+    pomCoordinatesToFile.set(coordinateToFileProvider)
+    pomContentHashes.set(contentHashesProvider)
 
     generateCsvReport = licenseExtension.generateCsvReport
     generateHtmlReport = licenseExtension.generateHtmlReport
@@ -129,13 +137,29 @@ internal fun Project.configureCommon(
 }
 
 private data class PomInput(
-  val files: ConfigurableFileCollection,
   val rootCoordinates: List<String>,
   val coordinateToFile: Map<String, String>,
+  val contentHashes: Map<String, String>,
 )
 
+/**
+ * Content hash used as a task input in place of the POM files themselves, so that a POM whose
+ * content changes at a stable path (e.g. in a mavenLocal or other file-based repository) still
+ * re-runs the task.
+ */
+private fun File.contentHash(): String =
+  try {
+    MessageDigest
+      .getInstance("SHA-256")
+      .digest(readBytes())
+      .joinToString("") { "%02x".format(it) }
+  } catch (_: Exception) {
+    // Fall back to file metadata so an unreadable file still contributes a distinguishing value.
+    "$absolutePath:${length()}:${lastModified()}"
+  }
+
 private fun Project.buildPomInput(configurationNames: List<String>): PomInput {
-  val fileCollection = objects.fileCollection()
+  val rootPomFiles = mutableListOf<File>()
   val coordinateToFile = sortedMapOf<String, String>()
   val roots = linkedSetOf<String>()
 
@@ -179,7 +203,7 @@ private fun Project.buildPomInput(configurationNames: List<String>): PomInput {
       val coordinate = "${componentId.group}:${componentId.module}:${componentId.version}"
       coordinateToFile.putIfAbsent(coordinate, pomFile.absolutePath)
       roots += coordinate
-      fileCollection.from(pomFile)
+      rootPomFiles += pomFile
     }
   }
 
@@ -187,13 +211,13 @@ private fun Project.buildPomInput(configurationNames: List<String>): PomInput {
 
   includeParentPomFilesRecursively(
     mavenReader = mavenReader,
-    fileCollection = fileCollection,
+    rootPomFiles = rootPomFiles,
     coordinateToFile = coordinateToFile,
   )
 
   return PomInput(
-    files = fileCollection,
     rootCoordinates = roots.toList().sorted(),
     coordinateToFile = coordinateToFile,
+    contentHashes = coordinateToFile.mapValues { (_, path) -> File(path).contentHash() },
   )
 }

--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/Project.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/Project.kt
@@ -99,13 +99,8 @@ internal fun Project.configureCommon(
   val reportingExtension = extensions.getByType(ReportingExtension::class.java)
   val licenseExtension = extensions.getByType(LicenseReportExtension::class.java)
 
-  // Dependency resolution must not run while the task is being configured: realizing the task
-  // during the configuration phase would resolve the (variant) classpath configurations, which AGP
-  // reports as "Configuration '...' was resolved during configuration time" (issue #804). Computing
-  // the POM input lazily (and at most once) defers the graph resolution, the POM artifact queries
-  // and the parent POM walk until these providers are first queried - when Gradle fingerprints the
-  // task inputs at execution time, or at configuration cache store time once the task graph is
-  // ready.
+  // Defer all resolution until the task inputs are queried at execution time; resolving during
+  // task configuration triggers AGP's "resolved during configuration time" warning (#804).
   val pomInput = lazy { buildPomInput(configurationNames) }
   val rootCoordinatesProvider = provider { pomInput.value.rootCoordinates }
   val coordinateToFileProvider = provider { pomInput.value.coordinateToFile }
@@ -142,11 +137,7 @@ private data class PomInput(
   val contentHashes: Map<String, String>,
 )
 
-/**
- * Content hash used as a task input in place of the POM files themselves, so that a POM whose
- * content changes at a stable path (e.g. in a mavenLocal or other file-based repository) still
- * re-runs the task.
- */
+/** Content hash tracked as a task input; a stable path (e.g. mavenLocal) can hide POM changes. */
 private fun File.contentHash(): String =
   try {
     MessageDigest
@@ -154,7 +145,7 @@ private fun File.contentHash(): String =
       .digest(readBytes())
       .joinToString("") { "%02x".format(it) }
   } catch (_: Exception) {
-    // Fall back to file metadata so an unreadable file still contributes a distinguishing value.
+    // Unreadable file: fall back to metadata so it still contributes a distinguishing value.
     "$absolutePath:${length()}:${lastModified()}"
   }
 

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginAndroidSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginAndroidSpec.groovy
@@ -2,6 +2,7 @@ package com.jaredsburrows.license
 
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
+import spock.lang.Issue
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -2230,6 +2231,65 @@ final class LicensePluginAndroidSpec extends Specification {
     result.output.find("Wrote JSON report to .*${reportFolder}/${taskName}.json.")
     assertHtml(expectedHtml, actualHtml)
     assertJson(expectedJson, actualJson)
+
+    where:
+    taskName << ['licenseDebugReport', 'licenseReleaseReport']
+  }
+
+  @Issue("jaredsburrows/gradle-license-plugin/issues/804")
+  @Unroll
+  def '#taskName does not resolve configurations at configuration time'() {
+    given: 'a build that flags configuration-time resolution the same way AGP does'
+    buildFile <<
+      """
+      buildscript {
+        dependencies {
+          classpath files($classpathString)
+        }
+      }
+
+      repositories {
+        maven {
+          url '${mavenRepoUrl}'
+        }
+      }
+
+      apply plugin: 'com.android.application'
+      apply plugin: 'com.jaredsburrows.license'
+
+      android {
+        compileSdkVersion $compileSdkVersion
+        namespace 'com.example'
+
+        defaultConfig {
+          applicationId 'com.example'
+        }
+      }
+
+      dependencies {
+        implementation 'group:child:1.0.0'
+      }
+
+      // Mirror AGP's DependencyResolutionChecks: report any project configuration that is
+      // resolved before the task graph is ready, i.e. during the configuration phase.
+      def configurationPhase = new java.util.concurrent.atomic.AtomicBoolean(true)
+      gradle.taskGraph.whenReady { configurationPhase.set(false) }
+      configurations.configureEach { conf ->
+        conf.incoming.beforeResolve {
+          if (configurationPhase.get()) {
+            println("CONFIGURATION-TIME-RESOLUTION: \${conf.name}")
+          }
+        }
+      }
+      """
+
+    when:
+    def result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
+
+    then: 'the report is generated without resolving any configuration during configuration'
+    result.task(":${taskName}").outcome == SUCCESS
+    !result.output.contains('CONFIGURATION-TIME-RESOLUTION:')
+    !result.output.contains('was resolved during configuration time')
 
     where:
     taskName << ['licenseDebugReport', 'licenseReleaseReport']

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginAndroidSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginAndroidSpec.groovy
@@ -2270,8 +2270,7 @@ final class LicensePluginAndroidSpec extends Specification {
         implementation 'group:child:1.0.0'
       }
 
-      // Mirror AGP's DependencyResolutionChecks: report any project configuration that is
-      // resolved before the task graph is ready, i.e. during the configuration phase.
+      // Mirror AGP's DependencyResolutionChecks: flag configurations resolved before the task graph is ready.
       def configurationPhase = new java.util.concurrent.atomic.AtomicBoolean(true)
       gradle.taskGraph.whenReady { configurationPhase.set(false) }
       configurations.configureEach { conf ->

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJavaSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJavaSpec.groovy
@@ -1703,8 +1703,7 @@ final class LicensePluginJavaSpec extends Specification {
         implementation 'group:name:1.0.0'
       }
 
-      // Mirror AGP's DependencyResolutionChecks: report any project configuration that is
-      // resolved before the task graph is ready, i.e. during the configuration phase.
+      // Mirror AGP's DependencyResolutionChecks: flag configurations resolved before the task graph is ready.
       def configurationPhase = new java.util.concurrent.atomic.AtomicBoolean(true)
       gradle.taskGraph.whenReady { configurationPhase.set(false) }
       configurations.configureEach { conf ->

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJavaSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJavaSpec.groovy
@@ -7,6 +7,7 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import static org.gradle.testkit.runner.TaskOutcome.UP_TO_DATE
 import static test.TestUtils.assertHtml
 import static test.TestUtils.assertJson
 import static test.TestUtils.getLicenseText
@@ -1680,5 +1681,107 @@ final class LicensePluginJavaSpec extends Specification {
     then:
     result.task(':licenseReport').outcome == SUCCESS
     assertJson(expectedJson, actualJson.text)
+  }
+
+  @Issue("jaredsburrows/gradle-license-plugin/issues/804")
+  def 'licenseReport does not resolve configurations at configuration time'() {
+    given: 'a build that flags configuration-time resolution the same way AGP does'
+    buildFile <<
+      """
+      plugins {
+        id 'java-library'
+        id 'com.jaredsburrows.license'
+      }
+
+      repositories {
+        maven {
+          url '${mavenRepoUrl}'
+        }
+      }
+
+      dependencies {
+        implementation 'group:name:1.0.0'
+      }
+
+      // Mirror AGP's DependencyResolutionChecks: report any project configuration that is
+      // resolved before the task graph is ready, i.e. during the configuration phase.
+      def configurationPhase = new java.util.concurrent.atomic.AtomicBoolean(true)
+      gradle.taskGraph.whenReady { configurationPhase.set(false) }
+      configurations.configureEach { conf ->
+        conf.incoming.beforeResolve {
+          if (configurationPhase.get()) {
+            println("CONFIGURATION-TIME-RESOLUTION: \${conf.name}")
+          }
+        }
+      }
+      """
+
+    when:
+    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+
+    then: 'the report is generated without resolving any configuration during configuration'
+    result.task(':licenseReport').outcome == SUCCESS
+    !result.output.contains('CONFIGURATION-TIME-RESOLUTION:')
+  }
+
+  @Issue("jaredsburrows/gradle-license-plugin/issues/804")
+  def 'licenseReport re-runs when a POM changes in place'() {
+    given: 'a dependency in a file-based repository inside the test project'
+    def repoDir = testProjectDir.newFolder('repo', 'group', 'local', '1.0.0')
+    def pomFile = new File(repoDir, 'local-1.0.0.pom')
+    pomFile.text = """<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>group</groupId>
+  <artifactId>local</artifactId>
+  <version>1.0.0</version>
+  <name>Local dependency</name>
+  <licenses>
+    <license>
+      <name>License A</name>
+      <url>https://example.com/a</url>
+    </license>
+  </licenses>
+</project>
+"""
+    new File(repoDir, 'local-1.0.0.jar').createNewFile()
+    buildFile <<
+      """
+      plugins {
+        id 'java-library'
+        id 'com.jaredsburrows.license'
+      }
+
+      repositories {
+        maven {
+          url '${testProjectDir.root.toURI()}repo'
+        }
+      }
+
+      dependencies {
+        implementation 'group:local:1.0.0'
+      }
+      """
+
+    when: 'the report is generated'
+    def first = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+
+    then:
+    first.task(':licenseReport').outcome == SUCCESS
+    new File(reportFolder, 'licenseReport.json').text.contains('License A')
+
+    when: 'nothing changes'
+    def second = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+
+    then:
+    second.task(':licenseReport').outcome == UP_TO_DATE
+
+    when: 'the POM content changes at the same path'
+    pomFile.text = pomFile.text.replace('License A', 'License B')
+    def third = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+
+    then: 'the task is not up-to-date and regenerates the report'
+    third.task(':licenseReport').outcome == SUCCESS
+    new File(reportFolder, 'licenseReport.json').text.contains('License B')
   }
 }


### PR DESCRIPTION
Fixes #804

## Problem

Running any license report task with AGP 9 produces:

```
Configuration 'fullReleaseCompileClasspath' was resolved during configuration time.
This is a build performance and scalability issue.
See https://github.com/gradle/gradle/issues/2298
```

The task registration action called `configureCommon` → `buildPomInput`, which resolved the variant classpath configurations (`resolutionResult.allComponents`), ran POM artifact resolution queries and recursively resolved parent POMs — all eagerly, the moment the task was realized (e.g. while Gradle populates the task graph, exactly the stack trace in the issue).

## Fix

`buildPomInput` now runs in a shared `lazy {}` block exposed to the task through provider-backed `@Input` **value** properties (`rootCoordinates`, `pomCoordinatesToFile`), so all resolution is deferred until Gradle fingerprints the task inputs at execution time — or at configuration cache store time, after the task graph is ready. This mirrors the design used by `app.cash.licensee`.

Two supporting changes:

* The former `@InputFiles pomFiles` collection is **removed**. Gradle eagerly resolves provider-backed *file collections* while computing task dependencies during scheduling (`ProviderBackedFileCollection.visitDependencies` → `provider.get()`, verified with a stack trace), which would defeat the deferral — and the task action never read it; POMs never come from task outputs (module components only), so it carried no real task dependencies.
* POM **content** is instead tracked through a new `@Input` SHA-256 hash map (`pomContentHashes`) derived from the same lazy block, so a POM whose content changes at a stable path (mavenLocal / file-based repositories, where paths don't embed a checksum) still re-runs the task.

## Tests

* `#taskName does not resolve configurations at configuration time` (Android, both variants) and `licenseReport does not resolve configurations at configuration time` (Java): mirror AGP's `DependencyResolutionChecks` (a `beforeResolve` marker armed until `taskGraph.whenReady`) and also assert AGP's own warning is absent. All three fail before this change and pass after.
* `licenseReport re-runs when a POM changes in place`: file-based repo, asserts SUCCESS → UP-TO-DATE → SUCCESS-with-new-license across an in-place POM edit (guards the content-hash input, and that the provider-computed inputs stay deterministic across builds).

## Verification

* Full suite: 123 tests, 0 failures (includes AGP 9.3.0 / Gradle 9.6.1 TestKit specs).
* Scratch project verified in vintage mode, configuration-cache store, and configuration-cache reuse (reports still generated correctly from a reused entry).

CHANGELOG entry left for the release PR, matching existing practice.