### PR TITLE
Lint the test apps

### DIFF
--- a/test-apps/.editorconfig
+++ b/test-apps/.editorconfig
@@ -1,0 +1,6 @@
+# Inherits the repository root .editorconfig; only the Compose-specific rule lives here.
+
+[*.kt]
+# Composables that emit UI are PascalCase by convention, which ktlint's function-naming rule
+# otherwise rejects and cannot auto-correct.
+ktlint_function_naming_ignore_when_annotated_with = Composable

--- a/test-apps/build.gradle.kts
+++ b/test-apps/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
   alias(libs.plugins.kotlin.compose) apply false
   // No version: the plugin comes from the build included in settings.gradle.kts.
   id("com.jaredsburrows.license") apply false
+  alias(libs.plugins.ktlint)
   idea
 }
 
@@ -21,6 +22,9 @@ idea {
 }
 
 subprojects {
+  // ktlint hooks itself into check, so "-p test-apps build" lints without a workflow change.
+  apply(plugin = "org.jlleitschuh.gradle.ktlint")
+
   tasks.withType<Test>().configureEach {
     testLogging {
       exceptionFormat = TestExceptionFormat.FULL

--- a/test-apps/build.gradle.kts
+++ b/test-apps/build.gradle.kts
@@ -22,9 +22,6 @@ idea {
 }
 
 subprojects {
-  // ktlint hooks itself into check, so "-p test-apps build" lints without a workflow change.
-  apply(plugin = "org.jlleitschuh.gradle.ktlint")
-
   tasks.withType<Test>().configureEach {
     testLogging {
       exceptionFormat = TestExceptionFormat.FULL

--- a/test-apps/gradle/libs.versions.toml
+++ b/test-apps/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ targetCompatibility = "17"
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version = "14.2.0" }
 
 [libraries]
 activity-compose = { module = "androidx.activity:activity-compose", version = "1.13.0" }

--- a/test-apps/test-app-compose-fulljson/build.gradle.kts
+++ b/test-apps/test-app-compose-fulljson/build.gradle.kts
@@ -7,12 +7,21 @@ plugins {
 
 android {
   namespace = "com.jaredsburrows.license.testapp.fulljson"
-  compileSdk = libs.versions.targetSdk.get().toInt()
+  compileSdk =
+    libs.versions.targetSdk
+      .get()
+      .toInt()
 
   defaultConfig {
     applicationId = "com.jaredsburrows.license.testapp.fulljson"
-    minSdk = libs.versions.minSdk.get().toInt()
-    targetSdk = libs.versions.targetSdk.get().toInt()
+    minSdk =
+      libs.versions.minSdk
+        .get()
+        .toInt()
+    targetSdk =
+      libs.versions.targetSdk
+        .get()
+        .toInt()
     versionCode = 1
     versionName = "1.0"
   }

--- a/test-apps/test-app-compose-fulljson/build.gradle.kts
+++ b/test-apps/test-app-compose-fulljson/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
   alias(libs.plugins.android.application)
   alias(libs.plugins.kotlin.compose)
+  alias(libs.plugins.ktlint)
   // No version: the plugin comes from the build included in settings.gradle.kts.
   id("com.jaredsburrows.license")
 }

--- a/test-apps/test-app-compose-fulljson/src/main/kotlin/com/jaredsburrows/license/testapp/fulljson/OpenSourceReport.kt
+++ b/test-apps/test-app-compose-fulljson/src/main/kotlin/com/jaredsburrows/license/testapp/fulljson/OpenSourceReport.kt
@@ -79,5 +79,4 @@ private fun JSONObject.stringOrNull(key: String): String? = if (isNull(key)) nul
 private fun <T> JSONArray?.mapObjects(transform: (JSONObject) -> T): List<T> =
   if (this == null) emptyList() else (0 until length()).map { transform(getJSONObject(it)) }
 
-private fun JSONArray?.toStringList(): List<String> =
-  if (this == null) emptyList() else (0 until length()).map { getString(it) }
+private fun JSONArray?.toStringList(): List<String> = if (this == null) emptyList() else (0 until length()).map { getString(it) }

--- a/test-apps/test-app-compose-fulljson/src/test/kotlin/com/jaredsburrows/license/testapp/fulljson/LicensesScreenTest.kt
+++ b/test-apps/test-app-compose-fulljson/src/test/kotlin/com/jaredsburrows/license/testapp/fulljson/LicensesScreenTest.kt
@@ -8,9 +8,9 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToNode
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlin.test.Test
 import org.junit.Rule
 import org.junit.runner.RunWith
+import kotlin.test.Test
 
 /** Drives the screen the way a user would, against the report generated into the app assets. */
 @RunWith(AndroidJUnit4::class)

--- a/test-apps/test-app-compose-fulljson/src/test/kotlin/com/jaredsburrows/license/testapp/fulljson/OpenSourceReportTest.kt
+++ b/test-apps/test-app-compose-fulljson/src/test/kotlin/com/jaredsburrows/license/testapp/fulljson/OpenSourceReportTest.kt
@@ -3,11 +3,11 @@ package com.jaredsburrows.license.testapp.fulljson
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.runner.RunWith
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
-import org.junit.runner.RunWith
 
 /**
  * Reads the report that `licenseDebugReport` generated into the app assets, so a change to the

--- a/test-apps/test-app-compose-html/build.gradle.kts
+++ b/test-apps/test-app-compose-html/build.gradle.kts
@@ -7,12 +7,21 @@ plugins {
 
 android {
   namespace = "com.jaredsburrows.license.testapp.html"
-  compileSdk = libs.versions.targetSdk.get().toInt()
+  compileSdk =
+    libs.versions.targetSdk
+      .get()
+      .toInt()
 
   defaultConfig {
     applicationId = "com.jaredsburrows.license.testapp.html"
-    minSdk = libs.versions.minSdk.get().toInt()
-    targetSdk = libs.versions.targetSdk.get().toInt()
+    minSdk =
+      libs.versions.minSdk
+        .get()
+        .toInt()
+    targetSdk =
+      libs.versions.targetSdk
+        .get()
+        .toInt()
     versionCode = 1
     versionName = "1.0"
   }

--- a/test-apps/test-app-compose-html/build.gradle.kts
+++ b/test-apps/test-app-compose-html/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
   alias(libs.plugins.android.application)
   alias(libs.plugins.kotlin.compose)
+  alias(libs.plugins.ktlint)
   // No version: the plugin comes from the build included in settings.gradle.kts.
   id("com.jaredsburrows.license")
 }

--- a/test-apps/test-app-compose-html/src/test/kotlin/com/jaredsburrows/license/testapp/html/MainScreenTest.kt
+++ b/test-apps/test-app-compose-html/src/test/kotlin/com/jaredsburrows/license/testapp/html/MainScreenTest.kt
@@ -7,12 +7,12 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 import org.junit.Rule
 import org.junit.runner.RunWith
 import org.robolectric.Shadows.shadowOf
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 
 /** Drives the screen the way a user would. */
 @RunWith(AndroidJUnit4::class)

--- a/test-apps/test-app-compose-html/src/test/kotlin/com/jaredsburrows/license/testapp/html/OpenSourceLicensesAssetTest.kt
+++ b/test-apps/test-app-compose-html/src/test/kotlin/com/jaredsburrows/license/testapp/html/OpenSourceLicensesAssetTest.kt
@@ -3,9 +3,9 @@ package com.jaredsburrows.license.testapp.html
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.runner.RunWith
 import kotlin.test.Test
 import kotlin.test.assertTrue
-import org.junit.runner.RunWith
 
 /**
  * The HTML report is displayed as-is, so the only thing to verify is that `licenseDebugReport`

--- a/test-apps/test-app-compose-json/build.gradle.kts
+++ b/test-apps/test-app-compose-json/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
   alias(libs.plugins.android.application)
   alias(libs.plugins.kotlin.compose)
+  alias(libs.plugins.ktlint)
   // No version: the plugin comes from the build included in settings.gradle.kts.
   id("com.jaredsburrows.license")
 }

--- a/test-apps/test-app-compose-json/build.gradle.kts
+++ b/test-apps/test-app-compose-json/build.gradle.kts
@@ -7,12 +7,21 @@ plugins {
 
 android {
   namespace = "com.jaredsburrows.license.testapp.json"
-  compileSdk = libs.versions.targetSdk.get().toInt()
+  compileSdk =
+    libs.versions.targetSdk
+      .get()
+      .toInt()
 
   defaultConfig {
     applicationId = "com.jaredsburrows.license.testapp.json"
-    minSdk = libs.versions.minSdk.get().toInt()
-    targetSdk = libs.versions.targetSdk.get().toInt()
+    minSdk =
+      libs.versions.minSdk
+        .get()
+        .toInt()
+    targetSdk =
+      libs.versions.targetSdk
+        .get()
+        .toInt()
     versionCode = 1
     versionName = "1.0"
   }

--- a/test-apps/test-app-compose-json/src/main/kotlin/com/jaredsburrows/license/testapp/json/OpenSourceLibrary.kt
+++ b/test-apps/test-app-compose-json/src/main/kotlin/com/jaredsburrows/license/testapp/json/OpenSourceLibrary.kt
@@ -50,5 +50,4 @@ private fun JSONObject.stringOrNull(key: String): String? = if (isNull(key)) nul
 private fun <T> JSONArray?.mapObjects(transform: (JSONObject) -> T): List<T> =
   if (this == null) emptyList() else (0 until length()).map { transform(getJSONObject(it)) }
 
-private fun JSONArray?.toStringList(): List<String> =
-  if (this == null) emptyList() else (0 until length()).map { getString(it) }
+private fun JSONArray?.toStringList(): List<String> = if (this == null) emptyList() else (0 until length()).map { getString(it) }

--- a/test-apps/test-app-compose-json/src/test/kotlin/com/jaredsburrows/license/testapp/json/LicensesScreenTest.kt
+++ b/test-apps/test-app-compose-json/src/test/kotlin/com/jaredsburrows/license/testapp/json/LicensesScreenTest.kt
@@ -7,9 +7,9 @@ import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performScrollToNode
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlin.test.Test
 import org.junit.Rule
 import org.junit.runner.RunWith
+import kotlin.test.Test
 
 /** Drives the screen the way a user would, against the report generated into the app assets. */
 @RunWith(AndroidJUnit4::class)

--- a/test-apps/test-app-compose-json/src/test/kotlin/com/jaredsburrows/license/testapp/json/OpenSourceLibraryTest.kt
+++ b/test-apps/test-app-compose-json/src/test/kotlin/com/jaredsburrows/license/testapp/json/OpenSourceLibraryTest.kt
@@ -3,11 +3,11 @@ package com.jaredsburrows.license.testapp.json
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.runner.RunWith
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
-import org.junit.runner.RunWith
 
 /**
  * Reads the report that `licenseDebugReport` generated into the app assets, so a change to the


### PR DESCRIPTION
Companion to #859, which lints the plugin build's root scripts. The test apps are a **separate Gradle
build** and had no ktlint at all, so their 5 build scripts and 11 Kotlin sources were never checked
while the plugin build was.

ktlint hooks itself into `check`, so `./gradlew -p test-apps build` now lints them - **39 ktlint check
tasks are in the build graph** and the workflow needs no change.

## 32 violations, all fixed

| category | n | how |
| --- | --- | --- |
| chain wrapping in the three app build scripts | 18 | `ktlintFormat` |
| import ordering, `kotlin.*` sorts last | 6 | `ktlintFormat` |
| body expression that fits on one line | 2 | `ktlintFormat` |
| **Composable function naming** | **6** | `.editorconfig` |

## The six that are not a formatting fix

They are all `@Composable` functions - `MainScreen`, `LicensesScreen`, `LibraryRow`,
`LibraryListScreen`, `LibraryDetailScreen`. **PascalCase is the convention for a composable that
emits UI**, so renaming them would be wrong, and ktlint cannot auto-correct that rule anyway.

`test-apps/.editorconfig` turns the rule off for annotated functions and inherits everything else
from the root file, so the shared style still lives in one place:

```
[*.kt]
ktlint_function_naming_ignore_when_annotated_with = Composable
```

**No composable is renamed, and no `MainActivity.kt` is touched** - you can confirm that from the
file list.

## On the count

I first measured **7**, which was wrong. ktlint failed on `test-app-compose-html` and stopped the
build, so the other two apps never reported; `--continue` gives the real 32. I then guessed the lone
Composable hit was an `@OptIn` annotation-ordering quirk - also wrong, since `LibraryListScreen` and
`LicensesScreen` carry identical annotations. Both were artefacts of the truncated run, and the
numbers above come from a full `--continue` pass.

`./gradlew -p test-apps build` is green.
