### PR TITLE
Collapse a library resolved at different versions across classpaths

### DIFF
--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
@@ -232,20 +232,24 @@ internal abstract class LicenseReportTask
     }
 
     /**
-     * True if [this] and [other] are the same module with the same display name (so only the
-     * version and/or platform suffix differ). The artifact ids must be equal, or one must be the
-     * other followed by a "-<platform>" suffix (e.g. annotation / annotation-jvm). Sibling artifacts
-     * that merely share a name (foo-1, foo-2 — neither a prefix of the other) are kept separate.
+     * True if [this] and [other] are the same library: the same module at any versions (display
+     * names may change between versions, e.g. "Okio" vs "okio"), or a Kotlin Multiplatform
+     * platform artifact of it (annotation / annotation-jvm). Other "-suffix" siblings (foo-ktx,
+     * kotlin-stdlib-jdk7) are distinct libraries and only collapse when their display names match.
      */
     private fun Model.isSameLibraryAs(other: Model): Boolean {
       if (groupId.orEmpty() != other.groupId.orEmpty()) return false
-      if (name.orEmpty() != other.name.orEmpty()) return false
 
       val thisArtifact = artifactId.orEmpty()
       val otherArtifact = other.artifactId.orEmpty()
-      return thisArtifact == otherArtifact ||
-        thisArtifact.startsWith("$otherArtifact-") ||
-        otherArtifact.startsWith("$thisArtifact-")
+      if (thisArtifact == otherArtifact) return true
+
+      val root = if (thisArtifact.length <= otherArtifact.length) thisArtifact else otherArtifact
+      val variant = if (root === thisArtifact) otherArtifact else thisArtifact
+      if (!variant.startsWith("$root-")) return false
+
+      return variant.removePrefix("$root-") in PLATFORM_ARTIFACT_SUFFIXES ||
+        name.orEmpty() == other.name.orEmpty()
     }
 
     /** Prefer the higher version; for equal versions prefer the shorter (root) artifact id. */
@@ -595,6 +599,9 @@ internal abstract class LicenseReportTask
       }
 
     private companion object {
+      // Kotlin Multiplatform platform-artifact suffixes safe to treat as the same library.
+      // "-android" is excluded: distinct products use it (dagger / dagger-android).
+      private val PLATFORM_ARTIFACT_SUFFIXES = setOf("jvm")
       private const val ANDROID_SUPPORT_GROUP_ID = "com.android.support"
       private const val APACHE_LICENSE_NAME = "The Apache Software License"
       private const val APACHE_LICENSE_URL = "http://www.apache.org/licenses/LICENSE-2.0.txt"

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJavaSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJavaSpec.groovy
@@ -1852,6 +1852,93 @@ final class LicensePluginJavaSpec extends Specification {
     new File(reportFolder, 'licenseReport.json').text.contains('License B')
   }
 
+  @Issue("jaredsburrows/gradle-license-plugin/issues/444")
+  def 'licenseReport collapses a library resolved at different versions across classpaths'() {
+    given: 'libraries whose display name or artifact id changed between the resolved versions'
+    buildFile <<
+      """
+      plugins {
+        id 'java-library'
+        id 'com.jaredsburrows.license'
+      }
+
+      repositories {
+        maven {
+          url '${mavenRepoUrl}'
+        }
+      }
+
+      dependencies {
+        // Same module, renamed between versions: compile resolves 1.0.0, runtime 2.0.0.
+        implementation 'group:renamed:1.0.0'
+        runtimeOnly 'group:renamed:2.0.0'
+        // Renamed to a Kotlin Multiplatform platform artifact between versions.
+        implementation 'group:kmpl:1.0.0'
+        runtimeOnly 'group:kmpl-jvm:2.0.0'
+        // A distinct "-suffix" sibling library that must stay its own report entry.
+        implementation 'group:kmpl-jdk7:2.0.0'
+      }
+      """
+
+    when:
+    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    def actualJson = new File(reportFolder, 'licenseReport.json')
+    def expectedJson =
+      """
+      [
+        {
+          "project":"kmpl",
+          "description":null,
+          "version":"2.0.0",
+          "developers":[],
+          "url":null,
+          "year":null,
+          "licenses":[
+            {
+              "license":"Some license",
+              "license_url":"http://website.tld/"
+            }
+          ],
+          "dependency":"group:kmpl-jvm:2.0.0"
+        },
+        {
+          "project":"Kmpl Jdk7",
+          "description":null,
+          "version":"2.0.0",
+          "developers":[],
+          "url":null,
+          "year":null,
+          "licenses":[
+            {
+              "license":"Some license",
+              "license_url":"http://website.tld/"
+            }
+          ],
+          "dependency":"group:kmpl-jdk7:2.0.0"
+        },
+        {
+          "project":"renamed",
+          "description":null,
+          "version":"2.0.0",
+          "developers":[],
+          "url":null,
+          "year":null,
+          "licenses":[
+            {
+              "license":"Some license",
+              "license_url":"http://website.tld/"
+            }
+          ],
+          "dependency":"group:renamed:2.0.0"
+        }
+      ]
+      """
+
+    then: 'each library appears once at its highest version; the sibling stays separate'
+    result.task(':licenseReport').outcome == SUCCESS
+    assertJson(expectedJson, actualJson.text)
+  }
+
   @Issue("jaredsburrows/gradle-license-plugin/issues/488")
   def 'licenseReport as a dependency of processResources produces a populated report'() {
     given: 'processResources depends on licenseReport and bundles its reports'

--- a/gradle-license-plugin/src/test/resources/maven/group/kmpl-jdk7/2.0.0/kmpl-jdk7-2.0.0.pom
+++ b/gradle-license-plugin/src/test/resources/maven/group/kmpl-jdk7/2.0.0/kmpl-jdk7-2.0.0.pom
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Fake dependency for testing - https://maven.apache.org/pom.html#Quick_Overview -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <!-- The Basics -->
+  <groupId>group</groupId>
+  <artifactId>kmpl-jdk7</artifactId>
+  <version>2.0.0</version>
+  <packaging>jar</packaging>
+
+  <!-- More Project Information -->
+  <name>Kmpl Jdk7</name>
+  <licenses>
+    <license>
+      <name>Some license</name>
+      <url>http://website.tld/</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+</project>

--- a/gradle-license-plugin/src/test/resources/maven/group/kmpl-jvm/2.0.0/kmpl-jvm-2.0.0.pom
+++ b/gradle-license-plugin/src/test/resources/maven/group/kmpl-jvm/2.0.0/kmpl-jvm-2.0.0.pom
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Fake dependency for testing - https://maven.apache.org/pom.html#Quick_Overview -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <!-- The Basics -->
+  <groupId>group</groupId>
+  <artifactId>kmpl-jvm</artifactId>
+  <version>2.0.0</version>
+  <packaging>jar</packaging>
+
+  <!-- More Project Information -->
+  <name>kmpl</name>
+  <licenses>
+    <license>
+      <name>Some license</name>
+      <url>http://website.tld/</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+</project>

--- a/gradle-license-plugin/src/test/resources/maven/group/kmpl/1.0.0/kmpl-1.0.0.pom
+++ b/gradle-license-plugin/src/test/resources/maven/group/kmpl/1.0.0/kmpl-1.0.0.pom
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Fake dependency for testing - https://maven.apache.org/pom.html#Quick_Overview -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <!-- The Basics -->
+  <groupId>group</groupId>
+  <artifactId>kmpl</artifactId>
+  <version>1.0.0</version>
+  <packaging>jar</packaging>
+
+  <!-- More Project Information -->
+  <name>Old Kmpl Name</name>
+  <licenses>
+    <license>
+      <name>Some license</name>
+      <url>http://website.tld/</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+</project>

--- a/gradle-license-plugin/src/test/resources/maven/group/renamed/1.0.0/renamed-1.0.0.pom
+++ b/gradle-license-plugin/src/test/resources/maven/group/renamed/1.0.0/renamed-1.0.0.pom
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Fake dependency for testing - https://maven.apache.org/pom.html#Quick_Overview -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <!-- The Basics -->
+  <groupId>group</groupId>
+  <artifactId>renamed</artifactId>
+  <version>1.0.0</version>
+  <packaging>jar</packaging>
+
+  <!-- More Project Information -->
+  <name>Renamed Library</name>
+  <licenses>
+    <license>
+      <name>Some license</name>
+      <url>http://website.tld/</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+</project>

--- a/gradle-license-plugin/src/test/resources/maven/group/renamed/2.0.0/renamed-2.0.0.pom
+++ b/gradle-license-plugin/src/test/resources/maven/group/renamed/2.0.0/renamed-2.0.0.pom
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Fake dependency for testing - https://maven.apache.org/pom.html#Quick_Overview -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <!-- The Basics -->
+  <groupId>group</groupId>
+  <artifactId>renamed</artifactId>
+  <version>2.0.0</version>
+  <packaging>jar</packaging>
+
+  <!-- More Project Information -->
+  <name>renamed</name>
+  <licenses>
+    <license>
+      <name>Some license</name>
+      <url>http://website.tld/</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+</project>


### PR DESCRIPTION
Fixes #444

## Problem

The issue's original mechanism (collecting from declaration configurations like `implementation`) was removed by #735, but a residual form reproduces on master. The compile and runtime classpaths can legitimately resolve the same library at different versions, and `deduplicate()` — whose stated purpose includes collapsing compile-vs-runtime version differences — required *identical POM display names*, which breaks whenever a library renamed itself between versions.

Reproduced with `implementation 'com.squareup.okio:okio:2.9.0'` + `runtimeOnly 'com.squareup.okio:okio:3.6.0'` against Maven Central. The report contained three phantom entries alongside the real ones:

* `Okio 2.9.0` **and** `okio 3.6.0` — same module, name case changed between versions
* `Kotlin Stdlib 1.9.10` **and** `org.jetbrains.kotlin:kotlin-stdlib 1.4.10` — old versions had placeholder-style names
* `Kotlin Stdlib Common` duplicated the same way

This is exactly the issue's reported pair (`annotation 1.5.0` + `annotation-jvm 1.7.0`, `okio 2.9.0` + `okio-jvm 3.6.0`).

## Fix

`isSameLibraryAs` now treats entries as the same library when:

1. **Same group + same artifactId** — always, at any versions; identical module coordinates cannot be two different libraries, so display-name drift no longer splits them.
2. **Same group + dash-prefix pair** (`foo` / `foo-jvm`) when the suffix is `jvm` (a pure KMP platform-artifact convention), **or** when display names match (the pre-existing rule, unchanged).

`-android` was deliberately **excluded** from the platform-suffix set: `dagger` / `dagger-android` are distinct shipped products that must keep separate entries. Same reason `foo-ktx` / `kotlin-stdlib-jdk7`-style siblings still require matching names.

## Tests

New fixtures and a test covering all three behaviors: `renamed` 1.0.0/2.0.0 (name changed between versions → single entry at 2.0.0), `kmpl` 1.0.0 / `kmpl-jvm` 2.0.0 (KMP repackaging → single entry), and `kmpl-jdk7` (distinct sibling → keeps its own entry). Fails pre-fix with 5 entries (2 phantoms), passes post-fix with 3.

## Verification

* Full suite: 127 tests, 0 failures — including all existing dedup boundary tests (`samename`/`samename-android`, `module-same-name-*`, `verlib`, `name5-*`) unchanged.
* Real-world okio scratch project: phantoms gone, `kotlin-stdlib-jdk7`/`-jdk8`/`-common` correctly remain separate entries.
* Adversarial multi-lens review: 4 findings raised, all refuted as pre-existing mechanics unchanged by this diff.

Note: this PR fixes the duplicate-entry symptom while keeping compileClasspath in the report (compileOnly dependencies stay attributed). The issue's alternative proposal — collecting only `${variantName}RuntimeClasspath` — is a larger product decision about what the report should represent, and is left out deliberately.