### PR TITLE
Stop attributing BOMs and platforms in the report

### DIFF
--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/Project.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/Project.kt
@@ -6,11 +6,28 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.artifacts.result.ResolvedArtifactResult
+import org.gradle.api.artifacts.result.ResolvedComponentResult
 import org.gradle.api.reporting.ReportingExtension
 import org.gradle.maven.MavenModule
 import org.gradle.maven.MavenPomArtifact
 import java.io.File
 import java.security.MessageDigest
+
+/**
+ * A BOM or platform ships no code, so it must not be attributed. Every variant Gradle selected for
+ * one is categorised platform or enforced-platform.
+ *
+ * Deliberately not a `packaging == "pom"` check: that is not the same question. kotlinx-coroutines-core,
+ * kotlinx-serialization-core, kotlin-stdlib-common 2.x and com.android.tools.build:aapt2 all declare
+ * pom packaging while carrying code, so filtering on it drops real libraries from the report.
+ */
+private fun ResolvedComponentResult.isPlatform(): Boolean =
+  variants.isNotEmpty() &&
+    variants.all { variant ->
+      val key = variant.attributes.keySet().firstOrNull { it.name == "org.gradle.category" }
+      val category = key?.let { variant.attributes.getAttribute(it)?.toString() }
+      category == "platform" || category == "enforced-platform"
+    }
 
 /** Returns true if plugin exists in project. */
 internal fun Project.hasPlugin(list: List<String>): Boolean = list.any { plugins.hasPlugin(it) }
@@ -190,6 +207,7 @@ private fun Project.buildPomInput(configurationNames: List<String>): PomInput {
         .incoming
         .resolutionResult
         .allComponents
+        .filterNot { it.isPlatform() }
         .map { it.id }
         .filterIsInstance<ModuleComponentIdentifier>()
         .forEach { componentIdentifiers += it }

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJavaSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJavaSpec.groovy
@@ -2260,4 +2260,40 @@ final class LicensePluginJavaSpec extends Specification {
     json.contains('group:ktxlib-ktx:1.0.0')
   }
 
+
+  def 'licenseReport does not attribute a BOM, which ships no code'() {
+    given: 'a platform dependency alongside a real library it constrains'
+    buildFile <<
+      """
+      plugins {
+        id 'java-library'
+        id 'com.jaredsburrows.license'
+      }
+
+      repositories {
+        maven {
+          url '${mavenRepoUrl}'
+        }
+      }
+
+      dependencies {
+        implementation platform('group:bom:1.0.0')
+        implementation 'group:name:1.0.0'
+      }
+      """
+
+    when:
+    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    def json = new File(reportFolder, 'licenseReport.json').text
+
+    then:
+    result.task(':licenseReport').outcome == SUCCESS
+
+    and: 'the library it constrains is attributed'
+    json.contains('group:name:1.0.0')
+
+    and: 'the BOM itself is not - it carries no code to attribute'
+    !json.contains('group:bom:1.0.0')
+  }
+
 }

--- a/gradle-license-plugin/src/test/resources/maven/group/bom/1.0.0/bom-1.0.0.pom
+++ b/gradle-license-plugin/src/test/resources/maven/group/bom/1.0.0/bom-1.0.0.pom
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Fake BOM for testing - ships no code, so it must not be attributed in a report -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>group</groupId>
+  <artifactId>bom</artifactId>
+  <version>1.0.0</version>
+  <packaging>pom</packaging>
+
+  <name>Fake BOM</name>
+  <description>Fake platform that only constrains versions</description>
+
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>group</groupId>
+        <artifactId>name</artifactId>
+        <version>1.0.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>


### PR DESCRIPTION
First of Tier 3. A BOM ships no code, so listing one in an open-source notice screen is wrong output.

Your own test app reported three:

```
androidx.compose:compose-bom:2026.08.00
org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.9.0
org.jetbrains.kotlinx:kotlinx-serialization-bom:1.7.3
```

## The obvious fix is wrong, and I tried it first

`packaging == "pom"` looks like the answer and is a different question. **Pom packaging does not mean
"no code"** - all of these declare it while carrying code:

- `org.jetbrains.kotlinx:kotlinx-coroutines-core`
- `org.jetbrains.kotlinx:kotlinx-serialization-core`
- `org.jetbrains.kotlin:kotlin-stdlib-common:2.4.10` (1.9.10 was `jar`)
- `com.android.tools.build:aapt2` - pom packaging *and* ships `aapt2-9.3.2-osx.jar`

Applying that filter removed `kotlinx-coroutines-core` and `kotlinx-serialization-core` from the
report. They *appeared* to survive only because `deduplicate()` had their `-jvm` siblings in the
graph to fall back on - luck, not design. A KMP root without a co-resolved platform sibling would
vanish outright. **Dropping an attributed library is the worst direction for this plugin to fail in**,
so this would have traded a cosmetic wrong-row for a missing-attribution bug.

## What this does instead

Filters at resolution time on the Gradle **category attribute**, which is `platform` or
`enforced-platform` for every variant Gradle selects for a platform. That also covers Maven-only BOMs
with no Gradle module metadata, because Gradle synthesises a platform variant from
`dependencyManagement`.

## Measured, not inferred

Regenerating the test app's report, before and after:

| | entries | BOMs | `coroutines-core` | `serialization-core` |
| --- | --- | --- | --- | --- |
| before | 68 | 3 | present | present |
| after | **65** | **0** | **present** | **present** |

Exactly the three BOMs removed, and the pom-packaged code-bearing libraries kept.

## Tests

New fixture `group:bom:1.0.0` with `<packaging>pom</packaging>` and a `dependencyManagement` block.
The test declares `implementation platform('group:bom:1.0.0')` alongside the library it constrains,
and asserts the library **is** attributed and the platform **is not**. It fails without the change.

**478 tests, 0 failures**, clean cache-disabled run, and `./gradlew -p test-apps build` green.
