### PR TITLE
Close the POM reader, and stop swallowing parse failures in silence

### DIFF
--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
@@ -1,6 +1,7 @@
 package com.jaredsburrows.license
 
 import com.jaredsburrows.license.internal.ConsoleRenderer
+import com.jaredsburrows.license.internal.readPom
 import com.jaredsburrows.license.internal.report.CsvReport
 import com.jaredsburrows.license.internal.report.HtmlReport
 import com.jaredsburrows.license.internal.report.JsonFullReport
@@ -11,7 +12,6 @@ import org.apache.maven.model.Developer
 import org.apache.maven.model.License
 import org.apache.maven.model.Model
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader
-import org.codehaus.plexus.util.ReaderFactory
 import org.gradle.api.DefaultTask
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
@@ -585,10 +585,7 @@ internal abstract class LicenseReportTask
       pomFile: File,
     ): Model? =
       try {
-        // use{}: the reader owns the file handle, and a report over a large graph parses thousands
-        // of POMs. Leaked handles exhaust the descriptor limit, and the failure then arrives here
-        // as an exception and is reported as "no license" rather than as the resource problem.
-        ReaderFactory.newXmlReader(pomFile).use { reader -> mavenReader.read(reader, false) }
+        mavenReader.readPom(pomFile)
       } catch (e: Exception) {
         logger.warn("Failed to read POM file '$pomFile': ${e.shortMessage()}")
         null

--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
@@ -585,7 +585,10 @@ internal abstract class LicenseReportTask
       pomFile: File,
     ): Model? =
       try {
-        mavenReader.read(ReaderFactory.newXmlReader(pomFile), false)
+        // use{}: the reader owns the file handle, and a report over a large graph parses thousands
+        // of POMs. Leaked handles exhaust the descriptor limit, and the failure then arrives here
+        // as an exception and is reported as "no license" rather than as the resource problem.
+        ReaderFactory.newXmlReader(pomFile).use { reader -> mavenReader.read(reader, false) }
       } catch (e: Exception) {
         logger.warn("Failed to read POM file '$pomFile': ${e.shortMessage()}")
         null

--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/Project.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/Project.kt
@@ -1,7 +1,7 @@
 package com.jaredsburrows.license
 
+import com.jaredsburrows.license.internal.readPom
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader
-import org.codehaus.plexus.util.ReaderFactory
 import org.gradle.api.Project
 import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
@@ -29,7 +29,7 @@ private fun Project.resolveParentPomFilesBreadthFirst(
     pomFilesToInspect.forEach { pomFile ->
       val model =
         try {
-          ReaderFactory.newXmlReader(pomFile).use { reader -> mavenReader.read(reader, false) }
+          mavenReader.readPom(pomFile)
         } catch (e: Exception) {
           // Previously swallowed in silence, so a descriptor exhaustion or a corrupt POM looked
           // exactly like a dependency that simply declares no parent.

--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/Project.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/Project.kt
@@ -29,8 +29,11 @@ private fun Project.resolveParentPomFilesBreadthFirst(
     pomFilesToInspect.forEach { pomFile ->
       val model =
         try {
-          mavenReader.read(ReaderFactory.newXmlReader(pomFile), false)
-        } catch (_: Exception) {
+          ReaderFactory.newXmlReader(pomFile).use { reader -> mavenReader.read(reader, false) }
+        } catch (e: Exception) {
+          // Previously swallowed in silence, so a descriptor exhaustion or a corrupt POM looked
+          // exactly like a dependency that simply declares no parent.
+          logger.warn("Failed to read POM file '$pomFile' while resolving parents: ${e.message}")
           return@forEach
         }
 

--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/internal/PomReader.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/internal/PomReader.kt
@@ -1,0 +1,16 @@
+package com.jaredsburrows.license.internal
+
+import org.apache.maven.model.Model
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader
+import org.codehaus.plexus.util.ReaderFactory
+import java.io.File
+
+/**
+ * Parse [pomFile], always closing the reader.
+ *
+ * The two callers - parent resolution at configuration time and the report itself at execution
+ * time - recover differently, so the error policy stays with them and this throws. What they must
+ * not differ on is the file handle: both leaked one per POM until they were fixed together, which
+ * is the reason this is shared rather than written twice.
+ */
+internal fun MavenXpp3Reader.readPom(pomFile: File): Model = ReaderFactory.newXmlReader(pomFile).use { read(it, false) }


### PR DESCRIPTION
Tier 1 of the audit queue. Measured, not inferred.

## The leak

Both places that parse a POM handed a fresh `Reader` to `MavenXpp3Reader` and never closed it:

```kotlin
mavenReader.read(ReaderFactory.newXmlReader(pomFile), false)
```

I measured it rather than reasoning about it - one `licenseDebugReport` run over a *single* test app,
counting what the daemon still holds afterwards:

| | open `.pom` descriptors held by the daemon |
| --- | --- |
| with the fix | **0** |
| without | **300** |

A real multi-module Android graph parses far more, every variant repeats it, and the daemon is
long-lived, so they accumulate across builds.

## Why it matters more than a leak

When the descriptor limit is reached, the failing `open` lands in the existing `catch` and the
dependency is reported as **having no license**. So the symptom of running out of file handles is a
quietly incomplete license report - no error, no warning, just missing attribution. Silent and wrong
is the combination this plugin can least afford.

## The silent swallow

`Project.kt` caught the failure and returned with **no diagnostic at all**:

```kotlin
} catch (_: Exception) {
  return@forEach
}
```

So a corrupt POM and an exhausted descriptor table looked identical to a dependency that simply
declares no parent. It now warns with the file and the cause.

## Verification

- **474 tests, 0 failures**, clean build with the cache disabled.
- `./gradlew -p test-apps build` green, and the three apps still emit reports of the expected size
  (46 KB / 26 KB / 32 KB). I ran that because #849 taught me the TestKit suite does not exercise a
  real AGP build, and `Project.kt` runs during configuration.

**On test coverage, honestly:** there is no unit test for the leak itself. A deterministic
descriptor-count assertion would be fragile and platform-specific, so the evidence here is the
measurement above plus the existing suite proving no behavioural regression. I would rather say that
than add a flaky test that looks like a guard and is not one.
