### PR TITLE
Anchor license links to the top of the license text

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,7 @@ design,null,26.1.0,null,null,null,The Apache Software License,http://www.apache.
         </dl>
       </li>
     </ul>
-    <a id="1934118923"></a>
-    <pre>apache-2.0.txt here</pre>
+    <pre id="1934118923">apache-2.0.txt here</pre>
     <br>
     <hr>
     <ul>
@@ -162,8 +161,7 @@ design,null,26.1.0,null,null,null,The Apache Software License,http://www.apache.
         </dl>
       </li>
     </ul>
-    <a id="1783810846"></a>
-    <pre>apache-2.0.txt here</pre>
+    <pre id="1783810846">apache-2.0.txt here</pre>
     <br>
     <hr>
   </body>

--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/internal/report/HtmlReport.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/internal/report/HtmlReport.kt
@@ -2,6 +2,8 @@ package com.jaredsburrows.license.internal.report
 
 import com.jaredsburrows.license.internal.LicenseHelper
 import kotlinx.html.Entities
+import kotlinx.html.FlowContent
+import kotlinx.html.PRE
 import kotlinx.html.a
 import kotlinx.html.body
 import kotlinx.html.br
@@ -133,14 +135,14 @@ class HtmlReport(
                 }
               }
 
-              a {
-                id = currentLicense.toString()
-              }
+              // The anchor id lives on the first license block itself: an empty inline anchor next
+              // to the inline-block <pre> sits at its baseline, scrolling links to the bottom (#462).
+              val anchorId = currentLicense.toString()
 
               // Display associated license text with libraries
               val licenses = currentProject?.licenses
               if (licenses.isNullOrEmpty()) {
-                pre {
+                licensePre(anchorId) {
                   +NO_LICENSE
                 }
               } else {
@@ -150,10 +152,11 @@ class HtmlReport(
                       Pair(getLicenseKey(license), license)
                     }.sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.first })
 
-                sortedKeysAndLicenses.forEach { (key, license) ->
+                sortedKeysAndLicenses.forEachIndexed { index, (key, license) ->
+                  val preId = if (index == 0) anchorId else null
                   if (key.isNotEmpty() && licenseMap.values.contains(key)) {
                     // license from license map
-                    pre {
+                    licensePre(preId) {
                       unsafe { +getLicenseText(key) }
                     }
                   } else {
@@ -162,19 +165,19 @@ class HtmlReport(
                     val currentUrl = license.url.trim()
 
                     if (currentLicenseName.isNotEmpty() && currentUrl.isNotEmpty()) {
-                      pre {
+                      licensePre(preId) {
                         unsafe { +"$currentLicenseName\n<a href=\"$currentUrl\">$currentUrl</a>" }
                       }
                     } else if (currentUrl.isNotEmpty()) {
-                      pre {
+                      licensePre(preId) {
                         unsafe { +"<a href=\"$currentUrl\">$currentUrl</a>" }
                       }
                     } else if (currentLicenseName.isNotEmpty()) {
-                      pre {
+                      licensePre(preId) {
                         unsafe { +"$currentLicenseName\n" }
                       }
                     } else {
-                      pre {
+                      licensePre(preId) {
                         +NO_LICENSE
                       }
                     }
@@ -210,6 +213,19 @@ class HtmlReport(
           }
         }
     }
+
+  /** A license text block; the first block of a group carries the anchor id (#462). */
+  private fun FlowContent.licensePre(
+    anchorId: String?,
+    block: PRE.() -> Unit,
+  ) {
+    pre {
+      if (anchorId != null) {
+        id = anchorId
+      }
+      block()
+    }
+  }
 
   /**
    * See if the license is in our list of known licenses (which coalesces differing URLs to the

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginAndroidSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginAndroidSpec.groovy
@@ -181,8 +181,7 @@ final class LicensePluginAndroidSpec extends Specification {
               </dl>
             </li>
           </ul>
-          <a id="1934118923"></a>
-          <pre>${getLicenseText('apache-2.0.txt')}</pre>
+          <pre id="1934118923">${getLicenseText('apache-2.0.txt')}</pre>
           <br>
           <hr>
         </body>
@@ -396,8 +395,7 @@ final class LicensePluginAndroidSpec extends Specification {
               </dl>
             </li>
           </ul>
-          <a id="1934118923"></a>
-          <pre>${getLicenseText('apache-2.0.txt')}</pre>
+          <pre id="1934118923">${getLicenseText('apache-2.0.txt')}</pre>
           <br>
           <hr>
         </body>
@@ -557,8 +555,7 @@ final class LicensePluginAndroidSpec extends Specification {
               </dl>
             </li>
           </ul>
-          <a id="1934118923"></a>
-          <pre>${getLicenseText('apache-2.0.txt')}</pre>
+          <pre id="1934118923">${getLicenseText('apache-2.0.txt')}</pre>
           <br>
           <hr>
         </body>
@@ -770,8 +767,7 @@ final class LicensePluginAndroidSpec extends Specification {
               </dl>
             </li>
           </ul>
-          <a id="1934118923"></a>
-          <pre>${getLicenseText('apache-2.0.txt')}</pre>
+          <pre id="1934118923">${getLicenseText('apache-2.0.txt')}</pre>
           <br>
           <hr>
           <ul>
@@ -782,8 +778,7 @@ final class LicensePluginAndroidSpec extends Specification {
               </dl>
             </li>
           </ul>
-          <a id="1783810846"></a>
-          <pre>${getLicenseText('mit.txt')}</pre>
+          <pre id="1783810846">${getLicenseText('mit.txt')}</pre>
           <br>
           <hr>
         </body>
@@ -917,8 +912,7 @@ final class LicensePluginAndroidSpec extends Specification {
               </dl>
             </li>
           </ul>
-          <a id="0"></a>
-          <pre>No license found</pre>
+          <pre id="0">No license found</pre>
           <hr>
         </body>
       </html>
@@ -1036,8 +1030,7 @@ final class LicensePluginAndroidSpec extends Specification {
               </dl>
             </li>
           </ul>
-          <a id="1934118923"></a>
-          <pre>${getLicenseText('apache-2.0.txt')}</pre>
+          <pre id="1934118923">${getLicenseText('apache-2.0.txt')}</pre>
           <br>
           <hr>
           <ul>
@@ -1048,8 +1041,7 @@ final class LicensePluginAndroidSpec extends Specification {
               </dl>
             </li>
           </ul>
-          <a id="-296292112"></a>
-          <pre>Some license
+          <pre id="-296292112">Some license
           <a href="http://website.tld/">http://website.tld/</a></pre>
           <br>
           <hr>
@@ -1195,8 +1187,7 @@ final class LicensePluginAndroidSpec extends Specification {
               </dl>
             </li>
           </ul>
-          <a id="1934118923"></a>
-          <pre>${getLicenseText('apache-2.0.txt')}</pre>
+          <pre id="1934118923">${getLicenseText('apache-2.0.txt')}</pre>
           <br>
           <hr>
           <ul>
@@ -1208,8 +1199,7 @@ final class LicensePluginAndroidSpec extends Specification {
               </dl>
             </li>
           </ul>
-          <a id="-296292112"></a>
-          <pre>Some license
+          <pre id="-296292112">Some license
             <a href="http://website.tld/">http://website.tld/</a>
           </pre>
           <br>
@@ -1576,8 +1566,7 @@ final class LicensePluginAndroidSpec extends Specification {
               </dl>
             </li>
           </ul>
-          <a id="1934118923"></a>
-          <pre>${getLicenseText('apache-2.0.txt')}</pre>
+          <pre id="1934118923">${getLicenseText('apache-2.0.txt')}</pre>
           <br>
           <hr>
         </body>
@@ -1738,8 +1727,7 @@ final class LicensePluginAndroidSpec extends Specification {
               </dl>
             </li>
           </ul>
-          <a id="1934118923"></a>
-          <pre>${getLicenseText('apache-2.0.txt')}</pre>
+          <pre id="1934118923">${getLicenseText('apache-2.0.txt')}</pre>
           <br>
           <hr>
         </body>
@@ -1901,8 +1889,7 @@ final class LicensePluginAndroidSpec extends Specification {
               </dl>
             </li>
           </ul>
-          <a id="1783810846"></a>
-          <pre>${getLicenseText('mit.txt')}</pre>
+          <pre id="1783810846">${getLicenseText('mit.txt')}</pre>
           <br>
           <hr>
         </body>
@@ -1998,8 +1985,7 @@ final class LicensePluginAndroidSpec extends Specification {
               </dl>
             </li>
           </ul>
-          <a id="1934118923"></a>
-          <pre>${getLicenseText('apache-2.0.txt')}</pre>
+          <pre id="1934118923">${getLicenseText('apache-2.0.txt')}</pre>
           <br>
           <hr>
         </body>
@@ -2093,8 +2079,7 @@ final class LicensePluginAndroidSpec extends Specification {
               </dl>
             </li>
           </ul>
-          <a id="1934118923"></a>
-          <pre>${getLicenseText('apache-2.0.txt')}</pre>
+          <pre id="1934118923">${getLicenseText('apache-2.0.txt')}</pre>
           <br>
           <hr>
         </body>
@@ -2191,8 +2176,7 @@ final class LicensePluginAndroidSpec extends Specification {
               </dl>
             </li>
           </ul>
-          <a id="0"></a>
-          <pre>No license found</pre>
+          <pre id="0">No license found</pre>
           <hr>
         </body>
       </html>

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJavaSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJavaSpec.groovy
@@ -120,8 +120,7 @@ final class LicensePluginJavaSpec extends Specification {
               </dl>
             </li>
           </ul>
-          <a id="0"></a>
-          <pre>No license found</pre>
+          <pre id="0">No license found</pre>
           <hr>
         </body>
       </html>
@@ -214,8 +213,7 @@ final class LicensePluginJavaSpec extends Specification {
               </dl>
             </li>
           </ul>
-          <a id="1934118923"></a>
-          <pre>${getLicenseText('apache-2.0.txt')}</pre>
+          <pre id="1934118923">${getLicenseText('apache-2.0.txt')}</pre>
           <br>
           <hr>
         </body>
@@ -326,8 +324,7 @@ final class LicensePluginJavaSpec extends Specification {
               </dl>
             </li>
           </ul>
-          <a id="1934118923"></a>
-          <pre>${getLicenseText('apache-2.0.txt')}</pre>
+          <pre id="1934118923">${getLicenseText('apache-2.0.txt')}</pre>
           <br>
           <hr>
         </body>
@@ -488,8 +485,7 @@ final class LicensePluginJavaSpec extends Specification {
               </dl>
             </li>
           </ul>
-          <a id="-296292112"></a>
-          <pre>Some license
+          <pre id="-296292112">Some license
             <a href="http://website.tld/">http://website.tld/</a>
           </pre>
           <br>
@@ -580,8 +576,7 @@ final class LicensePluginJavaSpec extends Specification {
               </dl>
             </li>
           </ul>
-          <a id="1195092182"></a>
-          <pre>Some license
+          <pre id="1195092182">Some license
             <a href="http://website.tld/">http://website.tld/</a>
           </pre>
           <br>
@@ -681,8 +676,7 @@ final class LicensePluginJavaSpec extends Specification {
               </dl>
             </li>
           </ul>
-          <a id="1934118923"></a>
-          <pre>${getLicenseText('apache-2.0.txt')}</pre>
+          <pre id="1934118923">${getLicenseText('apache-2.0.txt')}</pre>
           <br>
           <hr>
           <ul>
@@ -694,8 +688,7 @@ final class LicensePluginJavaSpec extends Specification {
               </dl>
             </li>
           </ul>
-          <a id="-296292112"></a>
-          <pre>Some license
+          <pre id="-296292112">Some license
             <a href="http://website.tld/">http://website.tld/</a>
           </pre>
           <br>
@@ -877,8 +870,7 @@ final class LicensePluginJavaSpec extends Specification {
               </dl>
             </li>
           </ul>
-          <a id="1929112087"></a>
-          <pre>Some license 1
+          <pre id="1929112087">Some license 1
             <a href="http://website-1.tld/">http://website-1.tld/</a>
           </pre>
           <br>
@@ -1019,8 +1011,7 @@ final class LicensePluginJavaSpec extends Specification {
               </dl>
             </li>
           </ul>
-          <a id="1934118923"></a>
-          <pre>${getLicenseText('apache-2.0.txt')}</pre>
+          <pre id="1934118923">${getLicenseText('apache-2.0.txt')}</pre>
           <br>
           <hr>
         </body>
@@ -1210,8 +1201,7 @@ final class LicensePluginJavaSpec extends Specification {
               </dl>
             </li>
           </ul>
-          <a id="1934118923"></a>
-          <pre>${getLicenseText('apache-2.0.txt')}</pre>
+          <pre id="1934118923">${getLicenseText('apache-2.0.txt')}</pre>
           <br>
           <hr>
         </body>
@@ -1336,8 +1326,7 @@ final class LicensePluginJavaSpec extends Specification {
               </dl>
             </li>
           </ul>
-          <a id="1934118923"></a>
-          <pre>${getLicenseText('apache-2.0.txt')}</pre>
+          <pre id="1934118923">${getLicenseText('apache-2.0.txt')}</pre>
           <br>
           <hr>
         </body>
@@ -1472,8 +1461,7 @@ final class LicensePluginJavaSpec extends Specification {
               </dl>
             </li>
           </ul>
-          <a id="0"></a>
-          <pre>No license found</pre>
+          <pre id="0">No license found</pre>
           <hr>
         </body>
       </html>

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/internal/report/HtmlReportSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/internal/report/HtmlReportSpec.groovy
@@ -91,8 +91,7 @@ final class HtmlReportSpec extends Specification {
               </dl>
             </li>
           </ul>
-          <a id="0"></a>
-          <pre>No license found</pre>
+          <pre id="0">No license found</pre>
           <hr>
           <ul>
             <li>
@@ -114,8 +113,7 @@ final class HtmlReportSpec extends Specification {
               </dl>
             </li>
           </ul>
-          <a id="87638953"></a>
-          <pre>name
+          <pre id="87638953">name
           <a href="url">url</a></pre>
           <br>
           <hr>


### PR DESCRIPTION
Fixes #462

## Problem

Clicking a library link in the HTML report scrolls to the *bottom* of the license text instead of the top (reporter included a video demonstration). Cause: the report emits an empty inline `<a id="...">` before each license `<pre>`, and the stylesheet renders `pre` as `display: inline-block` — so the zero-size anchor shares the line box with the tall pre and sits at its **baseline**, which is exactly where the browser scrolls.

## Fix

The reporter's suggested fix, verified in their video: put the `id` on the license block itself. The first `<pre>` of each license group now carries the anchor id (subsequent blocks in multi-license groups are unchanged); the empty `<a>` is gone. `href` values are untouched, so nothing else about the report changes.

## Tests

All 32 golden HTML expectations across the four specs updated from `<a id="X"></a><pre>` to `<pre id="X">` — they now pin the corrected structure. Full suite: 129 tests, 0 failures. Also verified on a real generated report: license blocks carry the id, zero empty anchors remain.

README's HTML example output updated to match.