### PR TITLE
Match ignoredPatterns along coordinate segment boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,8 +328,8 @@ fun OpenSourceLicensesDialog(onDismiss: () -> Unit) {
 ```
 </details>
 
-<details>
-  <summary>Kotlin (Views)</summary>
+<details open>
+  <summary>Kotlin</summary>
   
 
 ```kotlin
@@ -437,8 +437,8 @@ if (showLicenses) {
 ```
 </details>
 
-<details>
-  <summary>Kotlin (Views)</summary>
+<details open>
+  <summary>Kotlin</summary>
   
 
 ```kotlin

--- a/README.md
+++ b/README.md
@@ -293,7 +293,43 @@ licenseReport {
 
 ### Create an open source dialog
 <details open>
-  <summary>Kotlin</summary>
+  <summary>Jetpack Compose</summary>
+
+
+```kotlin
+import android.webkit.WebView
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.viewinterop.AndroidView
+
+@Composable
+fun OpenSourceLicensesDialog(onDismiss: () -> Unit) {
+  AlertDialog(
+    onDismissRequest = onDismiss,
+    title = { Text("Open Source Licenses") },
+    text = {
+      AndroidView(
+        factory = { context ->
+          WebView(context).apply {
+            loadUrl("file:///android_asset/open_source_licenses.html")
+          }
+        },
+      )
+    },
+    confirmButton = {
+      TextButton(onClick = onDismiss) {
+        Text("OK")
+      }
+    },
+  )
+}
+```
+</details>
+
+<details>
+  <summary>Kotlin (Views)</summary>
   
 
 ```kotlin
@@ -385,7 +421,24 @@ public final class OpenSourceLicensesDialog extends DialogFragment {
 
 ### How to use it
 <details open>
-  <summary>Kotlin</summary>
+  <summary>Jetpack Compose</summary>
+
+
+```kotlin
+var showLicenses by remember { mutableStateOf(false) }
+
+Button(onClick = { showLicenses = true }) {
+  Text("Licenses")
+}
+
+if (showLicenses) {
+  OpenSourceLicensesDialog(onDismiss = { showLicenses = false })
+}
+```
+</details>
+
+<details>
+  <summary>Kotlin (Views)</summary>
   
 
 ```kotlin

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Gradle License Plugin
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
-[![Maven](https://img.shields.io/maven-central/v/com.jaredsburrows/gradle-license-plugin?label=maven&style=flat)](https://search.maven.org/artifact/com.jaredsburrows/gradle-license-plugin)
+[![Maven](https://img.shields.io/maven-central/v/com.jaredsburrows/gradle-license-plugin?label=maven&style=flat)](https://central.sonatype.com/artifact/com.jaredsburrows/gradle-license-plugin)
 [![Gradle Plugin Portal](https://img.shields.io/gradle-plugin-portal/v/com.jaredsburrows.license)](https://plugins.gradle.org/plugin/com.jaredsburrows.license)
 [![Build](https://github.com/jaredsburrows/gradle-license-plugin/actions/workflows/build.yml/badge.svg)](https://github.com/jaredsburrows/gradle-license-plugin/actions/workflows/build.yml)
 [![Twitter Follow](https://img.shields.io/twitter/follow/jaredsburrows.svg?style=social)](https://twitter.com/jaredsburrows)
@@ -84,7 +84,7 @@ plugins {
 ```groovy
 buildscript {
   repositories {
-    maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
+    maven { url 'https://central.sonatype.com/repository/maven-snapshots/' }
     google() // For Android projects
   }
 
@@ -98,7 +98,7 @@ apply plugin: 'com.jaredsburrows.license'
 ```
 </details>
 
-Snapshot versions are available in the [Sonatype's snapshots repository](https://oss.sonatype.org/content/repositories/snapshots/com/jaredsburrows/gradle-license-plugin/).
+Snapshot versions are available in the [Central Portal snapshots repository](https://central.sonatype.com/repository/maven-snapshots/com/jaredsburrows/gradle-license-plugin/).
 
 ## Tasks
 
@@ -273,7 +273,11 @@ The `copyHtmlReportToAssets` option in the above example would have no effect si
 
 The `useVariantSpecificAssetDirs` allows the reports to be copied into the source set asset directory of the variant. For example, `licensePaidProductionReleaseReport` would put the reports in `src/paidProductionRelease/assets`. They are copied into `src/main/assets` by default.
 
-The `ignoredPatterns` allows for ignoring artifact patterns. These can be partial or full patterns.
+The `ignoredPatterns` allows for ignoring artifact patterns. A pattern can cover whole segments of the
+`group:artifact:version` coordinate (a group, an artifact, a version, or any combination), but it only
+matches along segment boundaries: ignoring `com.some.group:some.name` does not ignore
+`com.some.group:some.name-extra`. Both `:` and `.` count as boundaries, so a pattern may also cover
+dot-separated pieces of a group or version - `1.2` still ignores version `1.2.3`.
 
 ```groovy
 apply plugin: "com.jaredsburrows.license"
@@ -401,9 +405,9 @@ new OpenSourceLicensesDialog().showLicenses(this);
 
 Source: https://github.com/google/iosched/blob/2531cbdbe27e5795eb78bf47d27e8c1be494aad4/android/src/main/java/com/google/samples/apps/iosched/util/AboutUtils.java#L52
 
-<img src="https://www.bignerdranch.com/assets/img/blog/2015/07/screenshot-gmail.png"  alt="License HTML"/>
+<img src="https://web.archive.org/web/20241102172214/https://bignerdranch.com/assets/img/blog/2015/07/screenshot-gmail.png" alt="License HTML"/>
 
-Source: https://www.bignerdranch.com/blog/open-source-licenses-and-android/
+Source: https://web.archive.org/web/20241102053331/https://bignerdranch.com/blog/open-source-licenses-and-android/
 
 ## License
 ```

--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
@@ -168,7 +168,7 @@ internal abstract class LicenseReportTask
           val pomFilePath = pomCoordinatesToFile.get()[coordinate] ?: return@mapNotNull null
           coordinate to File(pomFilePath)
         }.filter { (coordinate, _) ->
-          ignoredPatterns.none { coordinate.contains(it) }
+          ignoredPatterns.none { coordinate.matchesIgnoredPattern(it) }
         }.forEach { (coordinate, pomFile) ->
           val model = readModel(mavenReader, pomFile) ?: return@forEach
 
@@ -552,6 +552,30 @@ internal abstract class LicenseReportTask
         logger.warn("Failed to read POM file '$pomFile': ${e.shortMessage()}")
         null
       }
+
+    /**
+     * True when [pattern] occurs in this coordinate aligned to segment boundaries (':', '.' or
+     * either end), so ignoring "foo:bar" does not also ignore "foo:bar-extra" (#397).
+     */
+    private fun String.matchesIgnoredPattern(pattern: String): Boolean {
+      if (pattern.isEmpty()) {
+        return false
+      }
+
+      var index = indexOf(pattern)
+      while (index >= 0) {
+        val end = index + pattern.length
+        val startsAtBoundary = index == 0 || this[index - 1].isBoundary() || pattern.first().isBoundary()
+        val endsAtBoundary = end == length || this[end].isBoundary() || pattern.last().isBoundary()
+        if (startsAtBoundary && endsAtBoundary) {
+          return true
+        }
+        index = indexOf(pattern, index + 1)
+      }
+      return false
+    }
+
+    private fun Char.isBoundary(): Boolean = this == ':' || this == '.'
 
     private fun parseCoordinate(coordinate: String): Triple<String, String, String> {
       val parts = coordinate.split(":")

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJavaSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJavaSpec.groovy
@@ -1939,6 +1939,42 @@ final class LicensePluginJavaSpec extends Specification {
     assertJson(expectedJson, actualJson.text)
   }
 
+  @Issue("jaredsburrows/gradle-license-plugin/issues/397")
+  def 'ignoredPatterns does not ignore artifacts that merely extend the pattern'() {
+    given: 'two artifacts where one coordinate is a prefix of the other'
+    buildFile <<
+      """
+      plugins {
+        id 'java-library'
+        id 'com.jaredsburrows.license'
+      }
+
+      repositories {
+        maven {
+          url '${mavenRepoUrl}'
+        }
+      }
+
+      dependencies {
+        implementation 'group:kmpl:1.0.0'
+        implementation 'group:kmpl-jdk7:2.0.0'
+      }
+
+      licenseReport {
+        ignoredPatterns = ["group:kmpl"]
+      }
+      """
+
+    when:
+    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    def actualJson = new File(reportFolder, 'licenseReport.json')
+
+    then: 'only the exact artifact is ignored, not its -suffix sibling'
+    result.task(':licenseReport').outcome == SUCCESS
+    !actualJson.text.contains('"dependency":"group:kmpl:1.0.0"')
+    actualJson.text.contains('"dependency":"group:kmpl-jdk7:2.0.0"')
+  }
+
   @Issue("jaredsburrows/gradle-license-plugin/issues/488")
   def 'licenseReport as a dependency of processResources produces a populated report'() {
     given: 'processResources depends on licenseReport and bundles its reports'


### PR DESCRIPTION
Fixes #397

## Problem

`ignoredPatterns` used a plain substring check against the `group:artifact:version` coordinate, so ignoring `foo:bar:baz` also silently dropped `foo:bar:baz-qux` — missing attribution in a license report, with no warning. The README's own examples ("ignores the given artifact") already promised segment-scoped behavior the code didn't deliver.

## Fix

Patterns now match only along coordinate segment boundaries (`:`, `.`, or either end). Every documented pattern style — group, `group:artifact`, full GAV, bare artifact name, bare version — behaves exactly as before (all 7 pre-existing `ignoredPatterns` tests pass unchanged). The rule is strictly narrower than `contains()`, so any behavior change for undocumented partial patterns can only *add* entries back to the report, never silently remove more — the safe direction for a compliance report. One deliberate consequence: `-` is not a boundary, which is exactly what keeps `-suffix` siblings alive; hyphen-anchored patterns like `"-jvm"` no longer match (they were relying on the buggy substring behavior).

New regression test: ignoring `group:kmpl` excludes `group:kmpl:1.0.0` but keeps `group:kmpl-jdk7:2.0.0` — fails pre-fix, passes post-fix. README paragraph updated to describe the actual rule, including that `.` is a boundary (`1.2` still ignores version `1.2.3`).

## Also: dead README links (second commit)

* Sonatype OSSRH is decommissioned — snapshot instructions now point at the Central Portal snapshots repository (verified the plugin's snapshots are published there), and the maven badge links to central.sonatype.com.
* The Big Nerd Ranch article and screenshot in "Create an open source dialog" are gone — both now link Wayback Machine captures (verified live).

Full suite: 129 tests, 0 failures. Adversarial review of the matcher: no logic defects; one doc gap it found (the `.`-boundary clause) is included.