### PR TITLE
Move Spock off the M5 milestone to the 2.4 release

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,6 @@ kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", v
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 kotlinx-html = { module = "org.jetbrains.kotlinx:kotlinx-html-jvm", version = "0.12.0" }
 maven-model = { module = "org.apache.maven:maven-model", version = "3.9.16" }
-spock = { module = "org.spockframework:spock-junit4", version = "2.4-M5-groovy-4.0" } # Gradle 9 bundles Groovy 4 via localGroovy()
+spock = { module = "org.spockframework:spock-junit4", version = "2.4-groovy-4.0" } # Gradle 9 bundles Groovy 4 via localGroovy()
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version = "6.1.3" } # Gradle 9 no longer auto-provides the launcher
 xmlunit = { module = "org.xmlunit:xmlunit-matchers", version = "2.13.0" }


### PR DESCRIPTION
Moves the test dependency from a milestone build to the released version.

```diff
-spock = { module = "org.spockframework:spock-junit4", version = "2.4-M5-groovy-4.0" }
+spock = { module = "org.spockframework:spock-junit4", version = "2.4-groovy-4.0" }
```

`2.4-M5-groovy-4.0` is milestone 5. The line has since gone `M6` → `M7` → `2.4-groovy-4.0`, so this skips three releases forward onto the final one.

### Not a Groovy change

Spock publishes one artifact per Groovy major, and this stays on the `groovy-4.0` variant, so `localGroovy()` and the Gradle-bundled Groovy 4 are untouched. Resolved graph:

```
org.spockframework:spock-junit4:2.4-groovy-4.0
  +--- org.apache.groovy:groovy:4.0.29
  +--- org.spockframework:spock-core:2.4-groovy-4.0
```

Worth noting for anyone reading the version catalog later: Maven Central reports `2.4-groovy-5.0` as `<latest>`, but that is alphabetical ordering of the variant suffix rather than a newer release. Taking it would drag the whole test runtime to Groovy 5, which conflicts with the Groovy 4 that `gradleTestKit()` puts on the classpath.

### Verification

`./gradlew :gradle-license-plugin:test` — 482 tests, 0 failures.
