### PR TITLE
Add regression test for library subproject crash under AGP 9

### DIFF
--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginAndroidSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginAndroidSpec.groovy
@@ -2236,6 +2236,81 @@ final class LicensePluginAndroidSpec extends Specification {
     taskName << ['licenseDebugReport', 'licenseReleaseReport']
   }
 
+  @Issue("jaredsburrows/gradle-license-plugin/issues/811")
+  def 'licenseDebugReport with android library subproject and task iteration in afterEvaluate'() {
+    given: 'a library subproject configured by its own build file, after the app project'
+    testProjectDir.newFile('settings.gradle') <<
+      """
+      include 'library'
+      """
+    testProjectDir.newFolder('library')
+    testProjectDir.newFile('library/build.gradle') <<
+      """
+      apply plugin: 'com.android.library'
+
+      android {
+        compileSdk = $compileSdkVersion
+        namespace 'com.example.library'
+      }
+
+      dependencies {
+        implementation 'com.android.support:design:26.1.0'
+      }
+      """
+
+    buildFile <<
+      """
+      buildscript {
+        dependencies {
+          classpath files($classpathString)
+        }
+      }
+
+      allprojects {
+        repositories {
+          maven {
+            url '${mavenRepoUrl}'
+          }
+        }
+      }
+
+      apply plugin: 'com.android.application'
+      apply plugin: 'com.jaredsburrows.license'
+
+      android {
+        compileSdkVersion $compileSdkVersion
+        namespace 'com.example'
+
+        defaultConfig {
+          applicationId 'com.example'
+        }
+      }
+
+      dependencies {
+        implementation project(':library')
+        implementation 'group:name:1.0.0'
+      }
+
+      // Simulate a third-party plugin (e.g. AppLovin Quality Service) iterating the task
+      // container in afterEvaluate, which realizes the license tasks during configuration -
+      // before the library subproject is configured.
+      afterEvaluate {
+        tasks.forEach { }
+      }
+      """
+
+    when:
+    def result = gradleWithCommand(testProjectDir.root, 'licenseDebugReport', '-s')
+    def actualJson = new File(reportFolder, 'licenseDebugReport.json')
+
+    then: 'configuration does not crash and the report includes both modules dependencies'
+    result.task(':licenseDebugReport').outcome == SUCCESS
+    !result.output.contains('cannot be executed in the current context')
+    actualJson.exists()
+    actualJson.text.contains('group:name:1.0.0')
+    actualJson.text.contains('com.android.support:design:26.1.0')
+  }
+
   @Issue("jaredsburrows/gradle-license-plugin/issues/804")
   @Unroll
   def '#taskName does not resolve configurations at configuration time'() {


### PR DESCRIPTION
Fixes #811

## Verification of the reported crash

Reproduced with the reporter's repro project (`license-plugin-agp9-repro`, AGP 9.2.1 / Gradle 9.6.1):

* Against released **0.9.9**: `./gradlew tasks` fails with the exact reported error — `An exception occurred applying plugin request [id: 'com.android.library'] > Failed to apply plugin 'com.android.internal.library'. > Gradle#projectsEvaluated(Action) on build ':' cannot be executed in the current context.`
* Against **current master** (post-#814): `./gradlew tasks` succeeds and `:app:licenseDebugReport` generates all four reports.

The issue's analysis is correct: realizing the license task during configuration (via third-party `tasks` iteration in `afterEvaluate`) eagerly resolved the app classpath, configuring the `com.android.library` subproject out of turn — and AGP 9 registers a `Gradle#projectsEvaluated` action while applying itself, which Gradle rejects in that nested context. #814 removed the eager resolution (for #804), which also fixed this crash. The issue predates that merge by three days.

## Why it wasn't caught

Two gaps, both called out by the reporter:

1. The existing multi-module spec applies `com.android.application` to its subproject, and does so **inline from the root build file** (`project(':subproject') { apply plugin: ... }`), so the plugin applies during root configuration — never inside a nested, resolution-triggered configuration.
2. No test simulated third-party `tasks` iteration in `afterEvaluate`; running the report task by name doesn't crash because scheduling happens after all projects are configured.

## This PR

Adds the missing regression test: a `com.android.library` subproject configured by its **own** build file, plus a two-line third-party stand-in (`afterEvaluate { tasks.forEach { } }`) in the app project. Validated both ways:

* Injected into a worktree at pre-#814 master (`2df98d5`): fails with the exact `Gradle#projectsEvaluated(Action) ... cannot be executed in the current context` crash.
* On current master: passes, and the report includes dependencies from both modules.

Full suite: 125 tests, 0 failures.