### PR TITLE
Inherit url, description, inception year and developers from the parent POM

### DIFF
--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
@@ -231,17 +231,23 @@ internal abstract class LicenseReportTask
             licenses = mutableListOf()
           }
 
+          // Maven inherits description, url, inceptionYear and developers from the parent, the
+          // way licenses already were. Materialised once rather than walked per field, so a
+          // dependency with a parent is not re-parsed four times.
+          val chain = parentChain(mavenReader, pomFile, loggedMissingParentPomCoordinates).toList()
+
           val project =
             Model().apply {
               this.groupId = groupId
               this.artifactId = artifactId
               this.version = version
+              // name is deliberately not inherited: Maven does not inherit it either.
               this.name = model.pomName(mavenReader, pomFile, loggedMissingParentPomCoordinates)
-              this.description = model.pomDescription()
-              this.url = model.pomUrl()
-              this.inceptionYear = model.pomInceptionYear()
+              this.description = chain.inherited { it.description }
+              this.url = chain.inherited { it.url }
+              this.inceptionYear = chain.inherited { it.inceptionYear }
               this.licenses = licenses
-              this.developers = model.pomDevelopers()
+              this.developers = chain.inheritedDevelopers()
             }
 
           projects += project
@@ -538,18 +544,19 @@ internal abstract class LicenseReportTask
         }.toMap()
     }
 
-    private fun Model.pomDescription(): String = description.orEmpty().trim()
+    /** The value from the nearest POM in the chain that states it, as Maven inherits it. */
+    private fun List<Pair<File, Model>>.inherited(field: (Model) -> String?): String =
+      firstNotNullOfOrNull { (_, model) -> field(model).orEmpty().trim().ifEmpty { null } }.orEmpty()
 
-    private fun Model.pomUrl(): String = url.orEmpty().trim()
-
-    private fun Model.pomInceptionYear(): String = inceptionYear.orEmpty().trim()
-
-    private fun Model.pomDevelopers(): List<Developer> =
-      developers.orEmpty().map { developer ->
-        Developer().apply {
-          id = developer.name.orEmpty().trim()
+    /** Developers from the nearest POM in the chain that declares any. */
+    private fun List<Pair<File, Model>>.inheritedDevelopers(): List<Developer> =
+      firstNotNullOfOrNull { (_, model) -> model.developers?.takeIf { it.isNotEmpty() } }
+        .orEmpty()
+        .map { developer ->
+          Developer().apply {
+            id = developer.name.orEmpty().trim()
+          }
         }
-      }
 
     /**
      * Parent POM resolution is performed outside the task; this only looks up the already-provided mapping.

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJavaSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJavaSpec.groovy
@@ -2217,7 +2217,7 @@ final class LicensePluginJavaSpec extends Specification {
     html.contains('EPL library')
 
     and: 'the full JSON carries it under its own key, not apache-2.0 or mit'
-    def full = new groovy.json.JsonSlurper().parseText(new File(reportFolder, 'licenseReport.full.json').text)
+    def full = new JsonSlurper().parseText(new File(reportFolder, 'licenseReport.full.json').text)
     full.license_texts.keySet() == ['epl-1.0'] as Set
     full.dependencies[0].licenses[0].license_key == 'epl-1.0'
 
@@ -2283,7 +2283,7 @@ final class LicensePluginJavaSpec extends Specification {
 
     when:
     def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
-    def json = new groovy.json.JsonSlurper().parseText(new File(reportFolder, 'licenseReport.json').text)
+    def json = new JsonSlurper().parseText(new File(reportFolder, 'licenseReport.json').text)
     def entry = json.find { it.dependency == 'group:inheritchild:1.0.0' }
 
     then:

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJavaSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJavaSpec.groovy
@@ -2260,4 +2260,44 @@ final class LicensePluginJavaSpec extends Specification {
     json.contains('group:ktxlib-ktx:1.0.0')
   }
 
+
+  def 'licenseReport inherits url, description, inception year and developers from a parent POM'() {
+    given: 'a dependency whose POM declares none of them and relies on its parent'
+    buildFile <<
+      """
+      plugins {
+        id 'java-library'
+        id 'com.jaredsburrows.license'
+      }
+
+      repositories {
+        maven {
+          url '${mavenRepoUrl}'
+        }
+      }
+
+      dependencies {
+        implementation 'group:inheritchild:1.0.0'
+      }
+      """
+
+    when:
+    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    def json = new groovy.json.JsonSlurper().parseText(new File(reportFolder, 'licenseReport.json').text)
+    def entry = json.find { it.dependency == 'group:inheritchild:1.0.0' }
+
+    then:
+    result.task(':licenseReport').outcome == SUCCESS
+    entry != null
+
+    and: 'Maven inherits these four, so the report shows the parent values instead of blanks'
+    entry.description == 'Inherited description'
+    entry.url == 'https://github.com/user/inherited'
+    entry.year == '2011'
+    entry.developers == ['Inherited Developer']
+
+    and: 'name is NOT inherited in Maven, so it still falls back to the artifact id'
+    entry.project == 'inheritchild'
+  }
+
 }

--- a/gradle-license-plugin/src/test/resources/maven/group/inheritchild/1.0.0/inheritchild-1.0.0.pom
+++ b/gradle-license-plugin/src/test/resources/maven/group/inheritchild/1.0.0/inheritchild-1.0.0.pom
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Fake child for testing - declares none of the inheritable metadata itself -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>group</groupId>
+    <artifactId>inheritparent</artifactId>
+    <version>1.0.0</version>
+  </parent>
+
+  <artifactId>inheritchild</artifactId>
+  <version>1.0.0</version>
+  <packaging>jar</packaging>
+</project>

--- a/gradle-license-plugin/src/test/resources/maven/group/inheritparent/1.0.0/inheritparent-1.0.0.pom
+++ b/gradle-license-plugin/src/test/resources/maven/group/inheritparent/1.0.0/inheritparent-1.0.0.pom
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Fake parent for testing - declares the metadata Maven inherits -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>group</groupId>
+  <artifactId>inheritparent</artifactId>
+  <version>1.0.0</version>
+  <packaging>pom</packaging>
+
+  <name>Inherited parent name</name>
+  <description>Inherited description</description>
+  <url>https://github.com/user/inherited</url>
+  <inceptionYear>2011</inceptionYear>
+
+  <developers>
+    <developer>
+      <name>Inherited Developer</name>
+    </developer>
+  </developers>
+
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+</project>


### PR DESCRIPTION
Tier 3. Maven inherits `url`, `description`, `inceptionYear` and `developers` from a parent POM.
`licenses` was already read from the parent chain; these four were read only from the dependency's
own POM, so a dependency using the common parent-POM pattern reported blanks for metadata its POM
does define, one level up.

The inconsistency shows up plainly in the failing test - the Apache license came through from the
parent while every other field was null:

```
[project:inheritchild, description:null, url:null, year:null, developers:[],
 licenses:[[license:The Apache Software License ...]]]
```

## How common is it

Scanned the 1555 POMs in the local Gradle cache:

| | |
| --- | --- |
| POMs with a `<parent>` | 348 |
| ...omitting at least one of the four | **300** |

So roughly **a fifth of real POMs** stand to gain a field. On this repo's own test app the effect is
smaller, because androidx POMs mostly declare their own metadata: blank urls 1 -> 0, blank years
9 -> 8, dependencies with no developers 2 -> 1.

## Two deliberate decisions

- **`name` is not inherited.** Maven does not inherit it either, so it still falls back to the
  artifact id. The test asserts that explicitly, so nobody "fixes" it later.
- **The chain is materialised once per dependency**, not walked per field. Four lazy walks would
  re-parse the same POM four times over, since each stops at the first POM stating its own field.

The four `Model.pomX()` helpers are replaced rather than left behind, so nothing is orphaned the way
`pomVersion()` was by an earlier PR.

## Tests

New fixtures: `inheritchild` declares none of the four; `inheritparent` declares all of them. The
test asserts all four come through **and** that `name` still falls back to the artifact id. It fails
without the change.

No existing expectation moves - the existing `child`/`childa`/`childb` fixtures declare their own
metadata, so they never exercised inheritance, which is why this went unnoticed.

**478 tests, 0 failures**, clean cache-disabled run, and `./gradlew -p test-apps build` green.
