### PR TITLE
Assert what the bundled licenses are, and that they reach every report

### DIFF
--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
@@ -342,100 +342,84 @@ internal abstract class LicenseReportTask
       }
     }
 
-    private fun findVersion(
+    /**
+     * This POM and its ancestors, nearest first.
+     *
+     * Lazy, so a caller that only needs the nearest POM declaring some value does not pay to read
+     * the rest of the chain. Iterative rather than recursive, and guarded by a visited set and
+     * [MAX_PARENT_DEPTH]: a POM naming itself as its own parent, or a cycle between two POMs, would
+     * otherwise walk until the stack overflows.
+     */
+    private fun parentChain(
       mavenReader: MavenXpp3Reader,
       pomFile: File?,
       loggedMissingParentPomCoordinates: MutableSet<String>,
-    ): String {
-      if (pomFile.isNullOrEmpty()) {
-        return ""
-      }
-      val model = pomFile?.let { readModel(mavenReader, it) } ?: return ""
-
-      // If the POM is missing a name, do not record it
-      val name = model.pomName(mavenReader, pomFile, loggedMissingParentPomCoordinates)
-      if (name.isEmpty()) {
-        logger.warn("POM file is missing a name: $pomFile")
-        return ""
-      }
-
-      val version = model.pomVersion()
-      if (version.isNotEmpty()) {
-        return version.trim()
-      }
-
-      if (model.parent.artifactId
-          .orEmpty()
-          .trim()
-          .isNotEmpty()
-      ) {
-        val parentPomFile = getParentPomFile(model, loggedMissingParentPomCoordinates)
-        if (parentPomFile != null) {
-          return findVersion(
-            mavenReader,
-            parentPomFile,
-            loggedMissingParentPomCoordinates,
-          )
+    ): Sequence<Pair<File, Model>> =
+      sequence {
+        val visited = hashSetOf<String>()
+        var current = pomFile
+        var depth = 0
+        while (depth++ < MAX_PARENT_DEPTH) {
+          val file = current ?: break
+          if (file.isNullOrEmpty() || !visited.add(file.absolutePath)) {
+            break
+          }
+          val model = readModel(mavenReader, file) ?: break
+          yield(file to model)
+          current = getParentPomFile(model, loggedMissingParentPomCoordinates)
         }
       }
-      return ""
-    }
 
     private fun findLicenses(
       mavenReader: MavenXpp3Reader,
       pomFile: File?,
       loggedMissingParentPomCoordinates: MutableSet<String>,
     ): List<License> {
-      if (pomFile.isNullOrEmpty()) {
-        return emptyList()
-      }
-      val model = pomFile?.let { readModel(mavenReader, it) } ?: return emptyList()
+      // Pre-20.0.0 support library POMs declare no license at all; they are all Apache 2.0. The
+      // flag is set as the chain is walked, matching the recursive version, which applied the
+      // fallback at whichever level declared the support group id.
+      var isSupportLibrary = false
 
-      // If the POM is missing a name, do not record it
-      val name = model.pomName(mavenReader, pomFile, loggedMissingParentPomCoordinates)
-      if (name.isEmpty()) {
-        logger.warn("POM file is missing a name: $pomFile")
-        return emptyList()
-      }
-
-      // License information found
-      return model.licenses
-        .orEmpty()
-        .map { license ->
-          License().apply {
-            this.name = license.name.orEmpty().trim()
-            this.url = license.url.orEmpty().trim()
-          }
-        }.filter {
-          it.name.isNotEmpty() || it.url.isUrlValid()
-        }.ifEmpty {
-          logger.info("Project, $name, has no license in POM file.")
-          val parentLicenses =
-            model.parent?.artifactId.orEmpty().trim().takeIf { it.isNotEmpty() }?.let {
-              val parentPomFile = getParentPomFile(model, loggedMissingParentPomCoordinates)
-              if (parentPomFile != null) {
-                findLicenses(
-                  mavenReader,
-                  parentPomFile,
-                  loggedMissingParentPomCoordinates,
-                )
-              } else {
-                emptyList()
-              }
-            } ?: emptyList()
-
-          // Pre-20.0.0 support library POMs declare no license at all; they are all Apache 2.0.
-          if (parentLicenses.isEmpty() && ANDROID_SUPPORT_GROUP_ID == model.groupId.orEmpty().trim()) {
-            listOf(
-              License().apply {
-                this.name = APACHE_LICENSE_NAME
-                url = APACHE_LICENSE_URL
-              },
-            )
-          } else {
-            parentLicenses
-          }
+      for ((file, model) in parentChain(mavenReader, pomFile, loggedMissingParentPomCoordinates)) {
+        // If the POM is missing a name, do not record it
+        val name = model.pomName(mavenReader, file, loggedMissingParentPomCoordinates)
+        if (name.isEmpty()) {
+          logger.warn("POM file is missing a name: $file")
+          break
         }
+
+        // License information found
+        val licenses =
+          model.licenses
+            .orEmpty()
+            .map { license ->
+              License().apply {
+                this.name = license.name.orEmpty().trim()
+                this.url = license.url.orEmpty().trim()
+              }
+            }.filter {
+              it.name.isNotEmpty() || it.url.isUrlValid()
+            }
+        if (licenses.isNotEmpty()) {
+          return licenses
+        }
+
+        logger.info("Project, $name, has no license in POM file.")
+        if (ANDROID_SUPPORT_GROUP_ID == model.groupId.orEmpty().trim()) {
+          isSupportLibrary = true
+        }
+      }
+
+      return if (isSupportLibrary) {
+        listOf(
+          License().apply {
+            name = APACHE_LICENSE_NAME
+            url = APACHE_LICENSE_URL
+          },
+        )
+      } else {
+        emptyList()
+      }
     }
 
     private fun String.isUrlValid(): Boolean =
@@ -505,15 +489,27 @@ internal abstract class LicenseReportTask
       mavenReader: MavenXpp3Reader,
       loggedMissingParentPomCoordinates: MutableSet<String>,
     ): Map<String, String> {
-      val merged = linkedMapOf<String, String>()
-      // Parent properties first so this POM's own properties take precedence.
-      getParentPomFile(this, loggedMissingParentPomCoordinates)?.let { parentPomFile ->
-        readModel(mavenReader, parentPomFile)?.let { parentModel ->
-          merged.putAll(parentModel.collectProperties(mavenReader, loggedMissingParentPomCoordinates))
+      // Walk to the root of the chain first, guarded the same way as parentChain: this starts from
+      // a Model rather than a File, so it cannot reuse it directly.
+      val chain = mutableListOf(this)
+      val visited = hashSetOf<String>()
+      var current: Model = this
+      var depth = 0
+      while (depth++ < MAX_PARENT_DEPTH) {
+        val parentPomFile = getParentPomFile(current, loggedMissingParentPomCoordinates) ?: break
+        if (!visited.add(parentPomFile.absolutePath)) {
+          break
         }
+        current = readModel(mavenReader, parentPomFile) ?: break
+        chain += current
       }
-      properties.stringPropertyNames().forEach { key ->
-        merged[key] = properties.getProperty(key).orEmpty()
+
+      // Root-most first, so a nearer POM's properties take precedence.
+      val merged = linkedMapOf<String, String>()
+      chain.asReversed().forEach { model ->
+        model.properties.stringPropertyNames().forEach { key ->
+          merged[key] = model.properties.getProperty(key).orEmpty()
+        }
       }
       return merged
     }
@@ -605,35 +601,33 @@ internal abstract class LicenseReportTask
       return Triple(parts[0].trim(), parts[1].trim(), parts[2].trim())
     }
 
+    /** The group id of the nearest POM in the chain that states one, as Maven inherits it. */
     private fun resolveEffectiveGroupId(
       mavenReader: MavenXpp3Reader,
       pomFile: File?,
       loggedMissingParentPomCoordinates: MutableSet<String>,
-    ): String {
-      val model = pomFile?.let { readModel(mavenReader, it) } ?: return ""
-      val groupId = model.groupId.orEmpty().trim()
-      if (groupId.isNotEmpty()) {
-        return groupId
-      }
+    ): String =
+      parentChain(mavenReader, pomFile, loggedMissingParentPomCoordinates)
+        .firstNotNullOfOrNull { (_, model) ->
+          model.groupId
+            .orEmpty()
+            .trim()
+            .ifEmpty { null }
+        }.orEmpty()
 
-      val parentFile = getParentPomFile(model, loggedMissingParentPomCoordinates) ?: return ""
-      return resolveEffectiveGroupId(mavenReader, parentFile, loggedMissingParentPomCoordinates)
-    }
-
+    /** The version of the nearest POM in the chain that states one, as Maven inherits it. */
     private fun resolveEffectiveVersion(
       mavenReader: MavenXpp3Reader,
       pomFile: File?,
       loggedMissingParentPomCoordinates: MutableSet<String>,
-    ): String {
-      val model = pomFile?.let { readModel(mavenReader, it) } ?: return ""
-      val version = model.version.orEmpty().trim()
-      if (version.isNotEmpty()) {
-        return version
-      }
-
-      val parentFile = getParentPomFile(model, loggedMissingParentPomCoordinates) ?: return ""
-      return resolveEffectiveVersion(mavenReader, parentFile, loggedMissingParentPomCoordinates)
-    }
+    ): String =
+      parentChain(mavenReader, pomFile, loggedMissingParentPomCoordinates)
+        .firstNotNullOfOrNull { (_, model) ->
+          model.version
+            .orEmpty()
+            .trim()
+            .ifEmpty { null }
+        }.orEmpty()
 
     private fun File?.isNullOrEmpty(): Boolean = this?.length() == 0L
 
@@ -654,6 +648,11 @@ internal abstract class LicenseReportTask
       private const val APACHE_LICENSE_NAME = "The Apache Software License"
       private const val APACHE_LICENSE_URL = "http://www.apache.org/licenses/LICENSE-2.0.txt"
       private const val OPEN_SOURCE_LICENSES = "open_source_licenses"
+
+      // A parent chain is a handful deep in practice; the cap only stops a malformed POM
+      // (a self-parent or an A -> B -> A cycle) from walking forever.
+      const val MAX_PARENT_DEPTH = 100
+
       private const val MAX_EXCEPTION_MESSAGE_LENGTH = 200
     }
   }

--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
@@ -343,31 +343,31 @@ internal abstract class LicenseReportTask
     }
 
     /**
-     * This POM and its ancestors, nearest first.
-     *
-     * Lazy, so a caller that only needs the nearest POM declaring some value does not pay to read
-     * the rest of the chain. Iterative rather than recursive, and guarded by a visited set and
-     * [MAX_PARENT_DEPTH]: a POM naming itself as its own parent, or a cycle between two POMs, would
-     * otherwise walk until the stack overflows.
+     * This POM and its ancestors, nearest first, lazily. Stops at a POM already seen, so a
+     * self-parent or an A -> B -> A cycle terminates instead of overflowing the stack.
      */
     private fun parentChain(
       mavenReader: MavenXpp3Reader,
       pomFile: File?,
       loggedMissingParentPomCoordinates: MutableSet<String>,
     ): Sequence<Pair<File, Model>> =
-      sequence {
+      // Sequence {} rather than a shared generateSequence: each iteration needs its own visited
+      // set, or consuming the chain twice would yield nothing the second time.
+      Sequence {
         val visited = hashSetOf<String>()
-        var current = pomFile
-        var depth = 0
-        while (depth++ < MAX_PARENT_DEPTH) {
-          val file = current ?: break
-          if (file.isNullOrEmpty() || !visited.add(file.absolutePath)) {
-            break
+
+        fun node(file: File?): Pair<File, Model>? {
+          val candidate = file ?: return null
+          if (candidate.isNullOrEmpty() || !visited.add(candidate.absolutePath)) {
+            return null
           }
-          val model = readModel(mavenReader, file) ?: break
-          yield(file to model)
-          current = getParentPomFile(model, loggedMissingParentPomCoordinates)
+          return readModel(mavenReader, candidate)?.let { candidate to it }
         }
+
+        generateSequence(node(pomFile)) { (_, model) ->
+          node(getParentPomFile(model, loggedMissingParentPomCoordinates))
+        }.take(MAX_PARENT_DEPTH)
+          .iterator()
       }
 
     private fun findLicenses(
@@ -489,29 +489,21 @@ internal abstract class LicenseReportTask
       mavenReader: MavenXpp3Reader,
       loggedMissingParentPomCoordinates: MutableSet<String>,
     ): Map<String, String> {
-      // Walk to the root of the chain first, guarded the same way as parentChain: this starts from
-      // a Model rather than a File, so it cannot reuse it directly.
-      val chain = mutableListOf(this)
+      // Guarded like parentChain, but seeded from a Model rather than a File, so it cannot reuse it.
       val visited = hashSetOf<String>()
-      var current: Model = this
-      var depth = 0
-      while (depth++ < MAX_PARENT_DEPTH) {
-        val parentPomFile = getParentPomFile(current, loggedMissingParentPomCoordinates) ?: break
-        if (!visited.add(parentPomFile.absolutePath)) {
-          break
-        }
-        current = readModel(mavenReader, parentPomFile) ?: break
-        chain += current
-      }
-
-      // Root-most first, so a nearer POM's properties take precedence.
-      val merged = linkedMapOf<String, String>()
-      chain.asReversed().forEach { model ->
-        model.properties.stringPropertyNames().forEach { key ->
-          merged[key] = model.properties.getProperty(key).orEmpty()
-        }
-      }
-      return merged
+      return generateSequence(this) { model ->
+        getParentPomFile(model, loggedMissingParentPomCoordinates)
+          ?.takeIf { visited.add(it.absolutePath) }
+          ?.let { readModel(mavenReader, it) }
+      }.take(MAX_PARENT_DEPTH)
+        .toList()
+        // Root-most first, so a nearer POM's properties overwrite an ancestor's.
+        .asReversed()
+        .flatMap { model ->
+          model.properties.stringPropertyNames().map { key ->
+            key to model.properties.getProperty(key).orEmpty()
+          }
+        }.toMap()
     }
 
     private fun Model.pomDescription(): String = description.orEmpty().trim()

--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/Project.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/Project.kt
@@ -15,7 +15,7 @@ import java.security.MessageDigest
 /** Returns true if plugin exists in project. */
 internal fun Project.hasPlugin(list: List<String>): Boolean = list.any { plugins.hasPlugin(it) }
 
-private fun Project.includeParentPomFilesRecursively(
+private fun Project.resolveParentPomFilesBreadthFirst(
   mavenReader: MavenXpp3Reader,
   rootPomFiles: List<File>,
   coordinateToFile: MutableMap<String, String>,
@@ -223,7 +223,7 @@ private fun Project.buildPomInput(configurationNames: List<String>): PomInput {
 
   val mavenReader = MavenXpp3Reader()
 
-  includeParentPomFilesRecursively(
+  resolveParentPomFilesBreadthFirst(
     mavenReader = mavenReader,
     rootPomFiles = rootPomFiles,
     coordinateToFile = coordinateToFile,

--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/internal/LicenseHelper.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/internal/LicenseHelper.kt
@@ -13,6 +13,32 @@ package com.jaredsburrows.license.internal
  * below list each name or URL only once even though POMs spell them many ways.
  */
 object LicenseHelper {
+  // Deliberately not "." - it separates the parts of a version number ("2.0").
+  private val PUNCTUATION = Regex("[\",'()]")
+
+  // \s misses the non-breaking and zero-width spaces that turn up in POMs copied from a web page.
+  private val WHITESPACE = Regex("[\\s\\u00a0\\u200b\\ufeff]+")
+
+  // "License - v 1.0" and "License 1.0" must reach the same key.
+  private val SEPARATOR = Regex("\\s+-\\s+")
+
+  // "Version 2.0", "v2.0", "v 2.0" and "v. 2.0" all mean "2.0".
+  private val VERSION_PREFIX = Regex("\\b(version\\s+|v\\.?\\s*(?=\\d))")
+
+  // The GNU licenses SPDX re-spelled with an explicit -only / -or-later suffix.
+  private val GNU_FAMILY = Regex("(A|L)?GPL-[0-9.]+")
+
+  private val EXTENSION = Regex("\\.(txt|html?|php)$")
+  private val LOCALE = Regex("\\.[a-z]{2}$")
+  private val PORT = Regex("^([^/]+):\\d+")
+
+  /**
+   * URLs that do not name a specific variant of a license family.
+   * opensource.org/licenses/bsd-license.php is the retired OSI page that POMs cite for both the
+   * 2-clause and 3-clause BSD licenses, so a name that does state the variant wins over it.
+   */
+  private val AMBIGUOUS_URLS: Set<String> = setOf("opensource.org/licenses/bsd-license")
+
   /** Canonical SPDX identifier to the bundled license text file. */
   private val texts =
     linkedMapOf(
@@ -102,12 +128,20 @@ object LicenseHelper {
       "apache license 2.0" to "Apache-2.0",
       "apache software license 2.0" to "Apache-2.0",
       "apache software license" to "Apache-2.0",
+      "apache 2" to "Apache-2.0",
+      "apache license" to "Apache-2.0",
+      "apache software license 2" to "Apache-2.0",
       // BSD 2-Clause "Simplified" License
       "bsd 2-clause simplified license" to "BSD-2-Clause",
       "bsd 2-clause license" to "BSD-2-Clause",
+      "simplified bsd license" to "BSD-2-Clause",
+      "freebsd license" to "BSD-2-Clause",
       // BSD 3-Clause "New" or "Revised" License
       "bsd 3-clause new or revised license" to "BSD-3-Clause",
       "bsd 3-clause license" to "BSD-3-Clause",
+      "new bsd license" to "BSD-3-Clause",
+      "modified bsd license" to "BSD-3-Clause",
+      "revised bsd license" to "BSD-3-Clause",
       // Creative Commons Zero v1.0 Universal
       "creative commons zero 1.0 universal" to "CC0-1.0",
       "cc0 1.0 universal" to "CC0-1.0",
@@ -152,11 +186,9 @@ object LicenseHelper {
       "cddl 1.1" to "CDDL-1.1",
       // Eclipse Distribution License 1.0 is the BSD 3-Clause text
       "eclipse distribution license 1.0" to "BSD-3-Clause",
-      "eclipse distribution license - v 1.0" to "BSD-3-Clause",
       "edl 1.0" to "BSD-3-Clause",
       // Eclipse Public License 1.0
       "eclipse public license 1.0" to "EPL-1.0",
-      "eclipse public license - v 1.0" to "EPL-1.0",
       "common public license 1.0" to "EPL-1.0",
       // GNU General Public License v2.0 with the Classpath exception
       "gnu general public license 2.0 w/classpath exception" to "GPL-2.0-with-classpath-exception",
@@ -194,12 +226,14 @@ object LicenseHelper {
       "opensource.org/licenses/epl-2.0" to "EPL-2.0",
       // GNU General Public License v2.0
       "gnu.org/licenses/gpl-2.0" to "GPL-2.0",
+      "gnu.org/licenses/old-licenses/gpl-2.0" to "GPL-2.0",
       "opensource.org/licenses/gpl-2.0" to "GPL-2.0",
       // GNU General Public License v3.0
       "gnu.org/licenses/gpl-3.0" to "GPL-3.0",
       "opensource.org/licenses/gpl-3.0" to "GPL-3.0",
       // GNU Lesser General Public License v2.1
       "gnu.org/licenses/lgpl-2.1" to "LGPL-2.1",
+      "gnu.org/licenses/old-licenses/lgpl-2.1" to "LGPL-2.1",
       "opensource.org/licenses/lgpl-2.1" to "LGPL-2.1",
       // GNU Lesser General Public License v3.0
       "gnu.org/licenses/lgpl-3.0" to "LGPL-3.0",
@@ -227,6 +261,7 @@ object LicenseHelper {
       "creativecommons.org/licenses/by-sa/4.0" to "CC-BY-SA-4.0",
       // Common Development and Distribution License 1.0
       "opensource.org/licenses/cddl-1.0" to "CDDL-1.0",
+      "opensource.org/licenses/cddl1" to "CDDL-1.0",
       "glassfish.dev.java.net/public/cddlv1.0" to "CDDL-1.0",
       // Common Development and Distribution License 1.1
       "glassfish.java.net/public/cddl+gpl_1_1" to "CDDL-1.1",
@@ -244,6 +279,7 @@ object LicenseHelper {
       "opensource.org/licenses/isc" to "ISC",
       // GNU Lesser General Public License v2.0
       "gnu.org/licenses/lgpl-2.0" to "LGPL-2.0",
+      "gnu.org/licenses/old-licenses/lgpl-2.0" to "LGPL-2.0",
       "opensource.org/licenses/lgpl-2.0" to "LGPL-2.0",
       // MIT No Attribution
       "opensource.org/licenses/mit-0" to "MIT-0",
@@ -252,8 +288,28 @@ object LicenseHelper {
       "opensource.org/licenses/unlicense" to "Unlicense",
     )
 
-  /** SPDX identifiers, lower cased, for case-insensitive lookup of a bare identifier. */
-  private val spdxIds: Map<String, String> = texts.keys.associateBy { it.lowercase() }
+  /**
+   * SPDX identifiers, lower cased, for case-insensitive lookup of a bare identifier.
+   *
+   * SPDX deprecated the bare GNU identifiers in list v3.0 (2018) in favour of an explicit
+   * "-only"/"-or-later" suffix, and that is what current tooling emits - logback, for one, declares
+   * "LGPL-2.1-only". Both spellings resolve to the same bundled text, since the plugin reports the
+   * license rather than the choice of version.
+   */
+  private val spdxIds: Map<String, String> =
+    buildMap {
+      texts.keys.forEach { id ->
+        put(id.lowercase(), id)
+        if (GNU_FAMILY.matches(id)) {
+          put("$id-only".lowercase(), id)
+          put("$id-or-later".lowercase(), id)
+        }
+      }
+      // "GPL-2.0-only WITH Classpath-exception-2.0" is the modern spelling of the deprecated
+      // GPL-2.0-with-classpath-exception identifier.
+      listOf("gpl-2.0", "gpl-2.0-only", "gpl-2.0-or-later")
+        .forEach { put("$it with classpath-exception-2.0", "GPL-2.0-with-classpath-exception") }
+    }
 
   /**
    * Strip everything that varies between spellings of the same URL: the scheme, a leading "www.",
@@ -261,12 +317,25 @@ object LicenseHelper {
    * `http://apache.org/licenses/LICENSE-2.0` both become `apache.org/licenses/license-2.0`.
    */
   private fun normalizeUrl(url: String): String {
-    var value = url.trim().lowercase()
+    var value = url.trim().lowercase().replace(WHITESPACE, "")
     value = value.substringAfter("://", value)
+    // Protocol-relative "//host/path".
+    value = value.removePrefix("//")
+    // A fragment or query string never identifies the license.
+    value = value.substringBefore('#').substringBefore('?')
     value = value.removePrefix("www.")
+    value = value.replace(PORT, "$1")
     value = value.trimEnd('/')
-    for (extension in listOf(".txt", ".html", ".htm", ".php")) {
-      value = value.removeSuffix(extension)
+    // Repeated rather than an ordered list, so ".txt.html" folds the same way as ".html.txt".
+    while (true) {
+      val stripped = value.replace(EXTENSION, "")
+      if (stripped == value) break
+      value = stripped
+    }
+    // gnu.org serves its retired licenses as "lgpl-2.1.en.html"; drop the locale segment. Only
+    // when there is a path, so a bare host such as "unlicense.org" keeps its ".org".
+    if (value.contains('/')) {
+      value = value.replace(LOCALE, "")
     }
     return value.trimEnd('/')
   }
@@ -281,27 +350,46 @@ object LicenseHelper {
     value = value.replace(PUNCTUATION, " ")
     value = value.replace(WHITESPACE, " ").trim()
     value = value.removePrefix("the ")
+    value = value.replace(SEPARATOR, " ")
     value = value.replace(VERSION_PREFIX, "")
     return value.replace(WHITESPACE, " ").trim()
   }
 
-  /** The canonical SPDX identifier for [name]/[url], or null when it is not one we bundle. */
+  /** The SPDX identifier a URL names, or null. */
+  private fun spdxIdFromUrl(url: String): String? {
+    val normalized = normalizeUrl(url)
+    // https://spdx.org/licenses/MIT.html names the identifier directly.
+    val fromSpdxUrl = normalized.substringAfter("spdx.org/licenses/", "")
+    return spdxIds[fromSpdxUrl] ?: urlAliases[normalized]
+  }
+
+  /** The SPDX identifier a name states, or null. */
+  private fun spdxIdFromName(name: String): String? =
+    spdxIds[name.trim().lowercase().replace(WHITESPACE, " ")] ?: nameAliases[normalizeName(name)]
+
+  /**
+   * The canonical SPDX identifier for [name]/[url], or null when it is not one we bundle.
+   *
+   * The URL is consulted first because it is the more precise signal, except for the handful of
+   * URLs in [AMBIGUOUS_URLS] that do not name a specific variant. For those the name decides when
+   * it says something more specific, so a POM such as hamcrest's - "New BSD License" pointing at
+   * the retired opensource.org/licenses/bsd-license.php page - is not reported as BSD 2-Clause.
+   */
   private fun spdxId(
     name: String?,
     url: String?,
   ): String? {
+    var fromUrl: String? = null
+    var urlIsAmbiguous = false
     if (!url.isNullOrBlank()) {
-      val normalized = normalizeUrl(url)
-      // https://spdx.org/licenses/MIT.html names the identifier directly.
-      val fromSpdxUrl = normalized.substringAfter("spdx.org/licenses/", "")
-      spdxIds[fromSpdxUrl]?.let { return it }
-      urlAliases[normalized]?.let { return it }
+      fromUrl = spdxIdFromUrl(url)
+      urlIsAmbiguous = normalizeUrl(url) in AMBIGUOUS_URLS
     }
+    if (fromUrl != null && !urlIsAmbiguous) return fromUrl
     if (!name.isNullOrBlank()) {
-      spdxIds[name.trim().lowercase()]?.let { return it }
-      nameAliases[normalizeName(name)]?.let { return it }
+      spdxIdFromName(name)?.let { return it }
     }
-    return null
+    return fromUrl
   }
 
   /**
@@ -333,9 +421,4 @@ object LicenseHelper {
 
   /** Every alias, name and URL alike, paired with the file it must resolve to. Used by tests. */
   fun allAliases(): Map<String, String> = (nameAliases + urlAliases).mapValues { (_, id) -> texts.getValue(id) }
-
-  // Deliberately not "." - it separates the parts of a version number ("2.0").
-  private val PUNCTUATION = Regex("[\",'()]")
-  private val WHITESPACE = Regex("\\s+")
-  private val VERSION_PREFIX = Regex("\\b(version\\s+|v(?=\\d))")
 }

--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/internal/LicenseHelper.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/internal/LicenseHelper.kt
@@ -28,7 +28,7 @@ object LicenseHelper {
   // The GNU licenses SPDX re-spelled with an explicit -only / -or-later suffix.
   private val GNU_FAMILY = Regex("(A|L)?GPL-[0-9.]+")
 
-  private val EXTENSION = Regex("\\.(txt|html?|php)$")
+  private val EXTENSION = Regex("(\\.(txt|html?|php))+$")
   private val LOCALE = Regex("\\.[a-z]{2}$")
   private val PORT = Regex("^([^/]+):\\d+")
 
@@ -326,12 +326,9 @@ object LicenseHelper {
     value = value.removePrefix("www.")
     value = value.replace(PORT, "$1")
     value = value.trimEnd('/')
-    // Repeated rather than an ordered list, so ".txt.html" folds the same way as ".html.txt".
-    while (true) {
-      val stripped = value.replace(EXTENSION, "")
-      if (stripped == value) break
-      value = stripped
-    }
+    // A repeated group in one pass, so ".txt.html" folds the same way as ".html.txt" without
+    // depending on the order a list of suffixes would impose, and without a loop.
+    value = value.replace(EXTENSION, "")
     // gnu.org serves its retired licenses as "lgpl-2.1.en.html"; drop the locale segment. Only
     // when there is a path, so a bare host such as "unlicense.org" keeps its ".org".
     if (value.contains('/')) {

--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/internal/LicenseHelper.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/internal/LicenseHelper.kt
@@ -1,16 +1,10 @@
 package com.jaredsburrows.license.internal
 
 /**
- * Map License name and URL to license text file.
+ * Map License name and URL to license text file, matched after normalisation so one alias covers
+ * every spelling of the same thing (scheme, casing, www, trailing slash, extension, punctuation).
  *
- * Based on "popular and widely-used or with strong communities" found here:
- * https://opensource.org/licenses/category.
- * License text from: https://github.com/github/choosealicense.com/blob/gh-pages/_licenses.
- *
- * Names and URLs are matched after normalisation, so a single alias covers every spelling of the
- * same thing: `http` and `https`, a leading `www.`, a trailing slash, a `.txt`/`.html`/`.php`
- * suffix, any casing, and surrounding whitespace all collapse to one key. That is why the tables
- * below list each name or URL only once even though POMs spell them many ways.
+ * Based on https://opensource.org/licenses/category; text from choosealicense and the SPDX list.
  */
 object LicenseHelper {
   // Deliberately not "." - it separates the parts of a version number ("2.0").
@@ -32,11 +26,7 @@ object LicenseHelper {
   private val LOCALE = Regex("\\.[a-z]{2}$")
   private val PORT = Regex("^([^/]+):\\d+")
 
-  /**
-   * URLs that do not name a specific variant of a license family.
-   * opensource.org/licenses/bsd-license.php is the retired OSI page that POMs cite for both the
-   * 2-clause and 3-clause BSD licenses, so a name that does state the variant wins over it.
-   */
+  /** URLs cited for more than one variant of a family, so a name stating the variant wins. */
   private val AMBIGUOUS_URLS: Set<String> = setOf("opensource.org/licenses/bsd-license")
 
   /** Canonical SPDX identifier to the bundled license text file. */
@@ -289,12 +279,8 @@ object LicenseHelper {
     )
 
   /**
-   * SPDX identifiers, lower cased, for case-insensitive lookup of a bare identifier.
-   *
-   * SPDX deprecated the bare GNU identifiers in list v3.0 (2018) in favour of an explicit
-   * "-only"/"-or-later" suffix, and that is what current tooling emits - logback, for one, declares
-   * "LGPL-2.1-only". Both spellings resolve to the same bundled text, since the plugin reports the
-   * license rather than the choice of version.
+   * SPDX identifiers, lower cased. SPDX deprecated the bare GNU ids in 2018, so the "-only" and
+   * "-or-later" spellings current tooling emits map to the same text.
    */
   private val spdxIds: Map<String, String> =
     buildMap {
@@ -311,11 +297,7 @@ object LicenseHelper {
         .forEach { put("$it with classpath-exception-2.0", "GPL-2.0-with-classpath-exception") }
     }
 
-  /**
-   * Strip everything that varies between spellings of the same URL: the scheme, a leading "www.",
-   * a trailing slash and a file extension. `https://www.Apache.org/licenses/LICENSE-2.0.txt` and
-   * `http://apache.org/licenses/LICENSE-2.0` both become `apache.org/licenses/license-2.0`.
-   */
+  /** Strip everything that varies between spellings: scheme, www, port, query, slash, extension. */
   private fun normalizeUrl(url: String): String {
     var value = url.trim().lowercase().replace(WHITESPACE, "")
     value = value.substringAfter("://", value)
@@ -337,11 +319,7 @@ object LicenseHelper {
     return value.trimEnd('/')
   }
 
-  /**
-   * Reduce a license name to its distinguishing words: lower case, punctuation removed, runs of
-   * whitespace collapsed, a leading "the" dropped and "version 2.0"/"v2.0" folded to "2.0".
-   * `The Apache Software License, Version 2.0` becomes `apache software license 2.0`.
-   */
+  /** Reduce a name to its distinguishing words: "The Apache Software License, Version 2.0" -> "apache software license 2.0". */
   private fun normalizeName(name: String): String {
     var value = name.trim().lowercase()
     value = value.replace(PUNCTUATION, " ")
@@ -365,12 +343,8 @@ object LicenseHelper {
     spdxIds[name.trim().lowercase().replace(WHITESPACE, " ")] ?: nameAliases[normalizeName(name)]
 
   /**
-   * The canonical SPDX identifier for [name]/[url], or null when it is not one we bundle.
-   *
-   * The URL is consulted first because it is the more precise signal, except for the handful of
-   * URLs in [AMBIGUOUS_URLS] that do not name a specific variant. For those the name decides when
-   * it says something more specific, so a POM such as hamcrest's - "New BSD License" pointing at
-   * the retired opensource.org/licenses/bsd-license.php page - is not reported as BSD 2-Clause.
+   * The SPDX id for [name]/[url], or null. URL first, since it is the more precise signal - unless
+   * it is in [AMBIGUOUS_URLS], where a name that states the variant wins (hamcrest, #846).
    */
   private fun spdxId(
     name: String?,

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJavaSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJavaSpec.groovy
@@ -2178,4 +2178,52 @@ final class LicensePluginJavaSpec extends Specification {
   }
 
 
+
+  def 'licenseReport renders a bundled license that is neither Apache nor MIT, in every format'() {
+    given: 'a dependency under EPL-1.0, one of the licenses added in #843'
+    buildFile <<
+      """
+      plugins {
+        id 'java-library'
+        id 'com.jaredsburrows.license'
+      }
+
+      licenseReport {
+        generateCsvReport = true
+        generateTextReport = true
+        generateJsonFullReport = true
+      }
+
+      repositories {
+        maven {
+          url '${mavenRepoUrl}'
+        }
+      }
+
+      dependencies {
+        implementation 'group:eplib:1.0.0'
+      }
+      """
+
+    when:
+    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+
+    then:
+    result.task(':licenseReport').outcome == SUCCESS
+
+    and: 'the HTML inlines the full EPL text rather than only linking to it'
+    def html = new File(reportFolder, 'licenseReport.html').text
+    html.contains('Eclipse Public License - v 1.0')
+    html.contains('EPL library')
+
+    and: 'the full JSON carries it under its own key, not apache-2.0 or mit'
+    def full = new groovy.json.JsonSlurper().parseText(new File(reportFolder, 'licenseReport.full.json').text)
+    full.license_texts.keySet() == ['epl-1.0'] as Set
+    full.dependencies[0].licenses[0].license_key == 'epl-1.0'
+
+    and: 'the CSV and text reports name it too'
+    new File(reportFolder, 'licenseReport.csv').text.contains('Eclipse Public License 1.0')
+    new File(reportFolder, 'licenseReport.txt').text.contains('EPL library')
+  }
+
 }

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJavaSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJavaSpec.groovy
@@ -2146,4 +2146,36 @@ final class LicensePluginJavaSpec extends Specification {
     report.license_texts == [:]
     report.dependencies == []
   }
+
+  def 'licenseReport terminates on a POM that is its own parent'() {
+    given: 'a dependency whose POM names itself as its parent'
+    buildFile <<
+      """
+      plugins {
+        id 'java-library'
+        id 'com.jaredsburrows.license'
+      }
+
+      repositories {
+        maven {
+          url '${mavenRepoUrl}'
+        }
+      }
+
+      dependencies {
+        implementation 'group:selfparent:1.0.0'
+      }
+      """
+
+    when: 'the parent chain is walked'
+    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+
+    then: 'it stops at the repeat instead of recursing until the stack overflows'
+    result.task(':licenseReport').outcome == SUCCESS
+
+    and: 'the dependency really was walked, so the test is not vacuous'
+    new File(reportFolder, 'licenseReport.json').text.contains('Self parent')
+  }
+
+
 }

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/internal/LicenseHelperSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/internal/LicenseHelperSpec.groovy
@@ -350,7 +350,7 @@ final class LicenseHelperSpec extends Specification {
     where:
     url                                                  || expected
     'https://www.eclipse.org/legal/epl-v10.html'         || 'epl-1.0.txt'
-    'http://www.opensource.org/licenses/cddl1.php'       || null
+    'http://www.opensource.org/licenses/cddl1.php'       || 'cddl-1.0.txt'
     'https://opensource.org/licenses/CDDL-1.0'           || 'cddl-1.0.txt'
     'https://opensource.org/licenses/ISC'                || 'isc.txt'
     'https://unlicense.org/'                             || 'unlicense.txt'
@@ -404,6 +404,128 @@ final class LicenseHelperSpec extends Specification {
     text.contains('GNU GENERAL PUBLIC LICENSE')
     text.contains('CLASSPATH EXCEPTION')
     text.contains('link this library with independent modules')
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Real-world POM spellings that used to miss, or worse, resolve to the wrong license.
+  // ---------------------------------------------------------------------------------------------
+
+  def 'BUG: an ambiguous url no longer overrides a name that names the BSD variant'() {
+    expect: 'hamcrest declares "New BSD License" with the retired OSI bsd-license.php url'
+    HELPER.licenseFileName('New BSD License', 'http://www.opensource.org/licenses/bsd-license.php') == 'bsd-3-clause.txt'
+
+    and: 'the same url with a 2-clause name still resolves to 2-clause'
+    HELPER.licenseFileName('BSD 2-Clause License', 'http://www.opensource.org/licenses/bsd-license.php') == 'bsd-2-clause.txt'
+
+    and: 'and on its own, with nothing more specific to go on, it keeps its historical answer'
+    HELPER.licenseFileName(null, 'http://www.opensource.org/licenses/bsd-license.php') == 'bsd-2-clause.txt'
+  }
+
+  @Unroll
+  def 'an unambiguous url still wins over a conflicting name - #url'() {
+    expect: 'only the urls listed as ambiguous defer to the name'
+    HELPER.licenseFileName('MIT License', url) == expected
+
+    where:
+    url                                              || expected
+    'http://www.apache.org/licenses/LICENSE-2.0.txt' || 'apache-2.0.txt'
+    'https://opensource.org/licenses/GPL-3.0'        || 'gpl-3.0.txt'
+  }
+
+  @Unroll
+  def 'BUG: the modern SPDX id #id resolves'() {
+    expect: 'SPDX deprecated the bare GNU ids in 2018; current tooling emits -only/-or-later'
+    HELPER.licenseFileName(id, null) == expected
+
+    where:
+    id                                          || expected
+    'GPL-2.0-only'                              || 'gpl-2.0.txt'
+    'GPL-2.0-or-later'                          || 'gpl-2.0.txt'
+    'GPL-3.0-only'                              || 'gpl-3.0.txt'
+    'GPL-3.0-or-later'                          || 'gpl-3.0.txt'
+    'LGPL-2.0-only'                             || 'lgpl-2.0.txt'
+    'LGPL-2.1-only'                             || 'lgpl-2.1.txt'
+    'LGPL-2.1-or-later'                         || 'lgpl-2.1.txt'
+    'LGPL-3.0-only'                             || 'lgpl-3.0.txt'
+    'AGPL-3.0-only'                             || 'agpl-3.0.txt'
+    'AGPL-3.0-or-later'                         || 'agpl-3.0.txt'
+    'GPL-2.0-only WITH Classpath-exception-2.0' || 'gpl-2.0-with-classpath-exception.txt'
+    'GPL-2.0 WITH Classpath-exception-2.0'      || 'gpl-2.0-with-classpath-exception.txt'
+  }
+
+  @Unroll
+  def 'BUG: the gnu.org retired-license url #url resolves'() {
+    expect: 'gnu.org serves every retired license under /old-licenses/'
+    HELPER.licenseFileName(null, url) == expected
+
+    where:
+    url                                                              || expected
+    'https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html'        || 'lgpl-2.1.txt'
+    'http://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html'      || 'lgpl-2.1.txt'
+    'https://www.gnu.org/licenses/old-licenses/gpl-2.0.html'         || 'gpl-2.0.txt'
+    'https://www.gnu.org/licenses/old-licenses/lgpl-2.0.html'        || 'lgpl-2.0.txt'
+  }
+
+  @Unroll
+  def 'a query string, fragment or port does not defeat the url - #url'() {
+    expect:
+    HELPER.licenseFileName(null, url) == 'apache-2.0.txt'
+
+    where:
+    url << [
+      'https://www.apache.org/licenses/LICENSE-2.0.txt?raw=true',
+      'https://www.apache.org/licenses/LICENSE-2.0#section',
+      'https://www.apache.org/licenses/LICENSE-2.0.txt?a=b#c',
+      'https://www.apache.org:443/licenses/LICENSE-2.0.txt',
+      '//www.apache.org/licenses/LICENSE-2.0.txt',
+      'https://www.apache.org/licenses/LICENSE-2.0.txt.html',
+      'https://www.apache.org/licenses/LICENSE-2.0.html.txt',
+    ]
+  }
+
+  @Unroll
+  def 'unusual whitespace inside a name does not block a match - #description'() {
+    expect:
+    HELPER.licenseFileName(name, null) == 'apache-2.0.txt'
+
+    where:
+    description            | name
+    'a non-breaking space' | 'Apache License 2.0'
+    'a zero-width space'   | 'Apache\u200bLicense 2.0'
+    'a tab'                | 'Apache\tLicense 2.0'
+    'a newline'            | 'Apache\nLicense 2.0'
+    'padded'               | '  Apache License 2.0  '
+  }
+
+  @Unroll
+  def 'version separators are folded consistently - #name'() {
+    expect: 'the dashed and dotted spellings reach the same alias as the plain one'
+    HELPER.licenseFileName(name, null) == expected
+
+    where:
+    name                              || expected
+    'Eclipse Public License - v 1.0'  || 'epl-1.0.txt'
+    'Eclipse Public License v1.0'     || 'epl-1.0.txt'
+    'Eclipse Public License - v 2.0'  || 'epl-2.0.txt'
+    'Eclipse Public License v. 2.0'   || 'epl-2.0.txt'
+    'Eclipse Public License v2.0'     || 'epl-2.0.txt'
+    'Eclipse Public License - v. 2.0' || 'epl-2.0.txt'
+  }
+
+  @Unroll
+  def 'common BSD and Apache name spellings resolve - #name'() {
+    expect:
+    HELPER.licenseFileName(name, null) == expected
+
+    where:
+    name                     || expected
+    'New BSD License'        || 'bsd-3-clause.txt'
+    'Modified BSD License'   || 'bsd-3-clause.txt'
+    'Revised BSD License'    || 'bsd-3-clause.txt'
+    'Simplified BSD License' || 'bsd-2-clause.txt'
+    'FreeBSD License'        || 'bsd-2-clause.txt'
+    'Apache 2'               || 'apache-2.0.txt'
+    'Apache Software License 2' || 'apache-2.0.txt'
   }
 
   @Unroll

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/internal/LicenseHelperSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/internal/LicenseHelperSpec.groovy
@@ -540,4 +540,85 @@ final class LicenseHelperSpec extends Specification {
     'an unbundled license'    | 'Some license'    | 'http://website.tld/'                            || null
     'no license at all'       | null              | null                                             || null
   }
+
+  @Unroll
+  def 'the bundled text really is #fileName, not another license'() {
+    given: 'the phrase, together with what must be absent, identifies exactly one bundled license'
+    def text = HELPER.licenseText(fileName)
+
+    expect:
+    text.contains(mustContain)
+    mustNotContain.every { !text.contains(it) }
+
+    where:
+    fileName | mustContain | mustNotContain
+    '0bsd.txt'                             | 'BSD Zero Clause License'                               | []
+    'agpl-3.0.txt'                         | 'Version 3, 19 November 2007'                           | []
+    'apache-1.1.txt'                       | 'The Apache Software License, Version 1.1'              | []
+    'apache-2.0.txt'                       | 'Version 2.0, January 2004'                             | []
+    'bsd-2-clause.txt'                     | 'BSD 2-Clause License'                                  | []
+    'bsd-3-clause.txt'                     | 'BSD 3-Clause License'                                  | []
+    'bsd-4-clause.txt'                     | 'BSD 4-Clause License'                                  | []
+    'cc-by-4.0.txt'                        | 'Attribution 4.0 International'                         | ['ShareAlike']
+    'cc-by-sa-4.0.txt'                     | 'Attribution-ShareAlike 4.0 International'              | []
+    'cc0-1.0.txt'                          | 'CC0 1.0 Universal'                                     | []
+    'cddl-1.0.txt'                         | 'Sun Microsystems, Inc. is the initial license steward' | []
+    'cddl-1.1.txt'                         | 'Oracle is the initial license steward'                 | []
+    'epl-1.0.txt'                          | 'Eclipse Public License - v 1.0'                        | []
+    'epl-2.0.txt'                          | 'Eclipse Public License - v 2.0'                        | []
+    'gpl-2.0-with-classpath-exception.txt' | 'CLASSPATH EXCEPTION'                                   | []
+    'gpl-2.0.txt'                          | 'Version 2, June 1991'                                  | ['CLASSPATH EXCEPTION', 'LIBRARY GENERAL PUBLIC LICENSE']
+    'gpl-3.0.txt'                          | 'Version 3, 29 June 2007'                               | ['LESSER GENERAL PUBLIC LICENSE']
+    'isc.txt'                              | 'ISC License'                                           | []
+    'lgpl-2.0.txt'                         | 'GNU LIBRARY GENERAL PUBLIC LICENSE'                    | []
+    'lgpl-2.1.txt'                         | 'Version 2.1, February 1999'                            | []
+    'lgpl-3.0.txt'                         | 'GNU LESSER GENERAL PUBLIC LICENSE'                     | ['Version 2.1, February 1999']
+    'mit-0.txt'                            | 'MIT No Attribution'                                    | []
+    'mit.txt'                              | 'MIT License'                                           | ['No Attribution']
+    'mpl-2.0.txt'                          | 'Mozilla Public License Version 2.0'                    | []
+    'unlicense.txt'                        | 'unencumbered software released into the public domain' | []
+  }
+
+  def 'the identity table covers every bundled license'() {
+    given: 'so a license added without an identity assertion fails here'
+    def asserted = [
+      '0bsd.txt',
+      'agpl-3.0.txt',
+      'apache-1.1.txt',
+      'apache-2.0.txt',
+      'bsd-2-clause.txt',
+      'bsd-3-clause.txt',
+      'bsd-4-clause.txt',
+      'cc-by-4.0.txt',
+      'cc-by-sa-4.0.txt',
+      'cc0-1.0.txt',
+      'cddl-1.0.txt',
+      'cddl-1.1.txt',
+      'epl-1.0.txt',
+      'epl-2.0.txt',
+      'gpl-2.0-with-classpath-exception.txt',
+      'gpl-2.0.txt',
+      'gpl-3.0.txt',
+      'isc.txt',
+      'lgpl-2.0.txt',
+      'lgpl-2.1.txt',
+      'lgpl-3.0.txt',
+      'mit-0.txt',
+      'mit.txt',
+      'mpl-2.0.txt',
+      'unlicense.txt',
+    ] as Set
+
+    expect:
+    asserted == HELPER.bundledFileNames()
+  }
+
+  def 'no two bundled licenses have identical text'() {
+    given: 'a copy-paste that duplicates a license would otherwise ship silently'
+    def texts = HELPER.bundledFileNames().collect { HELPER.licenseText(it) }
+
+    expect:
+    texts.toSet().size() == texts.size()
+  }
+
 }

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/internal/report/JsonFullReportSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/internal/report/JsonFullReportSpec.groovy
@@ -6,6 +6,7 @@ import org.apache.maven.model.Developer
 import org.apache.maven.model.License
 import org.apache.maven.model.Model
 import spock.lang.Specification
+import spock.lang.Unroll
 
 final class JsonFullReportSpec extends Specification {
   private static final String APACHE_URL = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
@@ -129,4 +130,22 @@ final class JsonFullReportSpec extends Specification {
       it.url = url
     }
   }
+
+  @Unroll
+  def 'every bundled license reaches the full report under its own key - #spdxId'() {
+    given: 'the key is the bundled file name without its extension'
+    def projects = [project('P', 'p', [license(spdxId, '')])]
+
+    when:
+    def report = new JsonSlurper().parseText(new JsonFullReport(projects).toString())
+
+    then: 'the dependency points at the key, and the text is carried under it'
+    report.dependencies[0].licenses[0].license_key == expectedKey
+    report.license_texts[expectedKey] == LicenseHelper.INSTANCE.licenseText(expectedKey + '.txt')
+
+    where:
+    spdxId << LicenseHelper.INSTANCE.bundledFileNames().collect { it - '.txt' }
+    expectedKey = spdxId
+  }
+
 }

--- a/gradle-license-plugin/src/test/resources/maven/group/eplib/1.0.0/eplib-1.0.0.pom
+++ b/gradle-license-plugin/src/test/resources/maven/group/eplib/1.0.0/eplib-1.0.0.pom
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Fake dependency for testing - a bundled license that is neither Apache nor MIT -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <!-- The Basics -->
+  <groupId>group</groupId>
+  <artifactId>eplib</artifactId>
+  <version>1.0.0</version>
+  <packaging>jar</packaging>
+
+  <!-- More Project Information -->
+  <name>EPL library</name>
+  <description>Fake dependency under the Eclipse Public License</description>
+
+  <licenses>
+    <license>
+      <name>Eclipse Public License 1.0</name>
+      <url>http://www.eclipse.org/legal/epl-v10.html</url>
+    </license>
+  </licenses>
+</project>

--- a/gradle-license-plugin/src/test/resources/maven/group/selfparent/1.0.0/selfparent-1.0.0.pom
+++ b/gradle-license-plugin/src/test/resources/maven/group/selfparent/1.0.0/selfparent-1.0.0.pom
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Fake dependency for testing - a POM that names itself as its own parent -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <!-- Parent Information - deliberately itself, which used to recurse forever -->
+  <parent>
+    <groupId>group</groupId>
+    <artifactId>selfparent</artifactId>
+    <version>1.0.0</version>
+  </parent>
+
+  <!-- The Basics -->
+  <groupId>group</groupId>
+  <artifactId>selfparent</artifactId>
+  <version>1.0.0</version>
+  <packaging>jar</packaging>
+
+  <!-- More Project Information -->
+  <name>Self parent</name>
+  <description>Fake dependency whose parent is itself</description>
+</project>


### PR DESCRIPTION
Stacked on #846 - review that first. No behaviour change; this is all test.

Every bug found in the last few PRs shipped for the same reason: **nothing asserted the thing.**

| Bug | Shipped for |
| --- | --- |
| `cc0-1.0.txt` bundled but unreachable | ~3 years |
| GPL/LGPL text silently truncated in HTML | unknown |
| hamcrest reported under the wrong BSD variant | unknown |
| A case in #843 pinning a *miss* as correct | mine, one PR |

So these are **invariants**, not more examples - the aim is to stop the class of mistake being
expressible.

## Identity: is `epl-1.0.txt` actually the EPL?

Nothing checked. A corrupted or mis-copied license text shipped silently, which for a legal artifact
is the worst gap on the list.

Each bundled file now carries a phrase it must contain, plus - where a family shares wording -
phrases it must **not**. That second half is load-bearing:

- The GPL family all open with `GNU GENERAL PUBLIC LICENSE`, so a first-line check passes even if
  `gpl-2.0.txt` and `gpl-3.0.txt` are swapped.
- `gpl-2.0.txt` is a **strict subset** of `gpl-2.0-with-classpath-exception.txt` (I composed the
  latter from the former), so *no* single phrase distinguishes it.
- CDDL 1.0 and 1.1 differ mainly in `Sun Microsystems` vs `Oracle` as license steward.

I verified every assertion matches **exactly one** of the 25 texts, then proved the tests bite:
swapping `gpl-2.0.txt` for `gpl-3.0.txt` and `mit.txt` for `mit-0.txt` fails three cases.

Two companions: the identity table must cover exactly the bundled set (so a license added without an
assertion fails), and no two texts may be byte-identical.

## Coverage

- `license_key` was pinned for `mit` and `apache-2.0` only. Now checked for **all 25**, along with
  the text carried under each key.
- Only Apache and MIT ever reached a *generated* report, leaving 23 texts unexercised end to end. A
  functional test now takes an **EPL-1.0** dependency through the real task and asserts the HTML,
  full JSON, CSV and text output - the first end-to-end coverage of CSV and text content.

**459 tests, 0 failures**, from a clean run with the build cache disabled.
