### PR TITLE
Upload the plugin's build outputs rather than the root project's

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,13 +59,14 @@ jobs:
         if: github.repository == 'jaredsburrows/gradle-license-plugin' && github.ref == 'refs/heads/master'
         with:
           name: gradle-license-plugin-${{ github.workflow }}-${{ github.run_id }}
+          # The plugin is the :gradle-license-plugin subproject, so its outputs are under
+          # gradle-license-plugin/build. The root build/libs holds only the near-empty jar the root
+          # project produces from java-library, and root build/reports is configuration-cache
+          # diagnostics rather than anything worth keeping.
           path: |
-            build/libs
-            build/outputs
-            build/publications
-            build/distributions
-            build/reports
-            build/test-results
+            gradle-license-plugin/build/libs
+            gradle-license-plugin/build/reports
+            gradle-license-plugin/build/test-results
 
   test-apps:
     name: Test Apps


### PR DESCRIPTION
The Build job's **Upload Artifacts** step pointed at `build/`, but the plugin is the
`:gradle-license-plugin` subproject - so none of its output is there.

What the configured paths actually resolve to after a real build:

| configured path | what is actually there |
| --- | --- |
| `build/libs` | the **root** project's jar - **261 bytes**, empty in practice |
| `build/reports` | configuration-cache and problems **diagnostics**, ~15 MB |
| `build/outputs` | absent |
| `build/publications` | absent |
| `build/distributions` | absent |
| `build/test-results` | absent |

Meanwhile, one directory down and never uploaded:

| | |
| --- | --- |
| `gradle-license-plugin/build/libs` | the real **260 KB** plugin jar |
| `gradle-license-plugin/build/reports` | ktlint + test reports |
| `gradle-license-plugin/build/test-results` | 14 JUnit XML files |

So every master build has been publishing a placeholder jar and a pile of build diagnostics instead
of the artifact anyone would actually want.

The three paths that never exist are **dropped rather than repointed**: `outputs` and `distributions`
are not produced by this build at all, and `publications` only appears during `publish`, which is a
different job that uploads nothing.

The `test-apps` job was already correct and is untouched. YAML re-parsed to confirm both upload steps
still resolve as intended.
