### PR TITLE
Resolve parent POMs of the same module at different versions

### DIFF
--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/Project.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/Project.kt
@@ -63,31 +63,52 @@ private fun Project.includeParentPomFilesRecursively(
   }
 }
 
-/** Resolve the POM files for the given GAV coordinates in a single batched dependency resolution. */
+/**
+ * Resolve the POM files for the given GAV coordinates in batched dependency resolutions.
+ * Coordinates sharing a module at different versions go to separate batches: within one
+ * configuration Gradle conflict-resolves them to a single version and silently drops the
+ * other POMs (#800).
+ */
 private fun Project.resolvePomFiles(coordinates: Collection<String>): Map<String, File> {
   if (coordinates.isEmpty()) {
     return emptyMap()
   }
 
-  val pomDependencies =
-    coordinates
-      .map { dependencies.create("$it@pom") }
-      .toTypedArray()
-  val detachedConfiguration =
-    configurations.detachedConfiguration(*pomDependencies).apply {
-      isTransitive = false
+  // batches[i] holds the i-th version of each module, so no batch sees two versions of one module.
+  val batches = mutableListOf<MutableList<String>>()
+  coordinates
+    .groupBy { it.substringBeforeLast(':') }
+    .values
+    .forEach { moduleCoordinates ->
+      moduleCoordinates.forEachIndexed { index, coordinate ->
+        if (batches.size <= index) {
+          batches.add(mutableListOf())
+        }
+        batches[index] += coordinate
+      }
     }
 
   val resolved = linkedMapOf<String, File>()
-  detachedConfiguration.incoming
-    .artifactView { it.isLenient = true }
-    .artifacts
-    .forEach { artifact ->
-      val id = artifact.id.componentIdentifier
-      if (id is ModuleComponentIdentifier) {
-        resolved["${id.group}:${id.module}:${id.version}"] = artifact.file
+  batches.forEach { batch ->
+    val pomDependencies =
+      batch
+        .map { dependencies.create("$it@pom") }
+        .toTypedArray()
+    val detachedConfiguration =
+      configurations.detachedConfiguration(*pomDependencies).apply {
+        isTransitive = false
       }
-    }
+
+    detachedConfiguration.incoming
+      .artifactView { it.isLenient = true }
+      .artifacts
+      .forEach { artifact ->
+        val id = artifact.id.componentIdentifier
+        if (id is ModuleComponentIdentifier) {
+          resolved["${id.group}:${id.module}:${id.version}"] = artifact.file
+        }
+      }
+  }
   return resolved
 }
 

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJavaSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJavaSpec.groovy
@@ -757,6 +757,74 @@ final class LicensePluginJavaSpec extends Specification {
     assertJson(expectedJson, actualJson.text)
   }
 
+  @Issue("jaredsburrows/gradle-license-plugin/issues/800")
+  def 'licenseReport with parents of the same module at different versions'() {
+    given: 'two dependencies whose parent POMs are different versions of the same module'
+    buildFile <<
+      """
+      plugins {
+        id 'java-library'
+        id 'com.jaredsburrows.license'
+      }
+
+      repositories {
+        maven {
+          url '${mavenRepoUrl}'
+        }
+      }
+
+      dependencies {
+        implementation 'group:childa:1.0.0'
+        implementation 'group:childb:1.0.0'
+      }
+      """
+
+    when:
+    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    def actualJson = new File(reportFolder, 'licenseReport.json')
+    def expectedJson =
+      """
+      [
+        {
+          "project":"Child A",
+          "description":"Fake dependency with parent at version 1",
+          "version":"1.0.0",
+          "developers":[],
+          "url":null,
+          "year":null,
+          "licenses":[
+            {
+              "license":"License One",
+              "license_url":"http://license-1.tld/"
+            }
+          ],
+          "dependency":"group:childa:1.0.0"
+        },
+        {
+          "project":"Child B",
+          "description":"Fake dependency with parent at version 2",
+          "version":"1.0.0",
+          "developers":[],
+          "url":null,
+          "year":null,
+          "licenses":[
+            {
+              "license":"License Two",
+              "license_url":"http://license-2.tld/"
+            }
+          ],
+          "dependency":"group:childb:1.0.0"
+        }
+      ]
+      """
+
+    then: 'both parent POMs are resolved and each child reports its own parent license'
+    result.task(':licenseReport').outcome == SUCCESS
+    !result.output.contains('Parent POM group:multiparent:1.0.0@pom not found')
+    !result.output.contains('Parent POM group:multiparent:2.0.0@pom not found')
+    assertJson(expectedJson, actualJson.text)
+  }
+
   def 'licenseReport with same set of multiple licenses'() {
     given:
     buildFile <<

--- a/gradle-license-plugin/src/test/resources/maven/group/childa/1.0.0/childa-1.0.0.pom
+++ b/gradle-license-plugin/src/test/resources/maven/group/childa/1.0.0/childa-1.0.0.pom
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Fake dependency for testing - https://maven.apache.org/pom.html#Quick_Overview -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <!-- Parent Information -->
+  <parent>
+    <groupId>group</groupId>
+    <artifactId>multiparent</artifactId>
+    <version>1.0.0</version>
+  </parent>
+
+  <!-- The Basics -->
+  <artifactId>childa</artifactId>
+  <version>1.0.0</version>
+  <packaging>jar</packaging>
+
+  <!-- More Project Information -->
+  <name>Child A</name>
+  <description>Fake dependency with parent at version 1</description>
+</project>

--- a/gradle-license-plugin/src/test/resources/maven/group/childb/1.0.0/childb-1.0.0.pom
+++ b/gradle-license-plugin/src/test/resources/maven/group/childb/1.0.0/childb-1.0.0.pom
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Fake dependency for testing - https://maven.apache.org/pom.html#Quick_Overview -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <!-- Parent Information -->
+  <parent>
+    <groupId>group</groupId>
+    <artifactId>multiparent</artifactId>
+    <version>2.0.0</version>
+  </parent>
+
+  <!-- The Basics -->
+  <artifactId>childb</artifactId>
+  <version>1.0.0</version>
+  <packaging>jar</packaging>
+
+  <!-- More Project Information -->
+  <name>Child B</name>
+  <description>Fake dependency with parent at version 2</description>
+</project>

--- a/gradle-license-plugin/src/test/resources/maven/group/multiparent/1.0.0/multiparent-1.0.0.pom
+++ b/gradle-license-plugin/src/test/resources/maven/group/multiparent/1.0.0/multiparent-1.0.0.pom
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Fake dependency for testing - https://maven.apache.org/pom.html#Quick_Overview -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <!-- The Basics -->
+  <groupId>group</groupId>
+  <artifactId>multiparent</artifactId>
+  <version>1.0.0</version>
+  <packaging>pom</packaging>
+
+  <!-- More Project Information -->
+  <name>Fake parent at version 1</name>
+  <licenses>
+    <license>
+      <name>License One</name>
+      <url>http://license-1.tld/</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+</project>

--- a/gradle-license-plugin/src/test/resources/maven/group/multiparent/2.0.0/multiparent-2.0.0.pom
+++ b/gradle-license-plugin/src/test/resources/maven/group/multiparent/2.0.0/multiparent-2.0.0.pom
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Fake dependency for testing - https://maven.apache.org/pom.html#Quick_Overview -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <!-- The Basics -->
+  <groupId>group</groupId>
+  <artifactId>multiparent</artifactId>
+  <version>2.0.0</version>
+  <packaging>pom</packaging>
+
+  <!-- More Project Information -->
+  <name>Fake parent at version 2</name>
+  <licenses>
+    <license>
+      <name>License Two</name>
+      <url>http://license-2.tld/</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+</project>


### PR DESCRIPTION
Fixes #800

## Problem

Since 0.9.9, `com.google.guava:failureaccess` (and `listenablefuture`) report `"licenses": []`. Reproduced with `com.google.guava:guava:33.4.8-jre` against Maven Central:

```
Parent POM com.google.guava:guava-parent:33.4.0-android@pom not found
Dependency 'failureaccess' does not have a license.
Parent POM com.google.guava:guava-parent:26.0-android@pom not found
Dependency 'listenablefuture' does not have a license.
```

## Root cause

0.9.9 introduced batched parent-POM resolution: all parent coordinates of a recursion level go into **one** detached configuration. Gradle conflict-resolves two versions of the same module within a configuration to a single version — so `guava-parent:33.4.8-jre` (guava's parent), `guava-parent:33.4.0-android` (failureaccess's parent) and `guava-parent:26.0-android` (listenablefuture's parent) collapse to just `33.4.8-jre`, and the dropped parents' license lookups fail. 0.9.8 resolved parent POMs individually, which is why it worked.

## Fix

Partition the coordinates so no batch contains two versions of the same module (batch *i* holds the *i*-th version of each module), and resolve each batch in its own detached configuration. In the common case — all parent modules unique — this is still a single batched resolution, preserving the 0.9.9 performance win.

## Tests

* New fixtures: `group:multiparent` at 1.0.0 and 2.0.0 (each declaring a distinct license), and `group:childa`/`group:childb` inheriting licenses from those two parent versions respectively.
* New test `licenseReport with parents of the same module at different versions`: fails before the fix (`Parent POM group:multiparent:1.0.0@pom not found`, Child A loses its license) and passes after, asserting both children report their own parent's license.

## Verification

* Full suite: 124 tests, 0 failures.
* Real-world check against Maven Central with `guava:33.4.8-jre`: `failureaccess` reports `Apache License, Version 2.0` (identical to the 0.9.8 output in the issue), `listenablefuture` is healed too, zero "Parent POM not found" warnings.