### PR TITLE
Escape license text and POM metadata in the HTML report

### DIFF
--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/internal/report/HtmlReport.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/internal/report/HtmlReport.kt
@@ -155,25 +155,32 @@ class HtmlReport(
                   val preId = if (index == 0) anchorId else null
                   if (key.isNotEmpty() && LicenseHelper.isBundled(key)) {
                     // license from license map
+                    // Escaped, not unsafe{}: the GPL family carries literal placeholders such as
+                    // "<year>" and "<name of author>" that a browser would otherwise parse as tags
+                    // and drop, silently truncating the license (8 of the bundled texts are
+                    // affected).
                     licensePre(preId) {
-                      unsafe { +getLicenseText(key) }
+                      +getLicenseText(key)
                     }
                   } else {
                     // if not found in the map, just display the info from the POM.xml
+                    // These come from a dependency's POM, so they are rendered as elements rather
+                    // than concatenated into markup.
                     val currentLicenseName = license.name.trim()
                     val currentUrl = license.url.trim()
 
                     if (currentLicenseName.isNotEmpty() && currentUrl.isNotEmpty()) {
                       licensePre(preId) {
-                        unsafe { +"$currentLicenseName\n<a href=\"$currentUrl\">$currentUrl</a>" }
+                        +"$currentLicenseName\n"
+                        a(href = currentUrl) { +currentUrl }
                       }
                     } else if (currentUrl.isNotEmpty()) {
                       licensePre(preId) {
-                        unsafe { +"<a href=\"$currentUrl\">$currentUrl</a>" }
+                        a(href = currentUrl) { +currentUrl }
                       }
                     } else if (currentLicenseName.isNotEmpty()) {
                       licensePre(preId) {
-                        unsafe { +"$currentLicenseName\n" }
+                        +"$currentLicenseName\n"
                       }
                     } else {
                       licensePre(preId) {

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/internal/report/HtmlReportSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/internal/report/HtmlReportSpec.groovy
@@ -5,6 +5,7 @@ import org.apache.maven.model.Developer
 import org.apache.maven.model.License
 import org.apache.maven.model.Model
 import spock.lang.Specification
+import spock.lang.Unroll
 
 import static test.TestUtils.assertHtml
 
@@ -156,6 +157,88 @@ final class HtmlReportSpec extends Specification {
     then: 'the text is inlined rather than linked'
     actual.contains('Permission is hereby granted, free of charge')
     !actual.contains('<a href="https://spdx.org/licenses/MIT.html">')
+  }
+
+  private static def projectWith(License license) {
+    new Model(
+      name: 'name',
+      description: '',
+      licenses: [license],
+      url: '',
+      developers: [],
+      inceptionYear: '',
+      groupId: 'foo',
+      artifactId: 'bar',
+      version: '1.2.3',
+    )
+  }
+
+  @Unroll
+  def 'bundled license text is escaped, not swallowed as markup - #spdxId'() {
+    given: 'a license whose bundled text contains angle-bracketed placeholders'
+    def report = new HtmlReport([projectWith(new License(name: spdxId, url: ''))], true)
+
+    when:
+    def actual = report.toString()
+
+    then: 'the placeholder survives, escaped'
+    actual.contains(escaped)
+
+    and: 'it is not emitted raw, where a browser would parse it as a tag and drop it'
+    !actual.contains(raw)
+
+    where:
+    spdxId     | raw                | escaped
+    'GPL-3.0'  | '<year>'           | '&lt;year&gt;'
+    'GPL-3.0'  | '<name of author>' | '&lt;name of author&gt;'
+    'GPL-3.0'  | '<program>'        | '&lt;program&gt;'
+    'GPL-2.0'  | '<year>'           | '&lt;year&gt;'
+    'AGPL-3.0' | '<year>'           | '&lt;year&gt;'
+    'LGPL-2.1' | '<year>'           | '&lt;year&gt;'
+  }
+
+  def 'every bundled license text survives rendering intact'() {
+    expect: 'nothing between angle brackets is lost from any of the bundled texts'
+    LicenseHelper.INSTANCE.bundledFileNames().every { fileName ->
+      def text = LicenseHelper.INSTANCE.licenseText(fileName)
+      def spdxId = LicenseHelper.INSTANCE.allAliases().find { alias, file -> file == fileName }?.key
+      def html = new HtmlReport([projectWith(new License(name: spdxId, url: ''))], true).toString()
+      // Every angle-bracketed run in the source text must appear escaped in the output.
+      (text =~ /<[^>\n]{1,60}>/).collect { it }.every { fragment ->
+        html.contains(fragment.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;'))
+      }
+    }
+  }
+
+  @Unroll
+  def 'license metadata from a POM cannot inject markup - #description'() {
+    given: 'a dependency POM carrying markup in its license fields'
+    def report = new HtmlReport([projectWith(new License(name: name, url: url))], true)
+
+    when:
+    def actual = report.toString()
+
+    then: 'the markup is escaped rather than emitted as elements'
+    !actual.contains(mustNotContain)
+
+    where:
+    description            | name                        | url                          | mustNotContain
+    'a script tag in name' | '<script>alert(1)</script>' | 'http://website.tld/'        | '<script>'
+    'a script tag in url'  | 'Some license'              | 'http://x/<script>a()' + '</script>' | '<script>'
+    'an attribute break'   | 'Some license'              | 'http://x/" onmouseover="a()' | 'onmouseover="a()"'
+    'an img onerror'       | '<img src=x onerror=a()>'   | 'http://website.tld/'        | '<img src=x'
+  }
+
+  def 'an unknown license still renders its url as a working link'() {
+    given:
+    def report = new HtmlReport([projectWith(new License(name: 'Some license', url: 'http://website.tld/'))], true)
+
+    when:
+    def actual = report.toString()
+
+    then: 'escaping did not cost us the anchor'
+    actual.contains('<a href="http://website.tld/">http://website.tld/</a>')
+    actual.contains('Some license')
   }
 
   def 'showVersions leaves the version out when disabled'() {


### PR DESCRIPTION
First of six fixes from the audit. This one changes what users actually read.

## Silent truncation

The report pushed bundled license text through kotlinx.html `unsafe{}`, so it reached the page as
raw markup. The GPL family carries literal placeholders that a browser parses as tags and drops:

```
<year>   <name of author>   <program>   <http://fsf.org/>   <http://www.gnu.org/licenses/>
```

So the rendered GPL-3.0 licence is missing pieces. **8 of the 25 bundled texts contain angle
brackets** - `gpl-2.0`, `gpl-3.0`, `gpl-2.0-with-classpath-exception`, `lgpl-2.1`, `lgpl-3.0`,
`agpl-3.0`, `apache-1.1`, `unlicense` - and **4 of those 8 arrived with #843**, so this got worse
rather than better.

## Markup injection

The license `name` and `url` come from a *dependency's* POM and were concatenated straight into
markup:

```kotlin
unsafe { +"$currentLicenseName\n<a href=\"$currentUrl\">$currentUrl</a>" }
```

A dependency could therefore close the `<pre>`, break out of the `href` attribute, or inject a tag
into the report.

## The change

License text is emitted escaped, and the name and URL are rendered as elements rather than
concatenated, so kotlinx.html escapes both the text and the attribute. The `unsafe{}` calls that
remain are `META` and `CSS_STYLE`, which are our own constants and legitimately raw.

Rendering is unchanged: inside `<pre>`, `&lt;year&gt;` displays as `<year>`, and the anchor for an
unknown license still comes out as `<a href="http://website.tld/">http://website.tld/</a>`.

## Tests

**No existing expectation changed.** The suite never rendered a license text containing angle
brackets - which is exactly why this shipped. Full suite: 361 tests, 0 failures.

The gap is now covered, and the tests are real regression guards: reverted against the previous
implementation, **11 of the 18 `HtmlReportSpec` cases fail**, including

- every angle-bracketed placeholder case (GPL-3.0 `<year>`, `<name of author>`, `<program>`, plus
  GPL-2.0, AGPL-3.0, LGPL-2.1),
- all four injection cases (`<script>` in the name, `<script>` in the URL, an `href` attribute
  break, an `<img onerror>`),
- and the invariant that **every** angle-bracketed run in **every** bundled text survives rendering
  escaped - which keeps this fixed as licenses are added.
