### PR TITLE
Stop asserting an exact dependency version in the test app tests

### DIFF
--- a/test-apps/test-app-compose-json/src/test/kotlin/com/jaredsburrows/license/testapp/json/OpenSourceLibraryTest.kt
+++ b/test-apps/test-app-compose-json/src/test/kotlin/com/jaredsburrows/license/testapp/json/OpenSourceLibraryTest.kt
@@ -31,7 +31,9 @@ class OpenSourceLibraryTest {
     val gifDrawable = libraries.single { it.name == "android-gif-drawable" }
     val license = gifDrawable.licenses.single()
 
-    assertEquals("1.2.29", gifDrawable.version)
+    // Deliberately not the exact version: Renovate bumps the dependency and the report follows it,
+    // so asserting a literal here only breaks the build on an unrelated upgrade.
+    assertTrue(gifDrawable.version.orEmpty().isNotBlank(), "the report should carry a version")
     assertEquals("The MIT License", license.name)
     assertEquals("https://spdx.org/licenses/MIT.html", license.url)
   }


### PR DESCRIPTION
Fixes master, which is red after #838.

## What broke

#838 (Renovate, automerged) bumped `android-gif-drawable` from `1.2.29` to `1.2.32` in the test apps' version catalog. `OpenSourceLibraryTest` asserted the literal old version, so the plugin generated a *correct* report carrying `1.2.32` and the test failed on it:

```
OpenSourceLibraryTest > the MIT licensed dependency keeps its name and url FAILED
    org.junit.ComparisonFailure: expected:<1.2.[29]> but was:<1.2.[32]>
```

Nothing is wrong with the plugin or the report - the test was coupled to a dependency version that Renovate is configured to bump and automerge.

## The fix

Bumping the literal to `1.2.32` would just move the failure to the next Renovate PR, so the assertion drops the exact version:

```kotlin
// Deliberately not the exact version: Renovate bumps the dependency and the report follows it,
// so asserting a literal here only breaks the build on an unrelated upgrade.
assertTrue(gifDrawable.version.orEmpty().isNotBlank(), "the report should carry a version")
```

The license name and URL assertions are untouched - they are what this test exists to cover, and they exercise the plugin resolving a license by POM name when the URL is not one it knows.

This was the only hard coded dependency version in the test app tests; I grepped the rest and the remaining literals are the fixture coordinates in `missing values are read as null rather than the string null`, which are self contained.

## Verification

* `./gradlew -p test-apps testDebugUnitTest --rerun` - 15 tests, 0 failures
* `./gradlew -p test-apps build` - green
* Failure reproduced first on `f8955a4` before changing anything, to confirm the cause