### PR TITLE
Lint the root build scripts too

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ import java.time.format.DateTimeFormatter
 plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.dokka) apply false
-  alias(libs.plugins.ktlint) apply false
+  alias(libs.plugins.ktlint)
   alias(libs.plugins.maven.publish) apply false
   alias(libs.plugins.plugin.publish) apply false
   alias(libs.plugins.versions)
@@ -41,10 +41,16 @@ subprojects {
   }
 
   tasks.withType<Jar>().configureEach {
-    val dateFile = layout.buildDirectory.file("jar-manifest-date.txt").get().asFile
+    val dateFile =
+      layout.buildDirectory
+        .file("jar-manifest-date.txt")
+        .get()
+        .asFile
     if (!dateFile.exists()) {
-      val date = DateTimeFormatter.ofPattern("EEE MMM dd HH:mm:ss zzz yyyy")
-        .format(ZonedDateTime.now())
+      val date =
+        DateTimeFormatter
+          .ofPattern("EEE MMM dd HH:mm:ss zzz yyyy")
+          .format(ZonedDateTime.now())
       dateFile.parentFile.mkdirs()
       dateFile.writeText(date.trim())
     }


### PR DESCRIPTION
ktlint was applied with `apply false` at the root, so `ktlintCheck` only ever covered the
`:gradle-license-plugin` subproject. `build.gradle.kts` and `settings.gradle.kts` were never linted -
which is exactly why the root file drifted while the module's stayed clean.

Applying it at the root adds `ktlintKotlinScriptCheck` there. CI already runs `ktlintCheck`, so the
workflow is untouched.

## The violations

**Five, not the ~23 I estimated earlier** - I'd carried that number over from an audit note and it was
wrong. All five are in `build.gradle.kts`; `settings.gradle.kts` was already clean.

All formatting, fixed with `ktlintFormat`:

```diff
-    val dateFile = layout.buildDirectory.file("jar-manifest-date.txt").get().asFile
+    val dateFile =
+      layout.buildDirectory
+        .file("jar-manifest-date.txt")
+        .get()
+        .asFile
     if (!dateFile.exists()) {
-      val date = DateTimeFormatter.ofPattern("EEE MMM dd HH:mm:ss zzz yyyy")
-        .format(ZonedDateTime.now())
+      val date =
+        DateTimeFormatter
+          .ofPattern("EEE MMM dd HH:mm:ss zzz yyyy")
+          .format(ZonedDateTime.now())
```

A chain long enough to require wrapping, and a multiline expression that has to start on its own
line. This is the same wrapping the module's `createClasspathManifest` already has - it was written
that way in #842 precisely *because* that file is linted and this one was not.

## Verification

The reformatted block is the only thing feeding the jar manifest, so I checked it directly rather
than assuming a formatting change is inert:

```
Created-By: Jared Burrows
Implementation-Title: Gradle License Plugin
Implementation-Version: 0.9.91-SNAPSHOT
Implementation-Vendor: Jared Burrows
Built-By: noname
Built-Date: Sun Aug 30 23:11:29 EDT 2026
Built-JDK: 21.0.9
Built-Gradle: 9.7.1
```

All attributes still populated. `clean ktlintCheck build` green with the cache disabled: **480 tests,
0 failures**.

One trap worth recording: the first few runs reported violations in a **deleted worktree** under
`/private/tmp`, surviving both the configuration cache and `--no-configuration-cache`. It was a stale
ktlint report being re-printed; `--rerun-tasks` was needed to get real paths. Worth knowing before
anyone debugs a ktlint result that points at a file that does not exist.
