### PR TITLE
Add regression test for licenseReport running as a task dependency

### DIFF
--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJavaSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJavaSpec.groovy
@@ -1851,4 +1851,67 @@ final class LicensePluginJavaSpec extends Specification {
     third.task(':licenseReport').outcome == SUCCESS
     new File(reportFolder, 'licenseReport.json').text.contains('License B')
   }
+
+  @Issue("jaredsburrows/gradle-license-plugin/issues/488")
+  def 'licenseReport as a dependency of processResources produces a populated report'() {
+    given: 'processResources depends on licenseReport and bundles its reports'
+    buildFile <<
+      """
+      plugins {
+        id 'java-library'
+        id 'com.jaredsburrows.license'
+      }
+
+      repositories {
+        maven {
+          url '${mavenRepoUrl}'
+        }
+      }
+
+      dependencies {
+        implementation 'group:name:1.0.0'
+      }
+
+      processResources {
+        dependsOn 'licenseReport'
+        from(layout.buildDirectory.dir('reports/licenses')) {
+          into 'public/oss'
+        }
+      }
+      """
+
+    when: 'the report task runs as part of the build task graph, not directly'
+    def result = gradleWithCommand(testProjectDir.root, 'build', '-s')
+    def actualJson = new File(reportFolder, 'licenseReport.json')
+    def bundledJson = new File(testProjectDir.root, 'build/resources/main/public/oss/licenseReport.json')
+    def expectedJson =
+      """
+      [
+        {
+          "project":"Fake dependency name",
+          "description":"Fake dependency description",
+          "version":"1.0.0",
+          "developers":[
+            "name"
+          ],
+          "url":"https://github.com/user/repo",
+          "year":"2017",
+          "licenses":[
+            {
+              "license":"Some license",
+              "license_url":"http://website.tld/"
+            }
+          ],
+          "dependency":"group:name:1.0.0"
+        }
+      ]
+      """
+
+    then: 'the report has the same content as when the task is invoked directly'
+    result.task(':licenseReport').outcome == SUCCESS
+    result.task(':processResources').outcome == SUCCESS
+    assertJson(expectedJson, actualJson.text)
+    bundledJson.exists()
+    assertJson(expectedJson, bundledJson.text)
+  }
 }


### PR DESCRIPTION
Fixes #488

## Verification of the reported bug

Reproduced the original symptom with plugin 0.9.7 on Gradle 8.14.3, minimal JVM project, the issue's exact wiring (`processResources { dependsOn 'licenseReport'; from("build/reports/licenses") { into 'public/oss' } }`):

* Run via `build`: **empty `[]` report**, build still green — the silent failure reported in the issue.
* Run `licenseReport` directly on the same clean project: populated report.

Cause: the pre-0.9.9 implementation force-flipped `canBeResolved` on dependency-scope configurations and resolved them at execution time. That was task-graph-sensitive — with `build`'s other tasks present, the configurations had already been observed and the forced resolution silently failed. #735 (released in 0.9.9) replaced this with reads of the already-resolvable classpaths, which behave identically regardless of how the task is triggered. Verified fixed on released 0.9.9 and current master: report populated and correctly bundled into `build/resources/main/public/oss/`.

## This PR

Adds the missing invocation-path coverage — every existing spec invokes the report tasks directly, so nothing guarded the run-as-dependency pattern. The new test wires `processResources` → `licenseReport`, runs `build`, and asserts the report content matches a direct invocation byte-for-byte (both the report location and the bundled copy in resources). Since the failure mode was a silently empty report in a green build, this is exactly the class of regression that would otherwise ship unnoticed.

Full suite: 126 tests, 0 failures.