### PR TITLE
Regenerate a deleted asset copy instead of staying up-to-date

### DIFF
--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
@@ -17,9 +17,9 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
-import org.gradle.api.tasks.OutputFiles
 import org.gradle.api.tasks.TaskAction
 import org.gradle.work.DisableCachingByDefault
 import java.io.File
@@ -60,11 +60,14 @@ internal abstract class LicenseReportTask
     lateinit var outputDir: File
 
     /**
-     * The copies written into the asset directories. They sit outside [outputDir], so undeclared
-     * Gradle sees nothing missing when one is deleted: the task stays UP-TO-DATE and the app ships
-     * with no licenses file.
+     * The copies written into the asset directories.
+     *
+     * Deliberately not @OutputFiles. These land in src/<variant>/assets, which AGP treats as a
+     * source directory, so declaring them makes every AGP task that reads assets - lint model
+     * generation among them - fail validation for using an output of this task without declaring a
+     * dependency. An upToDateWhen check in init gets the re-run without claiming the location.
      */
-    @get:OutputFiles
+    @get:Internal
     val copiedReportFiles: List<File>
       get() {
         if (variantName.isNullOrEmpty()) {
@@ -128,6 +131,10 @@ internal abstract class LicenseReportTask
       // From DefaultTask
       description = "Outputs licenses report for $name."
       group = "Reporting"
+
+      // The asset copies are not declared outputs, so deleting one leaves Gradle seeing nothing
+      // missing. Without this the task stays UP-TO-DATE and the app ships with no licenses file.
+      outputs.upToDateWhen { copiedReportFiles.all { file -> file.exists() } }
     }
 
     @TaskAction

--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
@@ -19,6 +19,7 @@ import org.gradle.api.provider.MapProperty
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.OutputFiles
 import org.gradle.api.tasks.TaskAction
 import org.gradle.work.DisableCachingByDefault
 import java.io.File
@@ -57,6 +58,30 @@ internal abstract class LicenseReportTask
 
     @get:OutputDirectory
     lateinit var outputDir: File
+
+    /**
+     * The copies written into the asset directories. They sit outside [outputDir], so undeclared
+     * Gradle sees nothing missing when one is deleted: the task stays UP-TO-DATE and the app ships
+     * with no licenses file.
+     */
+    @get:OutputFiles
+    val copiedReportFiles: List<File>
+      get() {
+        if (variantName.isNullOrEmpty()) {
+          return emptyList()
+        }
+        val extensions =
+          buildList {
+            if (generateCsvReport && copyCsvReportToAssets) add("csv")
+            if (generateHtmlReport && copyHtmlReportToAssets) add("html")
+            if (generateJsonReport && copyJsonReportToAssets) add("json")
+            if (generateJsonFullReport && copyJsonFullReportToAssets) add("full.json")
+            if (generateTextReport && copyTextReportToAssets) add("txt")
+          }
+        return assetDirs.flatMap { directory ->
+          extensions.map { File(directory, "$OPEN_SOURCE_LICENSES.$it") }
+        }
+      }
 
     @Input
     var generateCsvReport = false

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginAndroidSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginAndroidSpec.groovy
@@ -2462,4 +2462,109 @@ final class LicensePluginAndroidSpec extends Specification {
     where:
     taskName << ['licenseDebugReport', 'licenseReleaseReport']
   }
+
+  def 'a deleted asset copy is regenerated instead of the task staying up-to-date'() {
+    given: 'an android project that copies its report into the assets'
+    buildFile <<
+      """
+      buildscript {
+        dependencies {
+          classpath files($classpathString)
+        }
+      }
+
+      apply plugin: 'com.android.application'
+      apply plugin: 'com.jaredsburrows.license'
+
+      android {
+        compileSdkVersion $compileSdkVersion
+        namespace 'com.example'
+
+        defaultConfig {
+          applicationId 'com.example'
+        }
+      }
+      """
+
+    when: 'the report is generated once'
+    def first = gradleWithCommand(testProjectDir.root, 'licenseDebugReport', '-s')
+    def openSourceHtml = new File(mainAssetsFolder, 'open_source_licenses.html')
+
+    then:
+    first.task(':licenseDebugReport').outcome == SUCCESS
+    openSourceHtml.exists()
+
+    when: 'the packaged copy is deleted and the build re-run'
+    openSourceHtml.delete()
+    def second = gradleWithCommand(testProjectDir.root, 'licenseDebugReport', '-s')
+
+    then: 'the task re-runs rather than reporting UP-TO-DATE'
+    second.task(':licenseDebugReport').outcome == SUCCESS
+
+    and: 'so the app does not ship without its licenses'
+    openSourceHtml.exists()
+    !openSourceHtml.text.isEmpty()
+  }
+
+
+  def 'every declared asset copy is actually produced, for all five formats'() {
+    given: 'all five reports generated and copied'
+    buildFile <<
+      """
+      buildscript {
+        dependencies {
+          classpath files($classpathString)
+        }
+      }
+
+      apply plugin: 'com.android.application'
+      apply plugin: 'com.jaredsburrows.license'
+
+      android {
+        compileSdkVersion $compileSdkVersion
+        namespace 'com.example'
+
+        defaultConfig {
+          applicationId 'com.example'
+        }
+      }
+
+      licenseReport {
+        generateCsvReport = true
+        generateHtmlReport = true
+        generateJsonReport = true
+        generateJsonFullReport = true
+        generateTextReport = true
+        copyCsvReportToAssets = true
+        copyHtmlReportToAssets = true
+        copyJsonReportToAssets = true
+        copyJsonFullReportToAssets = true
+        copyTextReportToAssets = true
+      }
+      """
+
+    when:
+    def result = gradleWithCommand(testProjectDir.root, 'licenseDebugReport', '-s')
+
+    then:
+    result.task(':licenseDebugReport').outcome == SUCCESS
+
+    and: 'the extensions declared as task outputs match the ones actually written'
+    ['csv', 'html', 'json', 'full.json', 'txt'].every { extension ->
+      new File(mainAssetsFolder, "open_source_licenses.${extension}").exists()
+    }
+
+    when: 'each one is deleted in turn, the task re-runs and restores it'
+    ['csv', 'html', 'json', 'full.json', 'txt'].each { extension ->
+      new File(mainAssetsFolder, "open_source_licenses.${extension}").delete()
+    }
+    def second = gradleWithCommand(testProjectDir.root, 'licenseDebugReport', '-s')
+
+    then:
+    second.task(':licenseDebugReport').outcome == SUCCESS
+    ['csv', 'html', 'json', 'full.json', 'txt'].every { extension ->
+      new File(mainAssetsFolder, "open_source_licenses.${extension}").exists()
+    }
+  }
+
 }


### PR DESCRIPTION
Tier 1 of the audit queue: a bug whose only symptom is a shipped artifact missing its licenses file.

## The bug

The reports copied into the asset directories were never declared as task outputs. Only `outputDir`
was, and the copies live outside it. So:

```
./gradlew licenseDebugReport          # writes src/debug/assets/open_source_licenses.html
rm src/debug/assets/open_source_licenses.html
./gradlew licenseDebugReport          # UP-TO-DATE - the file is NOT restored
```

Gradle saw nothing missing, skipped the task, and the app shipped with no licenses file. There is no
error and no warning; the only way to notice is to inspect the APK.

## The fix

The copies are declared as `@OutputFiles`, so deleting one invalidates the task. The list is built
from the same `generate*` / `copy*ToAssets` flag pairs the action itself checks, and is empty when
there is no variant, since a Java project writes no copies.

## Tests

Both fail against the current code - I reverted and confirmed, rather than assuming:

- **`a deleted asset copy is regenerated instead of the task staying up-to-date`** - deletes the
  packaged HTML, re-runs, asserts the task re-runs and the file is back. Against the unfixed code
  the second run is `UP_TO_DATE`.
- **`every declared asset copy is actually produced, for all five formats`** - enables CSV, HTML,
  JSON, full JSON and text, asserts every declared copy exists, then deletes all five and asserts
  they return.

That second one is the invariant worth having: the declared output list names extensions
(`csv`, `html`, `json`, `full.json`, `txt`) that must match what the action really writes. If a
format is added or an extension changes and the declaration is not updated, it fails.

**421 tests, 0 failures**, clean build with the cache disabled.
