### PR TITLE
Assert what the bundled licenses are, and that they reach every report

### DIFF
--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJavaSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJavaSpec.groovy
@@ -2178,4 +2178,52 @@ final class LicensePluginJavaSpec extends Specification {
   }
 
 
+
+  def 'licenseReport renders a bundled license that is neither Apache nor MIT, in every format'() {
+    given: 'a dependency under EPL-1.0, one of the licenses added in #843'
+    buildFile <<
+      """
+      plugins {
+        id 'java-library'
+        id 'com.jaredsburrows.license'
+      }
+
+      licenseReport {
+        generateCsvReport = true
+        generateTextReport = true
+        generateJsonFullReport = true
+      }
+
+      repositories {
+        maven {
+          url '${mavenRepoUrl}'
+        }
+      }
+
+      dependencies {
+        implementation 'group:eplib:1.0.0'
+      }
+      """
+
+    when:
+    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+
+    then:
+    result.task(':licenseReport').outcome == SUCCESS
+
+    and: 'the HTML inlines the full EPL text rather than only linking to it'
+    def html = new File(reportFolder, 'licenseReport.html').text
+    html.contains('Eclipse Public License - v 1.0')
+    html.contains('EPL library')
+
+    and: 'the full JSON carries it under its own key, not apache-2.0 or mit'
+    def full = new groovy.json.JsonSlurper().parseText(new File(reportFolder, 'licenseReport.full.json').text)
+    full.license_texts.keySet() == ['epl-1.0'] as Set
+    full.dependencies[0].licenses[0].license_key == 'epl-1.0'
+
+    and: 'the CSV and text reports name it too'
+    new File(reportFolder, 'licenseReport.csv').text.contains('Eclipse Public License 1.0')
+    new File(reportFolder, 'licenseReport.txt').text.contains('EPL library')
+  }
+
 }

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/internal/LicenseHelperSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/internal/LicenseHelperSpec.groovy
@@ -608,4 +608,84 @@ final class LicenseHelperSpec extends Specification {
     'MIT 0'       || 'mit-0.txt'
   }
 
+  @Unroll
+  def 'the bundled text really is #fileName, not another license'() {
+    given: 'the phrase, together with what must be absent, identifies exactly one bundled license'
+    def text = HELPER.licenseText(fileName)
+
+    expect:
+    text.contains(mustContain)
+    mustNotContain.every { !text.contains(it) }
+
+    where:
+    fileName | mustContain | mustNotContain
+    '0bsd.txt'                             | 'BSD Zero Clause License'                               | []
+    'agpl-3.0.txt'                         | 'Version 3, 19 November 2007'                           | []
+    'apache-1.1.txt'                       | 'The Apache Software License, Version 1.1'              | []
+    'apache-2.0.txt'                       | 'Version 2.0, January 2004'                             | []
+    'bsd-2-clause.txt'                     | 'BSD 2-Clause License'                                  | []
+    'bsd-3-clause.txt'                     | 'BSD 3-Clause License'                                  | []
+    'bsd-4-clause.txt'                     | 'BSD 4-Clause License'                                  | []
+    'cc-by-4.0.txt'                        | 'Attribution 4.0 International'                         | ['ShareAlike']
+    'cc-by-sa-4.0.txt'                     | 'Attribution-ShareAlike 4.0 International'              | []
+    'cc0-1.0.txt'                          | 'CC0 1.0 Universal'                                     | []
+    'cddl-1.0.txt'                         | 'Sun Microsystems, Inc. is the initial license steward' | []
+    'cddl-1.1.txt'                         | 'Oracle is the initial license steward'                 | []
+    'epl-1.0.txt'                          | 'Eclipse Public License - v 1.0'                        | []
+    'epl-2.0.txt'                          | 'Eclipse Public License - v 2.0'                        | []
+    'gpl-2.0-with-classpath-exception.txt' | 'CLASSPATH EXCEPTION'                                   | []
+    'gpl-2.0.txt'                          | 'Version 2, June 1991'                                  | ['CLASSPATH EXCEPTION', 'LIBRARY GENERAL PUBLIC LICENSE']
+    'gpl-3.0.txt'                          | 'Version 3, 29 June 2007'                               | ['LESSER GENERAL PUBLIC LICENSE']
+    'isc.txt'                              | 'ISC License'                                           | []
+    'lgpl-2.0.txt'                         | 'GNU LIBRARY GENERAL PUBLIC LICENSE'                    | []
+    'lgpl-2.1.txt'                         | 'Version 2.1, February 1999'                            | []
+    'lgpl-3.0.txt'                         | 'GNU LESSER GENERAL PUBLIC LICENSE'                     | ['Version 2.1, February 1999']
+    'mit-0.txt'                            | 'MIT No Attribution'                                    | []
+    'mit.txt'                              | 'MIT License'                                           | ['No Attribution']
+    'mpl-2.0.txt'                          | 'Mozilla Public License Version 2.0'                    | []
+    'unlicense.txt'                        | 'unencumbered software released into the public domain' | []
+  }
+
+  def 'the identity table covers every bundled license'() {
+    given: 'so a license added without an identity assertion fails here'
+    def asserted = [
+      '0bsd.txt',
+      'agpl-3.0.txt',
+      'apache-1.1.txt',
+      'apache-2.0.txt',
+      'bsd-2-clause.txt',
+      'bsd-3-clause.txt',
+      'bsd-4-clause.txt',
+      'cc-by-4.0.txt',
+      'cc-by-sa-4.0.txt',
+      'cc0-1.0.txt',
+      'cddl-1.0.txt',
+      'cddl-1.1.txt',
+      'epl-1.0.txt',
+      'epl-2.0.txt',
+      'gpl-2.0-with-classpath-exception.txt',
+      'gpl-2.0.txt',
+      'gpl-3.0.txt',
+      'isc.txt',
+      'lgpl-2.0.txt',
+      'lgpl-2.1.txt',
+      'lgpl-3.0.txt',
+      'mit-0.txt',
+      'mit.txt',
+      'mpl-2.0.txt',
+      'unlicense.txt',
+    ] as Set
+
+    expect:
+    asserted == HELPER.bundledFileNames()
+  }
+
+  def 'no two bundled licenses have identical text'() {
+    given: 'a copy-paste that duplicates a license would otherwise ship silently'
+    def texts = HELPER.bundledFileNames().collect { HELPER.licenseText(it) }
+
+    expect:
+    texts.toSet().size() == texts.size()
+  }
+
 }

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/internal/report/JsonFullReportSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/internal/report/JsonFullReportSpec.groovy
@@ -6,6 +6,7 @@ import org.apache.maven.model.Developer
 import org.apache.maven.model.License
 import org.apache.maven.model.Model
 import spock.lang.Specification
+import spock.lang.Unroll
 
 final class JsonFullReportSpec extends Specification {
   private static final String APACHE_URL = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
@@ -129,4 +130,22 @@ final class JsonFullReportSpec extends Specification {
       it.url = url
     }
   }
+
+  @Unroll
+  def 'every bundled license reaches the full report under its own key - #spdxId'() {
+    given: 'the key is the bundled file name without its extension'
+    def projects = [project('P', 'p', [license(spdxId, '')])]
+
+    when:
+    def report = new JsonSlurper().parseText(new JsonFullReport(projects).toString())
+
+    then: 'the dependency points at the key, and the text is carried under it'
+    report.dependencies[0].licenses[0].license_key == expectedKey
+    report.license_texts[expectedKey] == LicenseHelper.INSTANCE.licenseText(expectedKey + '.txt')
+
+    where:
+    spdxId << LicenseHelper.INSTANCE.bundledFileNames().collect { it - '.txt' }
+    expectedKey = spdxId
+  }
+
 }

--- a/gradle-license-plugin/src/test/resources/maven/group/eplib/1.0.0/eplib-1.0.0.pom
+++ b/gradle-license-plugin/src/test/resources/maven/group/eplib/1.0.0/eplib-1.0.0.pom
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Fake dependency for testing - a bundled license that is neither Apache nor MIT -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <!-- The Basics -->
+  <groupId>group</groupId>
+  <artifactId>eplib</artifactId>
+  <version>1.0.0</version>
+  <packaging>jar</packaging>
+
+  <!-- More Project Information -->
+  <name>EPL library</name>
+  <description>Fake dependency under the Eclipse Public License</description>
+
+  <licenses>
+    <license>
+      <name>Eclipse Public License 1.0</name>
+      <url>http://www.eclipse.org/legal/epl-v10.html</url>
+    </license>
+  </licenses>
+</project>


### PR DESCRIPTION
Replaces #847, which conflicted after #846 was squash-merged (its base commits became duplicates).
Rebased onto master, keeping both sides of the overlap: the five audit regression tests that landed
with #846 and the three invariants added here. The diff against master is purely additive - 169
insertions, no deletions.

No behaviour change; this is all test.

Every bug found in the last few PRs shipped for the same reason: **nothing asserted the thing.**

| Bug | Shipped for |
| --- | --- |
| `cc0-1.0.txt` bundled but unreachable | ~3 years |
| GPL/LGPL text silently truncated in HTML | unknown |
| hamcrest reported under the wrong BSD variant | unknown |
| A case in #843 pinning a *miss* as correct | mine, one PR |

So these are **invariants**, not more examples - the aim is to stop the class of mistake being
expressible.

## Identity: is `epl-1.0.txt` actually the EPL?

Nothing checked. A corrupted or mis-copied license text shipped silently, which for a legal artifact
is the worst gap on the list.

Each bundled file now carries a phrase it must contain, plus - where a family shares wording -
phrases it must **not**. That second half is load-bearing:

- The GPL family all open with `GNU GENERAL PUBLIC LICENSE`, so a first-line check passes even if
  `gpl-2.0.txt` and `gpl-3.0.txt` are swapped.
- `gpl-2.0.txt` is a **strict subset** of `gpl-2.0-with-classpath-exception.txt` (I composed the
  latter from the former), so *no* single phrase distinguishes it.
- CDDL 1.0 and 1.1 differ mainly in `Sun Microsystems` vs `Oracle` as license steward.

I verified every assertion matches **exactly one** of the 25 texts, then proved the tests bite:
swapping `gpl-2.0.txt` for `gpl-3.0.txt` and `mit.txt` for `mit-0.txt` fails three cases.

Two companions: the identity table must cover exactly the bundled set (so a license added without an
assertion fails), and no two texts may be byte-identical.

## Coverage

- `license_key` was pinned for `mit` and `apache-2.0` only. Now checked for **all 25**, along with
  the text carried under each key.
- Only Apache and MIT ever reached a *generated* report, leaving 23 texts unexercised end to end. A
  functional test now takes an **EPL-1.0** dependency through the real task and asserts the HTML,
  full JSON, CSV and text output - the first end-to-end coverage of CSV and text content.

**472 tests, 0 failures**, from a clean run with the build cache disabled.
