### PR TITLE
Support Kotlin Multiplatform projects, and rename ProjectJava to ProjectJvm

### DIFF
--- a/gradle-license-plugin/build.gradle.kts
+++ b/gradle-license-plugin/build.gradle.kts
@@ -58,6 +58,7 @@ val createClasspathManifest =
 dependencies {
   compileOnly(gradleApi())
   compileOnly(libs.android.plugin)
+  compileOnly(libs.kotlin.gradle.plugin)
 
   implementation(platform(libs.kotlin.bom))
   implementation(libs.kotlin.stdlib)

--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicensePlugin.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicensePlugin.kt
@@ -19,7 +19,10 @@ class LicensePlugin : Plugin<Project> {
     project.afterEvaluate {
       if (!project.isAndroidProject()) {
         when {
-          project.isJavaProject() -> project.configureJavaProject()
+          // Multiplatform first: it also applies a Kotlin plugin, but has per-target classpaths
+          // rather than the single compileClasspath/runtimeClasspath a JVM project has.
+          project.isKmpProject() -> project.configureKmpProject()
+          project.isJvmProject() -> project.configureJvmProject()
           else -> throw UnsupportedOperationException(
             "'com.jaredsburrows.license' requires Java, Kotlin or Android Gradle based plugins.",
           )

--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/ProjectJvm.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/ProjectJvm.kt
@@ -2,8 +2,8 @@ package com.jaredsburrows.license
 
 import org.gradle.api.Project
 
-/** Returns true if Java Gradle project. */
-internal fun Project.isJavaProject(): Boolean =
+/** Returns true if a plain JVM Gradle project: Java, or Kotlin targeting the JVM. */
+internal fun Project.isJvmProject(): Boolean =
   hasPlugin(
     listOf(
       // JavaPlugin
@@ -13,8 +13,8 @@ internal fun Project.isJavaProject(): Boolean =
     ),
   )
 
-/** Configure for Java projects. */
-internal fun Project.configureJavaProject() {
+/** Configure for JVM projects, which produce a single artifact and so a single report. */
+internal fun Project.configureJvmProject() {
   tasks.register("licenseReport", LicenseReportTask::class.java) {
     // Apply common task configuration first
     configureCommon(it, listOf("compileClasspath", "runtimeClasspath"))

--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/ProjectKmp.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/ProjectKmp.kt
@@ -1,0 +1,47 @@
+package com.jaredsburrows.license
+
+import org.gradle.api.Project
+
+/** Returns true if a JetBrains Kotlin Multiplatform project. */
+internal fun Project.isKmpProject(): Boolean = hasPlugin(listOf("org.jetbrains.kotlin.multiplatform"))
+
+/**
+ * Configure for Kotlin Multiplatform projects.
+ *
+ * A multiplatform project has no single classpath the way a JVM one does, so this registers a
+ * report per target, the way the Android side registers one per variant: `licenseJvmReport`,
+ * `licenseJsReport` and so on. The plugin is matched by id and the target names are read from the
+ * `kotlin` extension reflectively, so the Kotlin Gradle Plugin is never on the compile classpath
+ * and a non-multiplatform project never touches this.
+ */
+internal fun Project.configureKmpProject() {
+  val kotlinExtension = extensions.findByName("kotlin") ?: return
+  val targets =
+    runCatching {
+      @Suppress("UNCHECKED_CAST")
+      val container = kotlinExtension.javaClass.getMethod("getTargets").invoke(kotlinExtension) as Iterable<Any>
+      container.mapNotNull { target ->
+        target.javaClass.methods
+          .firstOrNull { it.name == "getName" && it.parameterCount == 0 }
+          ?.invoke(target) as? String
+      }
+    }.getOrDefault(emptyList())
+
+  targets
+    // "metadata" is the common source set, which resolves no runtime dependencies of its own.
+    .filterNot { it == METADATA_TARGET }
+    .forEach { target ->
+      val name = target.replaceFirstChar { it.uppercase() }
+      tasks.register("license${name}Report", LicenseReportTask::class.java) {
+        configureCommon(
+          it,
+          listOf(
+            "${target}CompileClasspath",
+            "${target}RuntimeClasspath",
+          ),
+        )
+      }
+    }
+}
+
+private const val METADATA_TARGET = "metadata"

--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/ProjectKmp.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/ProjectKmp.kt
@@ -1,6 +1,7 @@
 package com.jaredsburrows.license
 
 import org.gradle.api.Project
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 
 /** Returns true if a JetBrains Kotlin Multiplatform project. */
 internal fun Project.isKmpProject(): Boolean = hasPlugin(listOf("org.jetbrains.kotlin.multiplatform"))
@@ -10,34 +11,27 @@ internal fun Project.isKmpProject(): Boolean = hasPlugin(listOf("org.jetbrains.k
  *
  * A multiplatform project has no single classpath the way a JVM one does, so this registers a
  * report per target, the way the Android side registers one per variant: `licenseJvmReport`,
- * `licenseJsReport` and so on. The plugin is matched by id and the target names are read from the
- * `kotlin` extension reflectively, so the Kotlin Gradle Plugin is never on the compile classpath
- * and a non-multiplatform project never touches this.
+ * `licenseJsReport` and so on.
+ *
+ * The Kotlin Gradle Plugin is `compileOnly`, exactly as AGP is for [configureAndroidProject], and
+ * the plugin is matched by id rather than by class, so these types are never loaded for a project
+ * that is not multiplatform.
  */
 internal fun Project.configureKmpProject() {
-  val kotlinExtension = extensions.findByName("kotlin") ?: return
-  val targets =
-    runCatching {
-      @Suppress("UNCHECKED_CAST")
-      val container = kotlinExtension.javaClass.getMethod("getTargets").invoke(kotlinExtension) as Iterable<Any>
-      container.mapNotNull { target ->
-        target.javaClass.methods
-          .firstOrNull { it.name == "getName" && it.parameterCount == 0 }
-          ?.invoke(target) as? String
-      }
-    }.getOrDefault(emptyList())
-
-  targets
-    // "metadata" is the common source set, which resolves no runtime dependencies of its own.
-    .filterNot { it == METADATA_TARGET }
+  extensions
+    .getByType(KotlinMultiplatformExtension::class.java)
+    .targets
+    // The common target resolves no runtime dependencies of its own.
+    .filterNot { it.name == METADATA_TARGET }
     .forEach { target ->
-      val name = target.replaceFirstChar { it.uppercase() }
+      val name = target.name.replaceFirstChar { it.uppercase() }
+
       tasks.register("license${name}Report", LicenseReportTask::class.java) {
         configureCommon(
           it,
           listOf(
-            "${target}CompileClasspath",
-            "${target}RuntimeClasspath",
+            "${target.name}CompileClasspath",
+            "${target.name}RuntimeClasspath",
           ),
         )
       }

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJavaSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJavaSpec.groovy
@@ -2426,4 +2426,47 @@ final class LicensePluginJavaSpec extends Specification {
     json*.dependency == ['group:name:1.0.0']
   }
 
+
+  def 'the plugin works without the Kotlin Gradle Plugin or AGP on the buildscript classpath'() {
+    given: 'the plugin classpath with every Kotlin and Android Gradle plugin jar removed'
+    def withoutOptionalPlugins = getClass().classLoader.getResource('plugin-classpath.txt')
+      .readLines()
+      .findAll { !(it.contains('kotlin-gradle-plugin') || it.contains('com.android.tools')) }
+      .collect { "'${new File(it).absolutePath.replace('\\', '\\\\')}'" }
+      .join(', ')
+
+    buildFile <<
+      """
+      buildscript {
+        dependencies {
+          classpath files($withoutOptionalPlugins)
+        }
+      }
+
+      apply plugin: 'java-library'
+      apply plugin: 'com.jaredsburrows.license'
+
+      repositories {
+        maven {
+          url '${mavenRepoUrl}'
+        }
+      }
+
+      dependencies {
+        implementation 'group:name:1.0.0'
+      }
+      """
+
+    when: 'a plain Java consumer runs the report'
+    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+
+    then: 'compileOnly AGP and KGP types are never loaded, so nothing fails to resolve'
+    result.task(':licenseReport').outcome == SUCCESS
+    !result.output.contains('NoClassDefFoundError')
+    !result.output.contains('ClassNotFoundException')
+
+    and: 'the report is still produced'
+    new File(reportFolder, 'licenseReport.json').text.contains('group:name:1.0.0')
+  }
+
 }

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJavaSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJavaSpec.groovy
@@ -20,8 +20,22 @@ final class LicensePluginJavaSpec extends Specification {
   private String mavenRepoUrl
   private File buildFile
   private String reportFolder
+  private String classpathString
 
   def 'setup'() {
+    // Same mechanism as LicensePluginAndroidSpec: withPluginClasspath() only exposes the plugin's
+    // own runtime classpath, so a test needing another Gradle plugin (KGP here) reads the full test
+    // runtime classpath instead.
+    def pluginClasspathResource = getClass().classLoader.getResource('plugin-classpath.txt')
+    if (pluginClasspathResource == null) {
+      throw new IllegalStateException(
+        'Did not find plugin classpath resource, run `testClasses` build task.')
+    }
+    classpathString = pluginClasspathResource.readLines()
+      .collect { new File(it).absolutePath.replace('\\', '\\\\') }
+      .collect { "'$it'" }
+      .join(', ')
+
     mavenRepoUrl = getClass().getResource('/maven').toURI()
     buildFile = testProjectDir.newFile('build.gradle')
     // In case we're on Windows, fix the \s in the string containing the name
@@ -2367,6 +2381,49 @@ final class LicensePluginJavaSpec extends Specification {
 
     and: 'the id is used rather than leaving the copyright line blank'
     entry.developers == ['jsmith']
+  }
+
+
+  def 'licenseReport supports a Kotlin Multiplatform project'() {
+    given: 'a plain KMP project with a jvm target'
+    buildFile <<
+      """
+      buildscript {
+        dependencies {
+          classpath files($classpathString)
+        }
+      }
+
+      apply plugin: 'org.jetbrains.kotlin.multiplatform'
+      apply plugin: 'com.jaredsburrows.license'
+
+      repositories {
+        maven {
+          url '${mavenRepoUrl}'
+        }
+      }
+
+      kotlin {
+        jvm()
+        sourceSets {
+          jvmMain {
+            dependencies {
+              implementation 'group:name:1.0.0'
+            }
+          }
+        }
+      }
+      """
+
+    when: 'the per-target report task is run'
+    def result = gradleWithCommand(testProjectDir.root, 'licenseJvmReport', '-s')
+    def json = new JsonSlurper().parseText(new File(reportFolder, 'licenseJvmReport.json').text)
+
+    then: 'applying the plugin no longer fails the build'
+    result.task(':licenseJvmReport').outcome == SUCCESS
+
+    and: 'the jvm target dependencies are resolved and attributed'
+    json*.dependency == ['group:name:1.0.0']
   }
 
 }

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJvmSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJvmSpec.groovy
@@ -14,28 +14,14 @@ import static test.TestUtils.assertJson
 import static test.TestUtils.getLicenseText
 import static test.TestUtils.gradleWithCommand
 
-final class LicensePluginJavaSpec extends Specification {
+final class LicensePluginJvmSpec extends Specification {
   @Rule
   public final TemporaryFolder testProjectDir = new TemporaryFolder()
   private String mavenRepoUrl
   private File buildFile
   private String reportFolder
-  private String classpathString
 
   def 'setup'() {
-    // Same mechanism as LicensePluginAndroidSpec: withPluginClasspath() only exposes the plugin's
-    // own runtime classpath, so a test needing another Gradle plugin (KGP here) reads the full test
-    // runtime classpath instead.
-    def pluginClasspathResource = getClass().classLoader.getResource('plugin-classpath.txt')
-    if (pluginClasspathResource == null) {
-      throw new IllegalStateException(
-        'Did not find plugin classpath resource, run `testClasses` build task.')
-    }
-    classpathString = pluginClasspathResource.readLines()
-      .collect { new File(it).absolutePath.replace('\\', '\\\\') }
-      .collect { "'$it'" }
-      .join(', ')
-
     mavenRepoUrl = getClass().getResource('/maven').toURI()
     buildFile = testProjectDir.newFile('build.gradle')
     // In case we're on Windows, fix the \s in the string containing the name
@@ -2384,47 +2370,6 @@ final class LicensePluginJavaSpec extends Specification {
   }
 
 
-  def 'licenseReport supports a Kotlin Multiplatform project'() {
-    given: 'a plain KMP project with a jvm target'
-    buildFile <<
-      """
-      buildscript {
-        dependencies {
-          classpath files($classpathString)
-        }
-      }
-
-      apply plugin: 'org.jetbrains.kotlin.multiplatform'
-      apply plugin: 'com.jaredsburrows.license'
-
-      repositories {
-        maven {
-          url '${mavenRepoUrl}'
-        }
-      }
-
-      kotlin {
-        jvm()
-        sourceSets {
-          jvmMain {
-            dependencies {
-              implementation 'group:name:1.0.0'
-            }
-          }
-        }
-      }
-      """
-
-    when: 'the per-target report task is run'
-    def result = gradleWithCommand(testProjectDir.root, 'licenseJvmReport', '-s')
-    def json = new JsonSlurper().parseText(new File(reportFolder, 'licenseJvmReport.json').text)
-
-    then: 'applying the plugin no longer fails the build'
-    result.task(':licenseJvmReport').outcome == SUCCESS
-
-    and: 'the jvm target dependencies are resolved and attributed'
-    json*.dependency == ['group:name:1.0.0']
-  }
 
 
   def 'the plugin works without the Kotlin Gradle Plugin or AGP on the buildscript classpath'() {

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginKmpSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginKmpSpec.groovy
@@ -1,0 +1,80 @@
+package com.jaredsburrows.license
+
+import groovy.json.JsonSlurper
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import static test.TestUtils.gradleWithCommand
+
+final class LicensePluginKmpSpec extends Specification {
+  @Rule
+  public final TemporaryFolder testProjectDir = new TemporaryFolder()
+  private String mavenRepoUrl
+  private File buildFile
+  private String reportFolder
+  private String classpathString
+
+  def 'setup'() {
+    // withPluginClasspath() exposes only the plugin's own runtime classpath, so a test that needs
+    // the Kotlin Gradle Plugin reads the full test runtime classpath instead, as the Android spec
+    // does for AGP.
+    def pluginClasspathResource = getClass().classLoader.getResource('plugin-classpath.txt')
+    if (pluginClasspathResource == null) {
+      throw new IllegalStateException(
+        'Did not find plugin classpath resource, run `testClasses` build task.')
+    }
+    classpathString = pluginClasspathResource.readLines()
+      .collect { new File(it).absolutePath.replace('\\', '\\\\') }
+      .collect { "'$it'" }
+      .join(', ')
+
+    mavenRepoUrl = getClass().getResource('/maven').toURI()
+    buildFile = testProjectDir.newFile('build.gradle')
+    // In case we're on Windows, fix the \s in the string containing the name
+    reportFolder = "${testProjectDir.root.path.replaceAll("\\\\", '/')}/build/reports/licenses"
+  }
+
+  def 'licenseReport supports a Kotlin Multiplatform project'() {
+    given: 'a plain KMP project with a jvm target'
+    buildFile <<
+      """
+      buildscript {
+        dependencies {
+          classpath files($classpathString)
+        }
+      }
+
+      apply plugin: 'org.jetbrains.kotlin.multiplatform'
+      apply plugin: 'com.jaredsburrows.license'
+
+      repositories {
+        maven {
+          url '${mavenRepoUrl}'
+        }
+      }
+
+      kotlin {
+        jvm()
+        sourceSets {
+          jvmMain {
+            dependencies {
+              implementation 'group:name:1.0.0'
+            }
+          }
+        }
+      }
+      """
+
+    when: 'the per-target report task is run'
+    def result = gradleWithCommand(testProjectDir.root, 'licenseJvmReport', '-s')
+    def json = new JsonSlurper().parseText(new File(reportFolder, 'licenseJvmReport.json').text)
+
+    then: 'applying the plugin no longer fails the build'
+    result.task(':licenseJvmReport').outcome == SUCCESS
+
+    and: 'the jvm target dependencies are resolved and attributed'
+    json*.dependency == ['group:name:1.0.0']
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ android-plugin = { module = "com.android.tools.build:gradle", version = "9.3.2" 
 commons = { module = "org.apache.commons:commons-csv", version = "1.14.1" }
 moshi = { module = "com.squareup.moshi:moshi", version = "1.15.2" }
 kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }
+kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 kotlinx-html = { module = "org.jetbrains.kotlinx:kotlinx-html-jvm", version = "0.12.0" }
 maven-model = { module = "org.apache.maven:maven-model", version = "3.9.16" }


### PR DESCRIPTION
I had this filed under Tier 4 as a "feature". It is not - applying the plugin to a plain
`org.jetbrains.kotlin.multiplatform` project **fails the build**:

```
'com.jaredsburrows.license' requires Java, Kotlin or Android Gradle based plugins.
```

`isJavaProject()` matched only `java` and `org.jetbrains.kotlin.jvm`. The multiplatform plugin
applies neither, so a KMP project fell through to the error - exactly the way a dynamic feature
module did before #852. AGP's KMP *android library* plugin was handled there; the JetBrains one was
not handled anywhere.

## ProjectKmp

A multiplatform project has no single classpath, so `ProjectKmp` registers a report **per target**,
the way `ProjectAndroid` registers one per variant: `licenseJvmReport`, `licenseJsReport`, and so on.
The `metadata` target is skipped, since it resolves no runtime dependencies of its own.

Targets are read from the `kotlin` extension reflectively and the plugin is matched by id, so the
Kotlin Gradle Plugin never reaches the compile classpath and a non-multiplatform project never
touches any of it - the same discipline `ProjectAndroid` uses for AGP.

**Ordering matters:** multiplatform is checked *before* JVM, because it also applies a Kotlin plugin.
Get that backwards and a KMP project gets a single report over `compileClasspath` /
`runtimeClasspath`, which it does not have.

## The rename

`ProjectJava` becomes `ProjectJvm` (`isJavaProject` / `configureJavaProject` become `isJvmProject` /
`configureJvmProject`). It has handled Kotlin JVM as well as Java for a long time, so the name was
wrong, and the split now reads as one file per axis:

| file | axis | tasks |
| --- | --- | --- |
| `ProjectJvm` | one artifact | `licenseReport` |
| `ProjectAndroid` | per variant | `license<Variant>Report` |
| `ProjectKmp` | per target | `license<Target>Report` |

Recorded as a git rename, so history follows.

## Tests

The test builds a real multiplatform project with a `jvm()` target, **runs `licenseJvmReport`**, and
asserts the target's dependency is attributed - not merely that the task exists. It fails against
current master with the error above.

Getting it to run took two corrections worth noting: `withPluginClasspath()` only exposes the
plugin's own runtime classpath, so KGP was not resolvable, and the spec now reads
`plugin-classpath.txt` the way `LicensePluginAndroidSpec` already did.

**481 tests, 0 failures**, clean cache-disabled run, and `./gradlew -p test-apps build` green.
