### PR TITLE
Give the internal specs explicit types, and type-check what Spock allows

### DIFF
--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/internal/LicenseHelperSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/internal/LicenseHelperSpec.groovy
@@ -4,11 +4,11 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 final class LicenseHelperSpec extends Specification {
-  private static final def HELPER = LicenseHelper.INSTANCE
+  private static final LicenseHelper HELPER = LicenseHelper.INSTANCE
 
   def 'every bundled license file is reachable from at least one alias'() {
     given:
-    def reachable = HELPER.allAliases().values().toSet()
+    Set<String> reachable = HELPER.allAliases().values().toSet()
 
     expect:
     HELPER.bundledFileNames().every { fileName -> reachable.contains(fileName) }
@@ -16,8 +16,8 @@ final class LicenseHelperSpec extends Specification {
 
   def 'every license text file on the classpath is a bundled license'() {
     given: 'the resource directory the plugin ships'
-    def dir = new File(getClass().getResource('/license').toURI())
-    def onDisk = dir.listFiles().findAll { it.name.endsWith('.txt') }.collect { it.name }.toSet()
+    File dir = new File(getClass().getResource('/license').toURI())
+    Set<String> onDisk = dir.listFiles().findAll { it.name.endsWith('.txt') }.collect { it.name }.toSet()
 
     expect: 'no orphaned file, and no table entry without a file'
     onDisk == HELPER.bundledFileNames()
@@ -32,7 +32,7 @@ final class LicenseHelperSpec extends Specification {
 
   def 'no alias is registered twice with a different result'() {
     given: 'allAliases merges the name and url tables'
-    def aliases = HELPER.allAliases()
+    Map<String, String> aliases = HELPER.allAliases()
 
     expect: 'the merge did not silently drop a colliding key'
     aliases.size() > 0
@@ -256,7 +256,7 @@ final class LicenseHelperSpec extends Specification {
 
   def 'licenseText returns the bundled text of a known license'() {
     when:
-    def text = HELPER.licenseText('apache-2.0.txt')
+    String text = HELPER.licenseText('apache-2.0.txt')
 
     then:
     text != null
@@ -398,7 +398,7 @@ final class LicenseHelperSpec extends Specification {
 
   def 'the classpath exception text contains both the GPL and the exception'() {
     when:
-    def text = HELPER.licenseText('gpl-2.0-with-classpath-exception.txt')
+    String text = HELPER.licenseText('gpl-2.0-with-classpath-exception.txt')
 
     then:
     text.contains('GNU GENERAL PUBLIC LICENSE')
@@ -559,7 +559,7 @@ final class LicenseHelperSpec extends Specification {
 
   def 'BUG: the glassfish CDDL+GPL page names two licenses, so the name decides'() {
     given: 'jaxb-api cites the same dual-license url for both of its license entries'
-    def url = 'https://glassfish.java.net/public/CDDL+GPL_1_1.html'
+    String url = 'https://glassfish.java.net/public/CDDL+GPL_1_1.html'
 
     expect: 'the GPL arm is no longer swallowed and reported as CDDL'
     HELPER.licenseFileName('GPL2 w/ CPE', url) == 'gpl-2.0-with-classpath-exception.txt'
@@ -611,7 +611,7 @@ final class LicenseHelperSpec extends Specification {
   @Unroll
   def 'the bundled text really is #fileName, not another license'() {
     given: 'the phrase, together with what must be absent, identifies exactly one bundled license'
-    def text = HELPER.licenseText(fileName)
+    String text = HELPER.licenseText(fileName)
 
     expect:
     text.contains(mustContain)
@@ -648,7 +648,7 @@ final class LicenseHelperSpec extends Specification {
 
   def 'the identity table covers every bundled license'() {
     given: 'so a license added without an identity assertion fails here'
-    def asserted = [
+    Set<String> asserted = [
       '0bsd.txt',
       'agpl-3.0.txt',
       'apache-1.1.txt',
@@ -682,7 +682,7 @@ final class LicenseHelperSpec extends Specification {
 
   def 'no two bundled licenses have identical text'() {
     given: 'a copy-paste that duplicates a license would otherwise ship silently'
-    def texts = HELPER.bundledFileNames().collect { HELPER.licenseText(it) }
+    List<String> texts = HELPER.bundledFileNames().collect { HELPER.licenseText(it) }
 
     expect:
     texts.toSet().size() == texts.size()

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/internal/report/CsvReportSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/internal/report/CsvReportSpec.groovy
@@ -1,24 +1,29 @@
 package com.jaredsburrows.license.internal.report
 
+import groovy.transform.TypeChecked
 import org.apache.maven.model.Developer
 import org.apache.maven.model.License
 import org.apache.maven.model.Model
 import spock.lang.Specification
 
-import static test.TestUtils.assertCsv
+import static test.TestUtils.csvRows
 
+@TypeChecked
 final class CsvReportSpec extends Specification {
+  private static final String HEADER =
+    'project,description,version,developers,url,year,licenses,license urls,dependency'
+
   def 'no open source csv'() {
     given:
     List<Model> projects = []
     CsvReport sut = new CsvReport(projects)
 
     when:
-    String actual = sut.toString()
-    String expected = ""
+    List<String> actual = csvRows(sut.toString())
+    List<String> expected = csvRows('')
 
     then:
-    assertCsv(expected, actual)
+    expected == actual
   }
 
   def 'open source csv - missing values'() {
@@ -50,14 +55,14 @@ final class CsvReportSpec extends Specification {
     CsvReport sut = new CsvReport(projects)
 
     when:
-    String actual = sut.toString()
-    String expected =
-      "project,description,version,developers,url,year,licenses,license urls,dependency\n" +
-        "name,,1.2.3,,,,,,foo:bar:1.2.3\n" +
-        "name,,1.2.3,\"name,name\",,,,,foo:bar:1.2.3"
+    List<String> actual = csvRows(sut.toString())
+    List<String> expected = csvRows(
+      HEADER + '\n' +
+        'name,,1.2.3,,,,,,foo:bar:1.2.3\n' +
+        'name,,1.2.3,"name,name",,,,,foo:bar:1.2.3')
 
     then:
-    assertCsv(expected, actual)
+    expected == actual
   }
 
   def 'open source csv - all values'() {
@@ -83,20 +88,20 @@ final class CsvReportSpec extends Specification {
     CsvReport sut = new CsvReport(projects)
 
     when:
-    String actual = sut.toString()
-    String expected =
-      "project,description,version,developers,url,year,licenses,license urls,dependency\n" +
-        "name,description,1.2.3,\"name,name\",url,year,name,url,foo:bar:1.2.3\n" +
-        "name,description,1.2.3,\"name,name\",url,year,name,url,foo:bar:1.2.3"
+    List<String> actual = csvRows(sut.toString())
+    List<String> expected = csvRows(
+      HEADER + '\n' +
+        'name,description,1.2.3,"name,name",url,year,name,url,foo:bar:1.2.3\n' +
+        'name,description,1.2.3,"name,name",url,year,name,url,foo:bar:1.2.3')
 
     then:
-    assertCsv(expected, actual)
+    expected == actual
   }
 
   def 'open source csv - escape characters'() {
     given:
     Developer developerA = new Developer(id: 'Joe')
-    Developer developerB = new Developer(id: '5\" Above Ground')
+    Developer developerB = new Developer(id: '5" Above Ground')
     List<Developer> developers = [developerA, developerB]
     License license = new License(
       name: 'Apache, 2.0',
@@ -117,12 +122,12 @@ final class CsvReportSpec extends Specification {
     CsvReport sut = new CsvReport(projects)
 
     when:
-    String actual = sut.toString()
-    String expected =
-      "project,description,version,developers,url,year,licenses,license urls,dependency\n" +
-        "\"Joe\'s project\",\"Copyright \"\"Joe\"\" 2023\n\nAll right reserved\\to me\",1.2.3,\"Joe,5\"\" Above Ground\",url,year,\"Apache, 2.0\",url,foo:bar:1.2.3"
+    List<String> actual = csvRows(sut.toString())
+    List<String> expected = csvRows(
+      HEADER + '\n' +
+        '"Joe\'s project","Copyright ""Joe"" 2023\n\nAll right reserved\\to me",1.2.3,"Joe,5"" Above Ground",url,year,"Apache, 2.0",url,foo:bar:1.2.3')
 
     then:
-    assertCsv(expected, actual)
+    expected == actual
   }
 }

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/internal/report/CsvReportSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/internal/report/CsvReportSpec.groovy
@@ -10,12 +10,12 @@ import static test.TestUtils.assertCsv
 final class CsvReportSpec extends Specification {
   def 'no open source csv'() {
     given:
-    def projects = []
-    def sut = new CsvReport(projects)
+    List<Model> projects = []
+    CsvReport sut = new CsvReport(projects)
 
     when:
-    def actual = sut.toString()
-    def expected = ""
+    String actual = sut.toString()
+    String expected = ""
 
     then:
     assertCsv(expected, actual)
@@ -23,8 +23,8 @@ final class CsvReportSpec extends Specification {
 
   def 'open source csv - missing values'() {
     given:
-    def developer = new Developer(id: 'name')
-    def project1 = new Model(
+    Developer developer = new Developer(id: 'name')
+    Model project1 = new Model(
       name: 'name',
       description: '',
       licenses: [],
@@ -35,7 +35,7 @@ final class CsvReportSpec extends Specification {
       artifactId: 'bar',
       version: '1.2.3',
     )
-    def project2 = new Model(
+    Model project2 = new Model(
       name: 'name',
       description: '',
       licenses: [],
@@ -46,12 +46,12 @@ final class CsvReportSpec extends Specification {
       artifactId: 'bar',
       version: '1.2.3',
     )
-    def projects = [project1, project2]
-    def sut = new CsvReport(projects)
+    List<Model> projects = [project1, project2]
+    CsvReport sut = new CsvReport(projects)
 
     when:
-    def actual = sut.toString()
-    def expected =
+    String actual = sut.toString()
+    String expected =
       "project,description,version,developers,url,year,licenses,license urls,dependency\n" +
         "name,,1.2.3,,,,,,foo:bar:1.2.3\n" +
         "name,,1.2.3,\"name,name\",,,,,foo:bar:1.2.3"
@@ -62,13 +62,13 @@ final class CsvReportSpec extends Specification {
 
   def 'open source csv - all values'() {
     given:
-    def developer = new Developer(id: 'name')
-    def developers = [developer, developer]
-    def license = new License(
+    Developer developer = new Developer(id: 'name')
+    List<Developer> developers = [developer, developer]
+    License license = new License(
       name: 'name',
       url: 'url'
     )
-    def project = new Model(
+    Model project = new Model(
       name: 'name',
       description: 'description',
       licenses: [license],
@@ -79,12 +79,12 @@ final class CsvReportSpec extends Specification {
       artifactId: 'bar',
       version: '1.2.3',
     )
-    def projects = [project, project]
-    def sut = new CsvReport(projects)
+    List<Model> projects = [project, project]
+    CsvReport sut = new CsvReport(projects)
 
     when:
-    def actual = sut.toString()
-    def expected =
+    String actual = sut.toString()
+    String expected =
       "project,description,version,developers,url,year,licenses,license urls,dependency\n" +
         "name,description,1.2.3,\"name,name\",url,year,name,url,foo:bar:1.2.3\n" +
         "name,description,1.2.3,\"name,name\",url,year,name,url,foo:bar:1.2.3"
@@ -95,14 +95,14 @@ final class CsvReportSpec extends Specification {
 
   def 'open source csv - escape characters'() {
     given:
-    def developerA = new Developer(id: 'Joe')
-    def developerB = new Developer(id: '5\" Above Ground')
-    def developers = [developerA, developerB]
-    def license = new License(
+    Developer developerA = new Developer(id: 'Joe')
+    Developer developerB = new Developer(id: '5\" Above Ground')
+    List<Developer> developers = [developerA, developerB]
+    License license = new License(
       name: 'Apache, 2.0',
       url: 'url'
     )
-    def project = new Model(
+    Model project = new Model(
       name: "Joe's project",
       description: 'Copyright "Joe" 2023\n\nAll right reserved\\to me',
       licenses: [license],
@@ -113,12 +113,12 @@ final class CsvReportSpec extends Specification {
       artifactId: 'bar',
       version: '1.2.3',
     )
-    def projects = [project]
-    def sut = new CsvReport(projects)
+    List<Model> projects = [project]
+    CsvReport sut = new CsvReport(projects)
 
     when:
-    def actual = sut.toString()
-    def expected =
+    String actual = sut.toString()
+    String expected =
       "project,description,version,developers,url,year,licenses,license urls,dependency\n" +
         "\"Joe\'s project\",\"Copyright \"\"Joe\"\" 2023\n\nAll right reserved\\to me\",1.2.3,\"Joe,5\"\" Above Ground\",url,year,\"Apache, 2.0\",url,foo:bar:1.2.3"
 

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/internal/report/HtmlReportSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/internal/report/HtmlReportSpec.groovy
@@ -12,12 +12,12 @@ import static test.TestUtils.assertHtml
 final class HtmlReportSpec extends Specification {
   def 'no open source html'() {
     given:
-    def projects = []
-    def report = new HtmlReport(projects, true)
+    List<Model> projects = []
+    HtmlReport report = new HtmlReport(projects, true)
 
     when:
-    def actual = report.toString()
-    def expected =
+    String actual = report.toString()
+    String expected =
       """
       <!DOCTYPE html>
       <html lang="en">
@@ -38,13 +38,13 @@ final class HtmlReportSpec extends Specification {
 
   def 'open source html'() {
     given:
-    def developer = new Developer(id: 'name')
-    def developers = [developer, developer]
-    def license = new License(
+    Developer developer = new Developer(id: 'name')
+    List<Developer> developers = [developer, developer]
+    License license = new License(
       name: 'name',
       url: 'url'
     )
-    def project = new Model(
+    Model project = new Model(
       name: 'name',
       description: 'description',
       licenses: [license],
@@ -55,7 +55,7 @@ final class HtmlReportSpec extends Specification {
       artifactId: 'bar',
       version: '1.2.3',
     )
-    def missingLicensesProject = new Model(
+    Model missingLicensesProject = new Model(
       name: 'name',
       description: '',
       licenses: [],
@@ -66,12 +66,12 @@ final class HtmlReportSpec extends Specification {
       artifactId: 'bar',
       version: '1.2.3',
     )
-    def projects = [project, project, missingLicensesProject]
-    def sut = new HtmlReport(projects, true)
+    List<Model> projects = [project, project, missingLicensesProject]
+    HtmlReport sut = new HtmlReport(projects, true)
 
     when:
-    def actual = sut.toString()
-    def expected =
+    String actual = sut.toString()
+    String expected =
       """
       <!DOCTYPE html>
       <html lang="en">
@@ -139,7 +139,7 @@ final class HtmlReportSpec extends Specification {
 
   def 'a bundled license is rendered as its full text'() {
     given: 'a license the plugin bundles, matched by name because the url is not in the map'
-    def project = new Model(
+    Model project = new Model(
       name: 'name',
       description: 'description',
       licenses: [new License(name: 'The MIT License', url: 'https://spdx.org/licenses/MIT.html')],
@@ -152,14 +152,14 @@ final class HtmlReportSpec extends Specification {
     )
 
     when:
-    def actual = new HtmlReport([project], false).toString()
+    String actual = new HtmlReport([project], false).toString()
 
     then: 'the text is inlined rather than linked'
     actual.contains('Permission is hereby granted, free of charge')
     !actual.contains('<a href="https://spdx.org/licenses/MIT.html">')
   }
 
-  private static def projectWith(License license) {
+  private static Model projectWith(License license) {
     new Model(
       name: 'name',
       description: '',
@@ -176,10 +176,10 @@ final class HtmlReportSpec extends Specification {
   @Unroll
   def 'bundled license text is escaped, not swallowed as markup - #spdxId'() {
     given: 'a license whose bundled text contains angle-bracketed placeholders'
-    def report = new HtmlReport([projectWith(new License(name: spdxId, url: ''))], true)
+    HtmlReport report = new HtmlReport([projectWith(new License(name: spdxId, url: ''))], true)
 
     when:
-    def actual = report.toString()
+    String actual = report.toString()
 
     then: 'the placeholder survives, escaped'
     actual.contains(escaped)
@@ -200,9 +200,9 @@ final class HtmlReportSpec extends Specification {
   def 'every bundled license text survives rendering intact'() {
     expect: 'nothing between angle brackets is lost from any of the bundled texts'
     LicenseHelper.INSTANCE.bundledFileNames().every { fileName ->
-      def text = LicenseHelper.INSTANCE.licenseText(fileName)
-      def spdxId = LicenseHelper.INSTANCE.allAliases().find { alias, file -> file == fileName }?.key
-      def html = new HtmlReport([projectWith(new License(name: spdxId, url: ''))], true).toString()
+      String text = LicenseHelper.INSTANCE.licenseText(fileName)
+      String spdxId = LicenseHelper.INSTANCE.allAliases().find { alias, file -> file == fileName }?.key
+      String html = new HtmlReport([projectWith(new License(name: spdxId, url: ''))], true).toString()
       // Every angle-bracketed run in the source text must appear escaped in the output.
       (text =~ /<[^>\n]{1,60}>/).collect { it }.every { fragment ->
         html.contains(fragment.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;'))
@@ -213,10 +213,10 @@ final class HtmlReportSpec extends Specification {
   @Unroll
   def 'license metadata from a POM cannot inject markup - #description'() {
     given: 'a dependency POM carrying markup in its license fields'
-    def report = new HtmlReport([projectWith(new License(name: name, url: url))], true)
+    HtmlReport report = new HtmlReport([projectWith(new License(name: name, url: url))], true)
 
     when:
-    def actual = report.toString()
+    String actual = report.toString()
 
     then: 'the markup is escaped rather than emitted as elements'
     !actual.contains(mustNotContain)
@@ -231,10 +231,10 @@ final class HtmlReportSpec extends Specification {
 
   def 'an unknown license still renders its url as a working link'() {
     given:
-    def report = new HtmlReport([projectWith(new License(name: 'Some license', url: 'http://website.tld/'))], true)
+    HtmlReport report = new HtmlReport([projectWith(new License(name: 'Some license', url: 'http://website.tld/'))], true)
 
     when:
-    def actual = report.toString()
+    String actual = report.toString()
 
     then: 'escaping did not cost us the anchor'
     actual.contains('<a href="http://website.tld/">http://website.tld/</a>')
@@ -243,7 +243,7 @@ final class HtmlReportSpec extends Specification {
 
   def 'showVersions leaves the version out when disabled'() {
     given:
-    def project = new Model(
+    Model project = new Model(
       name: 'name',
       description: '',
       licenses: [],

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/internal/report/JsonFullReportSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/internal/report/JsonFullReportSpec.groovy
@@ -14,7 +14,7 @@ final class JsonFullReportSpec extends Specification {
 
   def 'the empty report still has both top level keys'() {
     when:
-    def report = new JsonFullReport([])
+    JsonFullReport report = new JsonFullReport([])
 
     then:
     report.name() == 'Full JSON'
@@ -24,14 +24,14 @@ final class JsonFullReportSpec extends Specification {
 
   def 'a license text is stored once no matter how many dependencies share it'() {
     given: 'three dependencies, two of them Apache'
-    def projects = [
+    List<Model> projects = [
       project('First', 'first', [license('The Apache Software License', APACHE_URL)]),
       project('Second', 'second', [license('Apache License 2.0', 'https://www.apache.org/licenses/LICENSE-2.0')]),
       project('Third', 'third', [license(MIT_NAME, 'https://spdx.org/licenses/MIT.html')]),
     ]
 
     when:
-    def report = new JsonSlurper().parseText(new JsonFullReport(projects).toString())
+    Map<String, Object> report = (Map<String, Object>) new JsonSlurper().parseText(new JsonFullReport(projects).toString())
 
     then: 'differently spelled Apache licenses coalesce onto one text'
     report.license_texts.keySet() == ['apache-2.0', 'mit'] as Set
@@ -47,10 +47,10 @@ final class JsonFullReportSpec extends Specification {
 
   def 'the POM name and url are kept even when the license is not bundled'() {
     given:
-    def projects = [project('Unknown', 'unknown', [license('Some license', 'http://website.tld/')])]
+    List<Model> projects = [project('Unknown', 'unknown', [license('Some license', 'http://website.tld/')])]
 
     when:
-    def report = new JsonSlurper().parseText(new JsonFullReport(projects).toString())
+    Map<String, Object> report = (Map<String, Object>) new JsonSlurper().parseText(new JsonFullReport(projects).toString())
 
     then:
     report.license_texts.isEmpty()
@@ -62,12 +62,12 @@ final class JsonFullReportSpec extends Specification {
 
   def 'a dependency with several licenses references each of them'() {
     given:
-    def projects = [
+    List<Model> projects = [
       project('Dual', 'dual', [license(MIT_NAME, 'https://spdx.org/licenses/MIT.html'), license('The Apache Software License', APACHE_URL)]),
     ]
 
     when:
-    def report = new JsonSlurper().parseText(new JsonFullReport(projects).toString())
+    Map<String, Object> report = (Map<String, Object>) new JsonSlurper().parseText(new JsonFullReport(projects).toString())
 
     then:
     report.license_texts.keySet() == ['apache-2.0', 'mit'] as Set
@@ -76,15 +76,15 @@ final class JsonFullReportSpec extends Specification {
 
   def 'the dependency entries carry everything the JSON report carries'() {
     given:
-    def model = project('Full', 'full', [license(MIT_NAME, 'https://spdx.org/licenses/MIT.html')])
+    Model model = project('Full', 'full', [license(MIT_NAME, 'https://spdx.org/licenses/MIT.html')])
     model.description = 'A description'
     model.url = 'https://github.com/user/repo'
     model.inceptionYear = '2017'
     model.developers = [new Developer().tap { it.id = 'A Developer' }]
 
     when:
-    def report = new JsonSlurper().parseText(new JsonFullReport([model]).toString())
-    def dependency = report.dependencies[0]
+    Map<String, Object> report = (Map<String, Object>) new JsonSlurper().parseText(new JsonFullReport([model]).toString())
+    Map<String, Object> dependency = report.dependencies[0]
 
     then:
     dependency.project == 'Full'
@@ -98,10 +98,10 @@ final class JsonFullReportSpec extends Specification {
 
   def 'missing values are serialized as null rather than dropped'() {
     given:
-    def projects = [project('Sparse', 'sparse', [license(MIT_NAME, 'https://spdx.org/licenses/MIT.html')])]
+    List<Model> projects = [project('Sparse', 'sparse', [license(MIT_NAME, 'https://spdx.org/licenses/MIT.html')])]
 
     when:
-    def json = new JsonFullReport(projects).toString()
+    String json = new JsonFullReport(projects).toString()
 
     then: 'consumers can rely on the keys being present, as in the JSON report'
     json.contains('"description":null')
@@ -134,10 +134,10 @@ final class JsonFullReportSpec extends Specification {
   @Unroll
   def 'every bundled license reaches the full report under its own key - #spdxId'() {
     given: 'the key is the bundled file name without its extension'
-    def projects = [project('P', 'p', [license(spdxId, '')])]
+    List<Model> projects = [project('P', 'p', [license(spdxId, '')])]
 
     when:
-    def report = new JsonSlurper().parseText(new JsonFullReport(projects).toString())
+    Map<String, Object> report = (Map<String, Object>) new JsonSlurper().parseText(new JsonFullReport(projects).toString())
 
     then: 'the dependency points at the key, and the text is carried under it'
     report.dependencies[0].licenses[0].license_key == expectedKey

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/internal/report/JsonReportSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/internal/report/JsonReportSpec.groovy
@@ -10,12 +10,12 @@ import static test.TestUtils.assertJson
 final class JsonReportSpec extends Specification {
   def 'no open source json'() {
     given:
-    def projects = []
-    def sut = new JsonReport(projects)
+    List<Model> projects = []
+    JsonReport sut = new JsonReport(projects)
 
     when:
-    def actual = sut.toString()
-    def expected =
+    String actual = sut.toString()
+    String expected =
       """
       []
       """
@@ -26,8 +26,8 @@ final class JsonReportSpec extends Specification {
 
   def 'open source json - missing values'() {
     given:
-    def developer = new Developer(id: 'name')
-    def project1 = new Model(
+    Developer developer = new Developer(id: 'name')
+    Model project1 = new Model(
       name: 'name',
       description: '',
       licenses: [],
@@ -38,7 +38,7 @@ final class JsonReportSpec extends Specification {
       artifactId: 'bar',
       version: '1.2.3',
     )
-    def project2 = new Model(
+    Model project2 = new Model(
       name: 'name',
       description: '',
       licenses: [],
@@ -49,12 +49,12 @@ final class JsonReportSpec extends Specification {
       artifactId: 'bar',
       version: '1.2.3',
     )
-    def projects = [project1, project2]
-    def sut = new JsonReport(projects)
+    List<Model> projects = [project1, project2]
+    JsonReport sut = new JsonReport(projects)
 
     when:
-    def actual = sut.toString()
-    def expected =
+    String actual = sut.toString()
+    String expected =
       """
       [
         {
@@ -89,13 +89,13 @@ final class JsonReportSpec extends Specification {
 
   def 'open source json - all values'() {
     given:
-    def developer = new Developer(id: 'name')
-    def developers = [developer, developer]
-    def license = new License(
+    Developer developer = new Developer(id: 'name')
+    List<Developer> developers = [developer, developer]
+    License license = new License(
       name: 'name',
       url: 'url'
     )
-    def project = new Model(
+    Model project = new Model(
       name: 'name',
       description: 'description',
       licenses: [license],
@@ -106,12 +106,12 @@ final class JsonReportSpec extends Specification {
       artifactId: 'bar',
       version: '1.2.3',
     )
-    def projects = [project, project]
-    def sut = new JsonReport(projects)
+    List<Model> projects = [project, project]
+    JsonReport sut = new JsonReport(projects)
 
     when:
-    def actual = sut.toString()
-    def expected =
+    String actual = sut.toString()
+    String expected =
       """
       [
         {

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/internal/report/JsonReportSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/internal/report/JsonReportSpec.groovy
@@ -3,10 +3,12 @@ package com.jaredsburrows.license.internal.report
 import org.apache.maven.model.Developer
 import org.apache.maven.model.License
 import org.apache.maven.model.Model
+import groovy.transform.TypeChecked
 import spock.lang.Specification
 
-import static test.TestUtils.assertJson
+import static test.TestUtils.jsonOf
 
+@TypeChecked
 final class JsonReportSpec extends Specification {
   def 'no open source json'() {
     given:
@@ -14,14 +16,14 @@ final class JsonReportSpec extends Specification {
     JsonReport sut = new JsonReport(projects)
 
     when:
-    String actual = sut.toString()
-    String expected =
+    List<Map<String, Object>> actual = jsonOf(sut.toString())
+    List<Map<String, Object>> expected = jsonOf(
       """
       []
-      """
+      """)
 
     then:
-    assertJson(expected, actual)
+    expected == actual
   }
 
   def 'open source json - missing values'() {
@@ -53,8 +55,8 @@ final class JsonReportSpec extends Specification {
     JsonReport sut = new JsonReport(projects)
 
     when:
-    String actual = sut.toString()
-    String expected =
+    List<Map<String, Object>> actual = jsonOf(sut.toString())
+    List<Map<String, Object>> expected = jsonOf(
       """
       [
         {
@@ -81,10 +83,10 @@ final class JsonReportSpec extends Specification {
           "dependency": "foo:bar:1.2.3"
         }
       ]
-      """
+      """)
 
     then:
-    assertJson(expected, actual)
+    expected == actual
   }
 
   def 'open source json - all values'() {
@@ -110,8 +112,8 @@ final class JsonReportSpec extends Specification {
     JsonReport sut = new JsonReport(projects)
 
     when:
-    String actual = sut.toString()
-    String expected =
+    List<Map<String, Object>> actual = jsonOf(sut.toString())
+    List<Map<String, Object>> expected = jsonOf(
       """
       [
         {
@@ -151,9 +153,9 @@ final class JsonReportSpec extends Specification {
           "dependency": "foo:bar:1.2.3"
         }
       ]
-      """
+      """)
 
     then:
-    assertJson(expected, actual)
+    expected == actual
   }
 }

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/internal/report/TextReportSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/internal/report/TextReportSpec.groovy
@@ -8,12 +8,12 @@ import spock.lang.Specification
 final class TextReportSpec extends Specification {
   def 'no open source text'() {
     given:
-    def projects = []
-    def sut = new TextReport(projects)
+    List<Model> projects = []
+    TextReport sut = new TextReport(projects)
 
     when:
-    def actual = sut.toString().stripIndent().trim()
-    def expected = "".stripIndent().trim()
+    String actual = sut.toString().stripIndent().trim()
+    String expected = "".stripIndent().trim()
 
     then:
     expected == actual
@@ -21,8 +21,8 @@ final class TextReportSpec extends Specification {
 
   def 'open source text - missing values'() {
     given:
-    def developer = new Developer(id: 'developer-name')
-    def project1 = new Model(
+    Developer developer = new Developer(id: 'developer-name')
+    Model project1 = new Model(
       name: 'project-name',
       description: '',
       licenses: [],
@@ -33,7 +33,7 @@ final class TextReportSpec extends Specification {
       artifactId: 'bar',
       version: '1.2.3',
     )
-    def project2 = new Model(
+    Model project2 = new Model(
       name: 'project-name',
       description: '',
       licenses: [],
@@ -44,12 +44,12 @@ final class TextReportSpec extends Specification {
       artifactId: 'bar',
       version: '1.2.3',
     )
-    def projects = [project1, project2]
-    def sut = new TextReport(projects)
+    List<Model> projects = [project1, project2]
+    TextReport sut = new TextReport(projects)
 
     when:
-    def actual = sut.toString().stripIndent().trim()
-    def expected =
+    String actual = sut.toString().stripIndent().trim()
+    String expected =
       """
       Notice for packages
 
@@ -65,13 +65,13 @@ final class TextReportSpec extends Specification {
 
   def 'open source text - all values'() {
     given:
-    def developer = new Developer(id: 'name')
-    def developers = [developer, developer]
-    def license = new License(
+    Developer developer = new Developer(id: 'name')
+    List<Developer> developers = [developer, developer]
+    License license = new License(
       name: 'license-name',
       url: 'license-url'
     )
-    def project = new Model(
+    Model project = new Model(
       name: 'project-name',
       description: 'project-description',
       licenses: [license],
@@ -82,12 +82,12 @@ final class TextReportSpec extends Specification {
       artifactId: 'bar',
       version: '1.2.3',
     )
-    def projects = [project, project]
-    def sut = new TextReport(projects)
+    List<Model> projects = [project, project]
+    TextReport sut = new TextReport(projects)
 
     when:
-    def actual = sut.toString().stripIndent().trim()
-    def expected =
+    String actual = sut.toString().stripIndent().trim()
+    String expected =
       """
       Notice for packages
 

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/internal/report/TextReportSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/internal/report/TextReportSpec.groovy
@@ -3,8 +3,10 @@ package com.jaredsburrows.license.internal.report
 import org.apache.maven.model.Developer
 import org.apache.maven.model.License
 import org.apache.maven.model.Model
+import groovy.transform.TypeChecked
 import spock.lang.Specification
 
+@TypeChecked
 final class TextReportSpec extends Specification {
   def 'no open source text'() {
     given:

--- a/gradle-license-plugin/src/test/groovy/test/TestUtils.groovy
+++ b/gradle-license-plugin/src/test/groovy/test/TestUtils.groovy
@@ -21,9 +21,12 @@ final class TestUtils {
   }
 
   static boolean assertCsv(String expected, String actual) {
-    List<String> left = CSVFormat.DEFAULT.parse(new StringReader(actual)).records.collect { it.toString() }
-    List<String> right = CSVFormat.DEFAULT.parse(new StringReader(expected)).records.collect { it.toString() }
-    return left == right
+    return csvRows(expected) == csvRows(actual)
+  }
+
+  /** The parsed rows, so a spec can compare two values rather than assert on a boolean. */
+  static List<String> csvRows(String text) {
+    return CSVFormat.DEFAULT.parse(new StringReader(text)).records.collect { it.toString() }
   }
 
   static boolean assertHtml(String expected, String actual) {
@@ -40,10 +43,15 @@ final class TestUtils {
   }
 
   static boolean assertJson(String expected, String actual) {
+    return jsonOf(expected) == jsonOf(actual)
+  }
+
+  /** The parsed JSON, so a spec can compare two values rather than assert on a boolean. */
+  static List<Map<String, Object>> jsonOf(String text) {
     Moshi moshi = new Moshi.Builder().build()
     JsonAdapter<List<Map<String, Object>>> jsonAdapter =
       moshi.adapter(Types.newParameterizedType(List, Map, String, Object))
-    return jsonAdapter.fromJson(expected) == jsonAdapter.fromJson(actual)
+    return jsonAdapter.fromJson(text)
   }
 
   static BuildResult gradleWithCommand(File file, String... commands) {

--- a/gradle-license-plugin/src/test/groovy/test/TestUtils.groovy
+++ b/gradle-license-plugin/src/test/groovy/test/TestUtils.groovy
@@ -1,30 +1,34 @@
 package test
 
 import com.jaredsburrows.license.internal.report.HtmlReport
+import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types
+import groovy.transform.CompileStatic
 import javax.xml.parsers.DocumentBuilderFactory
 import org.apache.commons.csv.CSVFormat
+import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.xmlunit.builder.DiffBuilder
 import org.xmlunit.builder.Input
 import org.xmlunit.util.DocumentBuilderFactoryConfigurer
 
+@CompileStatic
 final class TestUtils {
   private TestUtils() {
     //noinspection GroovyAccessibility
     throw new AssertionError('No instances')
   }
 
-  static def assertCsv(String expected, String actual) {
-    def left = CSVFormat.DEFAULT.parse(new StringReader(actual)).records.collect { it.toString() }
-    def right = CSVFormat.DEFAULT.parse(new StringReader(expected)).records.collect { it.toString() }
+  static boolean assertCsv(String expected, String actual) {
+    List<String> left = CSVFormat.DEFAULT.parse(new StringReader(actual)).records.collect { it.toString() }
+    List<String> right = CSVFormat.DEFAULT.parse(new StringReader(expected)).records.collect { it.toString() }
     return left == right
   }
 
-  static def assertHtml(String expected, String actual) {
-    def left = htmlToXml(expected)
-    def right = htmlToXml(actual)
+  static boolean assertHtml(String expected, String actual) {
+    String left = htmlToXml(expected)
+    String right = htmlToXml(actual)
     return !DiffBuilder.compare(Input.fromString(right).build())
       .withTest(Input.fromString(left).build())
       // XMLUnit 2.12.0+ disallows DOCTYPE declarations by default, but the generated HTML reports start with one
@@ -35,13 +39,14 @@ final class TestUtils {
       .differences
   }
 
-  static def assertJson(String expected, String actual) {
-    def moshi = new Moshi.Builder().build()
-    def jsonAdapter = moshi.adapter(Types.newParameterizedType(List.class, Map.class, String.class, Object.class))
+  static boolean assertJson(String expected, String actual) {
+    Moshi moshi = new Moshi.Builder().build()
+    JsonAdapter<List<Map<String, Object>>> jsonAdapter =
+      moshi.adapter(Types.newParameterizedType(List, Map, String, Object))
     return jsonAdapter.fromJson(expected) == jsonAdapter.fromJson(actual)
   }
 
-  static def gradleWithCommand(File file, String... commands) {
+  static BuildResult gradleWithCommand(File file, String... commands) {
     return GradleRunner.create()
       .withProjectDir(file)
       .withArguments(commands)
@@ -49,7 +54,7 @@ final class TestUtils {
       .build()
   }
 
-  static def gradleWithCommandWithFail(File file, String... commands) {
+  static BuildResult gradleWithCommandWithFail(File file, String... commands) {
     return GradleRunner.create()
       .withProjectDir(file)
       .withArguments(commands)
@@ -57,20 +62,21 @@ final class TestUtils {
       .buildAndFail()
   }
 
-  static def getLicenseText(String fileName) {
+  static String getLicenseText(String fileName) {
     return HtmlReport.getLicenseText(fileName)
   }
 
-  private static def htmlToXml(String text) {
+  private static String htmlToXml(String text) {
     // Convert HTML into legal-enough XML that we can use the XML comparison
     // utility to compare two HTML strings. This is only just what we need for
     // this exact case, so update as needed.
-    text = text.replaceAll('<br>', '<br/>')
-    text = text.replaceAll('<hr>', '<hr/>')
-    text = text.replaceAll('&copy;', '(c)')
-    text = text.replaceAll('<meta http-equiv="content-type" content="text/html; charset=utf-8">', '<meta http-equiv="content-type" content="text/html; charset=utf-8" />')
+    String result = text
+    result = result.replaceAll('<br>', '<br/>')
+    result = result.replaceAll('<hr>', '<hr/>')
+    result = result.replaceAll('&copy;', '(c)')
+    result = result.replaceAll('<meta http-equiv="content-type" content="text/html; charset=utf-8">', '<meta http-equiv="content-type" content="text/html; charset=utf-8" />')
     // Unicode code points being transformed strangely - normalize
-    text = text.replaceAll('Karol Wr.*niak', 'Karol WrXXniak')
-    return text
+    result = result.replaceAll('Karol Wr.*niak', 'Karol WrXXniak')
+    return result
   }
 }


### PR DESCRIPTION
Replaces `def` with explicit types across the `internal` spec directory, statically compiles the shared test helper, and turns on real type checking where Spock allows it.

### What changed

- **`TestUtils` is `@CompileStatic`** with real return types (`boolean`, `String`, `BuildResult`) instead of `def`.
- **117 `def` declarations replaced with explicit types** across the six specs under `internal/`.
- **`TextReportSpec`, `CsvReportSpec` and `JsonReportSpec` are `@TypeChecked`** — compile-time enforced.
- **`TestUtils` gained `csvRows` and `jsonOf`**, which return the parsed value rather than a verdict. `assertCsv` and `assertJson` remain, implemented in terms of them, so the other callers are untouched.

`TextReportSpec` type-checked as-is because its condition was already a comparison of two typed locals (`expected == actual`). `CsvReportSpec` and `JsonReportSpec` could not, only because they called a boolean helper: `assertCsv(expected, actual)`. Comparing parsed values instead puts them in the same shape, and improves the failure output — a mismatch now renders both parsed structures rather than the raw strings beside a bare `false`.

### What this did and did not find

No behavioural bugs. The suite was green before this change and is green after, and neither spot below could have produced a wrong report — both are type looseness that the runtime resolved correctly.

- `TestUtils.htmlToXml` returned `def`. Its body is a chain of `replaceAll` calls, which always return `String`, so `Input.fromString(...)` always received a `String`. Only the static checker objected.
- `CsvReportSpec` built `def projects = []` (a `List<Object>`) and passed it to a constructor taking `List<Model>`. Generics are erased; an empty list is an empty list.

Worth stating plainly: this is a readability and tooling change, not a correctness fix.

The one thing typing genuinely caught was a mistake made *during* this change — `asserted` in `LicenseHelperSpec` is built with `as Set`, so it is a `Set<String>`. Typing it `List<String>` turned the suite red, which is the argument for writing the types down.

### Why the other three specs are not `@TypeChecked`

`@CompileStatic` / `@TypeChecked` on a Spock `Specification` is not workable in general. Spock's condition-rewriting transform emits `SpockRuntime.verifyMethodCondition(...)` with `<unknown parameter type>`, which the static type checker then rejects. Measured on this directory, annotating all six specs leaves **156 errors**:

| cause | count |
|---|---|
| dynamic method name in condition | 74 |
| method-call condition (`verifyMethodCondition`) | 30 |
| operator on a data variable in a condition | 18 |
| dynamic `JsonSlurper` navigation | 21 |
| other | 13 |

| spec | errors before | now |
|---|---|---|
| `LicenseHelperSpec` | 71 | 71 |
| `JsonFullReportSpec` | 56 | 56 |
| `HtmlReportSpec` | 22 | 22 |
| `CsvReportSpec` | 4 | **0** — `@TypeChecked` |
| `JsonReportSpec` | 3 | **0** — `@TypeChecked` |
| `TextReportSpec` | 0 | **0** — `@TypeChecked` |

The single blocker is a **method call inside a condition**. `where:` itself is not a blocker — data tables, data pipes and derived variables all type-check, with or without typed data-variable parameters in the signature. They only appear in the error counts because the conditions in those features happen to call methods.

That means much of the remainder is reachable by hoisting the call into `given:`:

```groovy
// before                                    // after
expect:                                      given:
HELPER.licenseFileName(id, null) == expected String actual = HELPER.licenseFileName(id, null)
                                             expect:
                                             actual == expected
```

42 of `LicenseHelperSpec`'s 71 errors are exactly that shape, and the hoist costs no diagnostics — both sides of the comparison still render, and the inputs are already in the iteration label.

Not done here, as it is a large mechanical change to test bodies and belongs in its own PR. Two things stay genuinely out of reach: boolean-returning helper conditions such as `assertCsv(expected, actual)`, where hoisting really does reduce the failure output to `ok | false`, and `JsonFullReportSpec`'s dynamic `JsonSlurper` navigation.

### Verification

`./gradlew :gradle-license-plugin:test` — 480 tests, 0 failures.

