### PR TITLE
Match OSI's current path, anchor spdx.org, and only strip real locales

### DIFF
--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/internal/LicenseHelper.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/internal/LicenseHelper.kt
@@ -23,9 +23,20 @@ object LicenseHelper {
   private val GNU_FAMILY = Regex("(A|L)?GPL-[0-9.]+")
 
   private val EXTENSION = Regex("(\\.(txt|html?|php))+$")
-  private val LOCALE = Regex("\\.[a-z]{2}$")
+
+  // Only actual language codes, the ones gnu.org serves. A bare "[a-z]{2}" also swallowed
+  // suffixes like ".rb" and ".py", which made opensource.org/licenses/MIT.rb resolve to MIT.
+  private val LOCALE =
+    Regex(
+      "\\.(ar|bg|ca|cs|de|el|en|eo|es|fa|fr|he|hr|id|it|ja|ko|ml|nb|nl|pl|pt|ro|ru|sk|sq|sr|ta|tr|uk|zh)$",
+    )
   private val LOCALE_SEGMENT = Regex("^([^/]+)/[a-z]{2}(-[a-z]{2})?/")
   private val PORT = Regex("^([^/]+):\\d+")
+  private val OSI_VERSION = Regex("-(\\d+)-(\\d+)$")
+
+  private const val SPDX_URL_PREFIX = "spdx.org/licenses/"
+  private const val OSI_LICENSE_PREFIX = "opensource.org/license/"
+  private const val OSI_LICENSES_PREFIX = "opensource.org/licenses/"
 
   /** Canonical SPDX identifier to the bundled license text file. */
   private val texts =
@@ -316,6 +327,11 @@ object LicenseHelper {
     }
     // mozilla.org/en-US/MPL/2.0 - the locale can be a path segment rather than a suffix.
     value = value.replace(LOCALE_SEGMENT, "$1/")
+    // OSI now serves /license/<slug>, hyphenating the version: /license/apache-2-0. Fold it onto
+    // the retired /licenses/<spdx-id> form so one alias covers both.
+    if (value.startsWith(OSI_LICENSE_PREFIX)) {
+      value = OSI_LICENSES_PREFIX + value.removePrefix(OSI_LICENSE_PREFIX).replace(OSI_VERSION, "-$1.$2")
+    }
     return value.trimEnd('/')
   }
 
@@ -333,9 +349,10 @@ object LicenseHelper {
   /** The SPDX identifier a URL names, or null. */
   private fun spdxIdFromUrl(url: String): String? {
     val normalized = normalizeUrl(url)
-    // https://spdx.org/licenses/MIT.html names the identifier directly.
-    val fromSpdxUrl = normalized.substringAfter("spdx.org/licenses/", "")
-    return spdxIds[fromSpdxUrl] ?: urlAliases[normalized]
+    // https://spdx.org/licenses/MIT.html names the identifier directly. Anchored to the start:
+    // substringAfter also matched any URL merely containing the path, wherever it appeared.
+    val fromSpdxUrl = normalized.removePrefix(SPDX_URL_PREFIX).takeIf { it != normalized }
+    return fromSpdxUrl?.let { spdxIds[it] } ?: urlAliases[normalized]
   }
 
   /** The SPDX identifier a name states, or null. */

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/internal/LicenseHelperSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/internal/LicenseHelperSpec.groovy
@@ -688,4 +688,55 @@ final class LicenseHelperSpec extends Specification {
     texts.toSet().size() == texts.size()
   }
 
+
+  // ---------------------------------------------------------------------------------------------
+  // URL matching: OSI's current path, spdx.org anchoring, and locale stripping.
+  // ---------------------------------------------------------------------------------------------
+
+  @Unroll
+  def 'BUG: OSI now serves the singular /license/ path - #url'() {
+    expect: 'both the current and the retired form resolve'
+    HELPER.licenseFileName(null, url) == expected
+
+    where:
+    url                                              || expected
+    'https://opensource.org/license/mit'             || 'mit.txt'
+    'https://opensource.org/license/apache-2-0'      || 'apache-2.0.txt'
+    'https://opensource.org/license/bsd-3-clause'    || 'bsd-3-clause.txt'
+    'https://opensource.org/license/gpl-2-0'         || 'gpl-2.0.txt'
+    'https://opensource.org/license/mpl-2-0'         || 'mpl-2.0.txt'
+    'https://opensource.org/license/epl-2-0'         || 'epl-2.0.txt'
+    'https://opensource.org/licenses/MIT'            || 'mit.txt'
+    'https://opensource.org/licenses/Apache-2.0'     || 'apache-2.0.txt'
+    'https://opensource.org/licenses/BSD-3-Clause'   || 'bsd-3-clause.txt'
+  }
+
+  @Unroll
+  def 'BUG: spdx.org is matched as a prefix, not anywhere in the url - #url'() {
+    expect:
+    HELPER.licenseFileName(null, url) == expected
+
+    where:
+    url                                                    || expected
+    'https://spdx.org/licenses/MIT.html'                   || 'mit.txt'
+    'https://spdx.org/licenses/MIT'                        || 'mit.txt'
+    'https://example.com/spdx.org/licenses/MIT'            || null
+    'https://evil.example.com/mirror/spdx.org/licenses/MIT'|| null
+    'https://notspdx.org/licenses/MIT'                     || null
+  }
+
+  @Unroll
+  def 'BUG: only a real language code is stripped from a url - #url'() {
+    expect:
+    HELPER.licenseFileName(null, url) == expected
+
+    where:
+    url                                             || expected
+    'https://www.gnu.org/licenses/gpl-3.0.de'       || 'gpl-3.0.txt'
+    'http://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html' || 'lgpl-2.1.txt'
+    'https://opensource.org/licenses/MIT.rb'        || null
+    'https://opensource.org/licenses/MIT.py'        || null
+    'https://opensource.org/licenses/MIT.gz'        || null
+  }
+
 }


### PR DESCRIPTION
Tier 4 correctness - the URL matching tail left over from #846. Three defects, each **verified
against the resolver before writing a fix**, since two of the three audit notes behind these turned
out to need correcting.

## 1. OSI moved to a singular path

OSI now serves `/license/<slug>`, hyphenating the version - `opensource.org/license/apache-2-0`.
Both paths return HTTP 200 today (I checked), but only the retired plural one resolved.

Rather than duplicating every alias, the singular form is folded onto the plural one, restoring the
dot in a trailing `-N-N` so `apache-2-0` reaches the `apache-2.0` entry. `bsd-3-clause` is untouched,
since it does not end in two numbers.

## 2. `spdx.org` was matched anywhere in the URL

`substringAfter` meant any URL merely *containing* the path resolved, wherever it appeared:

```
https://example.com/spdx.org/licenses/MIT          ->  mit.txt
https://evil.example.com/mirror/spdx.org/licenses/MIT  ->  mit.txt
```

Now anchored to the start of the normalised URL.

## 3. The locale strip was not a language test

`Regex("\\.[a-z]{2}$")` matches any two letters, so it removed suffixes that are not locales:

```
https://opensource.org/licenses/MIT.rb  ->  mit.txt
https://opensource.org/licenses/MIT.py  ->  mit.txt
```

It now matches only the language codes gnu.org actually serves, so `gpl-3.0.de` and
`lgpl-2.1.en.html` still fold correctly while `.rb`, `.py` and `.gz` no longer do.

## A note on how these were confirmed

My first probe for the locale bug **passed for the wrong reason** - I asserted a URL resolved to
`null` when it would have done so either way, proving nothing. The cases above are the redesigned
ones, and each distinguishes fixed from unfixed behaviour.

**19 cases added, 12 of which fail against the current resolver.** 501 tests, 0 failures, clean
cache-disabled run, and `./gradlew -p test-apps build` green.
