### PR TITLE
Support dynamic feature and Kotlin Multiplatform android library modules

### DIFF
--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/ProjectAndroid.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/ProjectAndroid.kt
@@ -2,6 +2,8 @@ package com.jaredsburrows.license
 
 import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import com.android.build.api.variant.Component
+import com.android.build.api.variant.DynamicFeatureAndroidComponentsExtension
+import com.android.build.api.variant.KotlinMultiplatformAndroidComponentsExtension
 import com.android.build.api.variant.LibraryAndroidComponentsExtension
 import com.android.build.api.variant.TestAndroidComponentsExtension
 import com.android.build.api.variant.Variant
@@ -21,6 +23,10 @@ internal fun Project.isAndroidProject(): Boolean =
       "com.android.library",
       // TestPlugin
       "com.android.test",
+      // DynamicFeaturePlugin
+      "com.android.dynamic-feature",
+      // KotlinMultiplatformAndroidPlugin
+      "com.android.kotlin.multiplatform.library",
     ),
   )
 
@@ -37,6 +43,8 @@ internal fun Project.isAndroidProject(): Boolean =
  * AppPlugin - "android", "com.android.application"
  * LibraryPlugin - "android-library", "com.android.library"
  * TestPlugin - "com.android.test"
+ * DynamicFeaturePlugin - "com.android.dynamic-feature"
+ * KotlinMultiplatformAndroidPlugin - "com.android.kotlin.multiplatform.library"
  */
 internal fun Project.configureAndroidProject() {
   // A project applies exactly one Android module plugin, but a single applied plugin can match
@@ -55,6 +63,8 @@ internal fun Project.configureAndroidProject() {
   plugins.withId("com.android.library") { once { configureLibraryVariants() } }
   plugins.withId("android-library") { once { configureLibraryVariants() } }
   plugins.withId("com.android.test") { once { configureTestVariants() } }
+  plugins.withId("com.android.dynamic-feature") { once { configureDynamicFeatureVariants() } }
+  plugins.withId("com.android.kotlin.multiplatform.library") { once { configureKotlinMultiplatformVariants() } }
 }
 
 private fun Project.configureApplicationVariants() =
@@ -70,6 +80,16 @@ private fun Project.configureLibraryVariants() =
 private fun Project.configureTestVariants() =
   extensions
     .getByType(TestAndroidComponentsExtension::class.java)
+    .run { onVariants(selector().all()) { configureVariant(it) } }
+
+private fun Project.configureDynamicFeatureVariants() =
+  extensions
+    .getByType(DynamicFeatureAndroidComponentsExtension::class.java)
+    .run { onVariants(selector().all()) { configureVariant(it) } }
+
+private fun Project.configureKotlinMultiplatformVariants() =
+  extensions
+    .getByType(KotlinMultiplatformAndroidComponentsExtension::class.java)
     .run { onVariants(selector().all()) { configureVariant(it) } }
 
 /**

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginAndroidSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginAndroidSpec.groovy
@@ -2567,4 +2567,85 @@ final class LicensePluginAndroidSpec extends Specification {
     }
   }
 
+
+  def 'licenseDebugReport supports a dynamic feature module'() {
+    given: 'an app with a dynamic feature module, both applying the plugin'
+    testProjectDir.newFile('settings.gradle') <<
+      """
+      include 'feature'
+      """
+    testProjectDir.newFolder('feature')
+    testProjectDir.newFile('feature/build.gradle') <<
+      """
+      apply plugin: 'com.android.dynamic-feature'
+      apply plugin: 'com.jaredsburrows.license'
+
+      android {
+        compileSdk = $compileSdkVersion
+        namespace 'com.example.feature'
+      }
+      """
+
+    buildFile <<
+      """
+      buildscript {
+        dependencies {
+          classpath files($classpathString)
+        }
+      }
+
+      apply plugin: 'com.android.application'
+      apply plugin: 'com.jaredsburrows.license'
+
+      android {
+        compileSdk = $compileSdkVersion
+        namespace 'com.example'
+
+        defaultConfig {
+          applicationId 'com.example'
+        }
+
+        dynamicFeatures = [':feature']
+      }
+      """
+
+    when: 'the report task is run on the dynamic feature module'
+    def result = gradleWithCommand(testProjectDir.root, ':feature:licenseDebugReport', '-s')
+
+    then: 'applying the plugin does not fail the build'
+    result.task(':feature:licenseDebugReport').outcome == SUCCESS
+  }
+
+  def 'licenseReport supports a kotlin multiplatform android library module'() {
+    given: 'a module using AGP\'s KMP android library plugin'
+    buildFile <<
+      """
+      buildscript {
+        dependencies {
+          classpath files($classpathString)
+        }
+      }
+
+      apply plugin: 'org.jetbrains.kotlin.multiplatform'
+      apply plugin: 'com.android.kotlin.multiplatform.library'
+      apply plugin: 'com.jaredsburrows.license'
+
+      kotlin {
+        androidLibrary {
+          namespace = 'com.example.kmp'
+          compileSdk = $compileSdkVersion
+        }
+      }
+      """
+
+    when: 'the plugin is applied'
+    def result = gradleWithCommand(testProjectDir.root, 'tasks', '--all', '-s')
+
+    then: 'it does not fail with the unsupported-project error'
+    !result.output.contains('requires Java, Kotlin or Android Gradle based plugins')
+
+    and: 'a report task is registered for the android target'
+    result.output.contains('licenseAndroidMainReport')
+  }
+
 }


### PR DESCRIPTION
Tier 2. Applying the plugin to a `com.android.dynamic-feature` module failed the build outright:

```
'com.jaredsburrows.license' requires Java, Kotlin or Android Gradle based plugins.
```

`isAndroidProject()` listed only the application, library and test ids, so a dynamic feature fell
through to the `afterEvaluate` branch, was not a Java project either, and threw. The same happened
for `com.android.kotlin.multiplatform.library`.

## Which module types actually exist

Rather than guess, I enumerated what AGP 9.3.2 publishes. It registers 12 plugin ids, but only
**six** types in `com.android.build.api.variant`:

| Extension | Before |
| --- | --- |
| `ApplicationAndroidComponentsExtension` | supported |
| `LibraryAndroidComponentsExtension` | supported |
| `TestAndroidComponentsExtension` | supported |
| `DynamicFeatureAndroidComponentsExtension` | **missing - the crash** |
| `KotlinMultiplatformAndroidComponentsExtension` | **missing** |
| `AndroidComponentsExtension` | base type |

Both fit the existing shape without changing it - `DynamicFeatureVariant extends Variant` and
`KotlinMultiplatformAndroidVariant extends LibraryVariant` - so `onVariants(selector().all())` and
the nested-component walk work unchanged.

## Not added, deliberately

`com.android.fused-library`, `asset-pack`, `asset-pack-bundle` and `ai-pack` register plugin ids, but
their extensions live in `com.android.build.api.dsl` with **no variant API to hook**, and the pack
plugins carry assets rather than code dependencies. `com.android.lint` is standalone lint on a JVM
module and `com.android.base` is applied by the others rather than being a module type.

## Tests

Both fail against the current code with the error above - written first, then fixed.

- **dynamic feature**: a real two-module build, app plus `:feature` with `dynamicFeatures = [':feature']`,
  running `:feature:licenseDebugReport` and asserting it succeeds.
- **KMP android library**: applies `org.jetbrains.kotlin.multiplatform` then the AGP KMP library
  plugin, and asserts **`licenseAndroidMainReport` is registered** - so it proves a task appears,
  not merely that nothing threw. (My first version only asserted the absence of the error message,
  which would have passed for the wrong reasons.)

**476 tests, 0 failures**, clean cache-disabled run, and `./gradlew -p test-apps build` green.
