### PR TITLE
Give the functional specs explicit types instead of def

### DIFF
--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginAndroidSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginAndroidSpec.groovy
@@ -1,6 +1,7 @@
 package com.jaredsburrows.license
 
 import groovy.json.JsonSlurper
+import org.gradle.testkit.runner.BuildResult
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Issue
@@ -26,7 +27,7 @@ final class LicensePluginAndroidSpec extends Specification {
   private String mainAssetsFolder
 
   def 'setup'() {
-    def pluginClasspathResource = getClass().classLoader.getResource('plugin-classpath.txt')
+    URL pluginClasspathResource = getClass().classLoader.getResource('plugin-classpath.txt')
     if (pluginClasspathResource == null) {
       throw new IllegalStateException(
         'Did not find plugin classpath resource, run `testClasses` build task.')
@@ -70,11 +71,11 @@ final class LicensePluginAndroidSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
-    def actualCsv = new File(reportFolder, "${taskName}.csv")
-    def actualHtml = new File(reportFolder, "${taskName}.html")
-    def openSourceHtml = new File(mainAssetsFolder, "open_source_licenses.html")
-    def expectedHtml =
+    BuildResult result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
+    File actualCsv = new File(reportFolder, "${taskName}.csv")
+    File actualHtml = new File(reportFolder, "${taskName}.html")
+    File openSourceHtml = new File(mainAssetsFolder, "open_source_licenses.html")
+    String expectedHtml =
       """
       <!DOCTYPE html>
       <html lang="en">
@@ -88,12 +89,12 @@ final class LicensePluginAndroidSpec extends Specification {
         </body>
       </html>
       """
-    def actualJson = new File(reportFolder, "${taskName}.json")
-    def expectedJson =
+    File actualJson = new File(reportFolder, "${taskName}.json")
+    String expectedJson =
       """
       []
       """
-    def actualText = new File(reportFolder, "${taskName}.txt")
+    File actualText = new File(reportFolder, "${taskName}.txt")
 
     then:
     result.task(":${taskName}").outcome == SUCCESS
@@ -151,11 +152,11 @@ final class LicensePluginAndroidSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
-    def actualCsv = new File(reportFolder, "${taskName}.csv")
-    def actualHtml = new File(reportFolder, "${taskName}.html")
-    def openSourceHtml = new File(mainAssetsFolder, "open_source_licenses.html")
-    def expectedHtml =
+    BuildResult result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
+    File actualCsv = new File(reportFolder, "${taskName}.csv")
+    File actualHtml = new File(reportFolder, "${taskName}.html")
+    File openSourceHtml = new File(mainAssetsFolder, "open_source_licenses.html")
+    String expectedHtml =
       """
       <!DOCTYPE html>
       <html lang="en">
@@ -188,8 +189,8 @@ final class LicensePluginAndroidSpec extends Specification {
         </body>
       </html>
       """
-    def actualJson = new File(reportFolder, "${taskName}.json")
-    def expectedJson =
+    File actualJson = new File(reportFolder, "${taskName}.json")
+    String expectedJson =
       """
       [
         {
@@ -224,7 +225,7 @@ final class LicensePluginAndroidSpec extends Specification {
         }
       ]
       """
-    def actualText = new File(reportFolder, "${taskName}.txt")
+    File actualText = new File(reportFolder, "${taskName}.txt")
 
     then:
     result.task(":${taskName}").outcome == SUCCESS
@@ -247,7 +248,7 @@ final class LicensePluginAndroidSpec extends Specification {
   @Unroll
   def 'not UP-TO-DATE when dependencies change'() {
     given:
-    def originalBuildFile = """
+    String originalBuildFile = """
       buildscript {
         dependencies {
           classpath files($classpathString)
@@ -276,7 +277,7 @@ final class LicensePluginAndroidSpec extends Specification {
         implementation 'com.android.support:appcompat-v7:26.1.0'
       }
       """
-    def modifiedBuildFile = """
+    String modifiedBuildFile = """
       buildscript {
         dependencies {
           classpath files($classpathString)
@@ -310,9 +311,9 @@ final class LicensePluginAndroidSpec extends Specification {
 
     when:
     buildFile << originalBuildFile
-    def result1 = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
+    BuildResult result1 = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
     buildFile << modifiedBuildFile
-    def result2 = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
+    BuildResult result2 = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
 
     then:
     result1.task(":${taskName}").outcome == SUCCESS
@@ -365,11 +366,11 @@ final class LicensePluginAndroidSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
-    def actualCsv = new File(reportFolder, "${taskName}.csv")
-    def actualHtml = new File(reportFolder, "${taskName}.html")
-    def openSourceHtml = new File(mainAssetsFolder, "open_source_licenses.html")
-    def expectedHtml =
+    BuildResult result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
+    File actualCsv = new File(reportFolder, "${taskName}.csv")
+    File actualHtml = new File(reportFolder, "${taskName}.html")
+    File openSourceHtml = new File(mainAssetsFolder, "open_source_licenses.html")
+    String expectedHtml =
       """
       <!DOCTYPE html>
       <html lang="en">
@@ -402,8 +403,8 @@ final class LicensePluginAndroidSpec extends Specification {
         </body>
       </html>
       """
-    def actualJson = new File(reportFolder, "${taskName}.json")
-    def expectedJson =
+    File actualJson = new File(reportFolder, "${taskName}.json")
+    String expectedJson =
       """
       [
         {
@@ -438,7 +439,7 @@ final class LicensePluginAndroidSpec extends Specification {
         }
       ]
       """
-    def actualText = new File(reportFolder, "${taskName}.txt")
+    File actualText = new File(reportFolder, "${taskName}.txt")
 
     then:
     result.task(":${taskName}").outcome == SUCCESS
@@ -515,11 +516,11 @@ final class LicensePluginAndroidSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
-    def actualCsv = new File(reportFolder, "${taskName}.csv")
-    def actualHtml = new File(reportFolder, "${taskName}.html")
-    def openSourceHtml = new File(mainAssetsFolder, "open_source_licenses.html")
-    def expectedHtml =
+    BuildResult result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
+    File actualCsv = new File(reportFolder, "${taskName}.csv")
+    File actualHtml = new File(reportFolder, "${taskName}.html")
+    File openSourceHtml = new File(mainAssetsFolder, "open_source_licenses.html")
+    String expectedHtml =
       """
       <!DOCTYPE html>
       <html lang="en">
@@ -562,8 +563,8 @@ final class LicensePluginAndroidSpec extends Specification {
         </body>
       </html>
       """
-    def actualJson = new File(reportFolder, "${taskName}.json")
-    def expectedJson =
+    File actualJson = new File(reportFolder, "${taskName}.json")
+    String expectedJson =
       """
       [
         {
@@ -628,7 +629,7 @@ final class LicensePluginAndroidSpec extends Specification {
         }
       ]
       """
-    def actualText = new File(reportFolder, "${taskName}.txt")
+    File actualText = new File(reportFolder, "${taskName}.txt")
 
     then:
     result.task(":${taskName}").outcome == SUCCESS
@@ -696,7 +697,7 @@ final class LicensePluginAndroidSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, 'licenseFlavor1Flavor3DebugReport',
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseFlavor1Flavor3DebugReport',
       'licenseFlavor1Flavor3ReleaseReport', 'licenseFlavor2Flavor4DebugReport',
       'licenseFlavor2Flavor4ReleaseReport', '-s')
 
@@ -745,11 +746,11 @@ final class LicensePluginAndroidSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
-    def actualCsv = new File(reportFolder, "${taskName}.csv")
-    def actualHtml = new File(reportFolder, "${taskName}.html")
-    def openSourceHtml = new File(mainAssetsFolder, "open_source_licenses.html")
-    def expectedHtml =
+    BuildResult result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
+    File actualCsv = new File(reportFolder, "${taskName}.csv")
+    File actualHtml = new File(reportFolder, "${taskName}.html")
+    File openSourceHtml = new File(mainAssetsFolder, "open_source_licenses.html")
+    String expectedHtml =
       """
       <!DOCTYPE html>
       <html lang="en">
@@ -785,8 +786,8 @@ final class LicensePluginAndroidSpec extends Specification {
         </body>
       </html>
       """
-    def actualJson = new File(reportFolder, "${taskName}.json")
-    def expectedJson =
+    File actualJson = new File(reportFolder, "${taskName}.json")
+    String expectedJson =
       """
       [
         {
@@ -823,8 +824,8 @@ final class LicensePluginAndroidSpec extends Specification {
         }
       ]
       """
-    def actualText = new File(reportFolder, "${taskName}.txt")
-    def expectedText =
+    File actualText = new File(reportFolder, "${taskName}.txt")
+    String expectedText =
       """
       Notice for packages
 
@@ -890,11 +891,11 @@ final class LicensePluginAndroidSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
-    def actualCsv = new File(reportFolder, "${taskName}.csv")
-    def actualHtml = new File(reportFolder, "${taskName}.html")
-    def openSourceHtml = new File(mainAssetsFolder, "open_source_licenses.html")
-    def expectedHtml =
+    BuildResult result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
+    File actualCsv = new File(reportFolder, "${taskName}.csv")
+    File actualHtml = new File(reportFolder, "${taskName}.html")
+    File openSourceHtml = new File(mainAssetsFolder, "open_source_licenses.html")
+    String expectedHtml =
       """
       <!DOCTYPE html>
       <html lang="en">
@@ -918,8 +919,8 @@ final class LicensePluginAndroidSpec extends Specification {
         </body>
       </html>
       """
-    def actualJson = new File(reportFolder, "${taskName}.json")
-    def expectedJson =
+    File actualJson = new File(reportFolder, "${taskName}.json")
+    String expectedJson =
       """
       [
         {
@@ -936,7 +937,7 @@ final class LicensePluginAndroidSpec extends Specification {
         }
       ]
       """
-    def actualText = new File(reportFolder, "${taskName}.txt")
+    File actualText = new File(reportFolder, "${taskName}.txt")
 
     then:
     result.task(":${taskName}").outcome == SUCCESS
@@ -1008,11 +1009,11 @@ final class LicensePluginAndroidSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
-    def actualCsv = new File(reportFolder, "${taskName}.csv")
-    def actualHtml = new File(reportFolder, "${taskName}.html")
-    def openSourceHtml = new File(mainAssetsFolder, "open_source_licenses.html")
-    def expectedHtml =
+    BuildResult result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
+    File actualCsv = new File(reportFolder, "${taskName}.csv")
+    File actualHtml = new File(reportFolder, "${taskName}.html")
+    File openSourceHtml = new File(mainAssetsFolder, "open_source_licenses.html")
+    String expectedHtml =
       """
       <!DOCTYPE html>
       <html lang="en">
@@ -1049,8 +1050,8 @@ final class LicensePluginAndroidSpec extends Specification {
         </body>
       </html>
       """
-    def actualJson = new File(reportFolder, "${taskName}.json")
-    def expectedJson =
+    File actualJson = new File(reportFolder, "${taskName}.json")
+    String expectedJson =
       """
       [
         {
@@ -1087,7 +1088,7 @@ final class LicensePluginAndroidSpec extends Specification {
         }
       ]
       """
-    def actualText = new File(reportFolder, "${taskName}.txt")
+    File actualText = new File(reportFolder, "${taskName}.txt")
 
     then:
     result.task(":${taskName}").outcome == SUCCESS
@@ -1164,11 +1165,11 @@ final class LicensePluginAndroidSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
-    def actualCsv = new File(reportFolder, "${taskName}.csv")
-    def actualHtml = new File(reportFolder, "${taskName}.html")
-    def openSourceHtml = new File(mainAssetsFolder, "open_source_licenses.html")
-    def expectedHtml =
+    BuildResult result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
+    File actualCsv = new File(reportFolder, "${taskName}.csv")
+    File actualHtml = new File(reportFolder, "${taskName}.html")
+    File openSourceHtml = new File(mainAssetsFolder, "open_source_licenses.html")
+    String expectedHtml =
       """
       <!DOCTYPE html>
       <html lang="en">
@@ -1208,8 +1209,8 @@ final class LicensePluginAndroidSpec extends Specification {
         </body>
       </html>
       """
-    def actualJson = new File(reportFolder, "${taskName}.json")
-    def expectedJson =
+    File actualJson = new File(reportFolder, "${taskName}.json")
+    String expectedJson =
       """
       [
         {
@@ -1246,7 +1247,7 @@ final class LicensePluginAndroidSpec extends Specification {
         }
       ]
       """
-    def actualText = new File(reportFolder, "${taskName}.txt")
+    File actualText = new File(reportFolder, "${taskName}.txt")
 
     then:
     result.task(":${taskName}").outcome == SUCCESS
@@ -1309,12 +1310,12 @@ final class LicensePluginAndroidSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
-    def actualCsv = new File(reportFolder, "${taskName}.csv")
-    def actualHtml = new File(reportFolder, "${taskName}.html")
-    def openSourceHtml = new File(mainAssetsFolder, "open_source_licenses.html")
-    def actualJson = new File(reportFolder, "${taskName}.json")
-    def actualText = new File(reportFolder, "${taskName}.txt")
+    BuildResult result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
+    File actualCsv = new File(reportFolder, "${taskName}.csv")
+    File actualHtml = new File(reportFolder, "${taskName}.html")
+    File openSourceHtml = new File(mainAssetsFolder, "open_source_licenses.html")
+    File actualJson = new File(reportFolder, "${taskName}.json")
+    File actualText = new File(reportFolder, "${taskName}.txt")
 
     then:
     result.task(":${taskName}").outcome == SUCCESS
@@ -1387,12 +1388,12 @@ final class LicensePluginAndroidSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
-    def actualCsv = new File(reportFolder, "${taskName}.csv")
-    def actualHtml = new File(reportFolder, "${taskName}.html")
-    def openSourceHtml = new File(mainAssetsFolder, "open_source_licenses.html")
-    def actualJson = new File(reportFolder, "${taskName}.json")
-    def actualText = new File(reportFolder, "${taskName}.txt")
+    BuildResult result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
+    File actualCsv = new File(reportFolder, "${taskName}.csv")
+    File actualHtml = new File(reportFolder, "${taskName}.html")
+    File openSourceHtml = new File(mainAssetsFolder, "open_source_licenses.html")
+    File actualJson = new File(reportFolder, "${taskName}.json")
+    File actualText = new File(reportFolder, "${taskName}.txt")
 
     then:
     result.task(":${taskName}").outcome == SUCCESS
@@ -1482,15 +1483,15 @@ final class LicensePluginAndroidSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
-    def variantName = taskName.replaceFirst(/^license/, '')
+    BuildResult result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
+    String variantName = taskName.replaceFirst(/^license/, '')
       .replaceFirst(/Report$/, '')
       .uncapitalize()
-    def variantAssetFolder = "${srcFolder}/${variantName}/assets"
-    def copiedCsv = new File(variantAssetFolder, "open_source_licenses.csv")
-    def copiedHtml = new File(variantAssetFolder, "open_source_licenses.html")
-    def copiedJson = new File(variantAssetFolder, "open_source_licenses.json")
-    def copiedText = new File(variantAssetFolder, "open_source_licenses.txt")
+    String variantAssetFolder = "${srcFolder}/${variantName}/assets"
+    File copiedCsv = new File(variantAssetFolder, "open_source_licenses.csv")
+    File copiedHtml = new File(variantAssetFolder, "open_source_licenses.html")
+    File copiedJson = new File(variantAssetFolder, "open_source_licenses.json")
+    File copiedText = new File(variantAssetFolder, "open_source_licenses.txt")
 
     then:
     result.task(":${taskName}").outcome == SUCCESS
@@ -1547,9 +1548,9 @@ final class LicensePluginAndroidSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
-    def actualHtml = new File(reportFolder, "${taskName}.html").text
-    def expectedHtml =
+    BuildResult result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
+    String actualHtml = new File(reportFolder, "${taskName}.html").text
+    String expectedHtml =
       """
       <!DOCTYPE html>
       <html lang="en">
@@ -1573,8 +1574,8 @@ final class LicensePluginAndroidSpec extends Specification {
         </body>
       </html>
       """
-    def actualJson = new File(reportFolder, "${taskName}.json").text
-    def expectedJson =
+    String actualJson = new File(reportFolder, "${taskName}.json").text
+    String expectedJson =
       """
       [
         {
@@ -1641,9 +1642,9 @@ final class LicensePluginAndroidSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
-    def actualHtml = new File(reportFolder, "${taskName}.html").text
-    def expectedHtml =
+    BuildResult result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
+    String actualHtml = new File(reportFolder, "${taskName}.html").text
+    String expectedHtml =
       """
       <!DOCTYPE html>
       <html lang="en">
@@ -1656,8 +1657,8 @@ final class LicensePluginAndroidSpec extends Specification {
         </body>
       </html>
       """
-    def actualJson = new File(reportFolder, "${taskName}.json").text
-    def expectedJson =
+    String actualJson = new File(reportFolder, "${taskName}.json").text
+    String expectedJson =
       """
       []
       """
@@ -1708,9 +1709,9 @@ final class LicensePluginAndroidSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
-    def actualHtml = new File(reportFolder, "${taskName}.html").text
-    def expectedHtml =
+    BuildResult result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
+    String actualHtml = new File(reportFolder, "${taskName}.html").text
+    String expectedHtml =
       """
       <!DOCTYPE html>
       <html lang="en">
@@ -1734,8 +1735,8 @@ final class LicensePluginAndroidSpec extends Specification {
         </body>
       </html>
       """
-    def actualJson = new File(reportFolder, "${taskName}.json").text
-    def expectedJson =
+    String actualJson = new File(reportFolder, "${taskName}.json").text
+    String expectedJson =
       """
       [
         {
@@ -1802,9 +1803,9 @@ final class LicensePluginAndroidSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
-    def actualHtml = new File(reportFolder, "${taskName}.html").text
-    def expectedHtml =
+    BuildResult result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
+    String actualHtml = new File(reportFolder, "${taskName}.html").text
+    String expectedHtml =
       """
       <!DOCTYPE html>
       <html lang="en">
@@ -1817,8 +1818,8 @@ final class LicensePluginAndroidSpec extends Specification {
         </body>
       </html>
       """
-    def actualJson = new File(reportFolder, "${taskName}.json").text
-    def expectedJson =
+    String actualJson = new File(reportFolder, "${taskName}.json").text
+    String expectedJson =
       """
       []
       """
@@ -1870,9 +1871,9 @@ final class LicensePluginAndroidSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
-    def actualHtml = new File(reportFolder, "${taskName}.html").text
-    def expectedHtml =
+    BuildResult result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
+    String actualHtml = new File(reportFolder, "${taskName}.html").text
+    String expectedHtml =
       """
       <!DOCTYPE html>
       <html lang="en">
@@ -1896,8 +1897,8 @@ final class LicensePluginAndroidSpec extends Specification {
         </body>
       </html>
       """
-    def actualJson = new File(reportFolder, "${taskName}.json").text
-    def expectedJson =
+    String actualJson = new File(reportFolder, "${taskName}.json").text
+    String expectedJson =
       """
       [
         {
@@ -1966,9 +1967,9 @@ final class LicensePluginAndroidSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
-    def actualHtml = new File(reportFolder, "${taskName}.html").text
-    def expectedHtml =
+    BuildResult result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
+    String actualHtml = new File(reportFolder, "${taskName}.html").text
+    String expectedHtml =
       """
       <!DOCTYPE html>
       <html lang="en">
@@ -1992,8 +1993,8 @@ final class LicensePluginAndroidSpec extends Specification {
         </body>
       </html>
       """
-    def actualJson = new File(reportFolder, "${taskName}.json").text
-    def expectedJson =
+    String actualJson = new File(reportFolder, "${taskName}.json").text
+    String expectedJson =
       """
       [
         {
@@ -2060,9 +2061,9 @@ final class LicensePluginAndroidSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
-    def actualHtml = new File(reportFolder, "${taskName}.html").text
-    def expectedHtml =
+    BuildResult result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
+    String actualHtml = new File(reportFolder, "${taskName}.html").text
+    String expectedHtml =
       """
       <!DOCTYPE html>
       <html lang="en">
@@ -2086,8 +2087,8 @@ final class LicensePluginAndroidSpec extends Specification {
         </body>
       </html>
       """
-    def actualJson = new File(reportFolder, "${taskName}.json").text
-    def expectedJson =
+    String actualJson = new File(reportFolder, "${taskName}.json").text
+    String expectedJson =
       """
       [
         {
@@ -2151,9 +2152,9 @@ final class LicensePluginAndroidSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
-    def actualHtml = new File(reportFolder, "${taskName}.html").text
-    def expectedHtml =
+    BuildResult result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
+    String actualHtml = new File(reportFolder, "${taskName}.html").text
+    String expectedHtml =
       """
       <!DOCTYPE html>
       <html lang="en">
@@ -2182,8 +2183,8 @@ final class LicensePluginAndroidSpec extends Specification {
         </body>
       </html>
       """
-    def actualJson = new File(reportFolder, "${taskName}.json").text
-    def expectedJson =
+    String actualJson = new File(reportFolder, "${taskName}.json").text
+    String expectedJson =
       """
       [
         {
@@ -2257,8 +2258,8 @@ final class LicensePluginAndroidSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, 'licenseDebugReport', '-s')
-    def actualJson = new File(reportFolder, 'licenseDebugReport.json')
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseDebugReport', '-s')
+    File actualJson = new File(reportFolder, 'licenseDebugReport.json')
 
     then: 'declared and parent-inherited licenses win; only the bare POM falls back to Apache'
     result.task(':licenseDebugReport').outcome == SUCCESS
@@ -2334,8 +2335,8 @@ final class LicensePluginAndroidSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, 'licenseDebugReport', '-s')
-    def actualJson = new File(reportFolder, 'licenseDebugReport.json')
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseDebugReport', '-s')
+    File actualJson = new File(reportFolder, 'licenseDebugReport.json')
 
     then: 'configuration does not crash and the report includes both modules dependencies'
     result.task(':licenseDebugReport').outcome == SUCCESS
@@ -2392,7 +2393,7 @@ final class LicensePluginAndroidSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
+    BuildResult result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
 
     then: 'the report is generated without resolving any configuration during configuration'
     result.task(":${taskName}").outcome == SUCCESS
@@ -2443,10 +2444,10 @@ final class LicensePluginAndroidSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
-    def actualJsonFull = new File(reportFolder, "${taskName}.full.json")
-    def openSourceJsonFull = new File(mainAssetsFolder, 'open_source_licenses.full.json')
-    def report = new JsonSlurper().parseText(openSourceJsonFull.text)
+    BuildResult result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
+    File actualJsonFull = new File(reportFolder, "${taskName}.full.json")
+    File openSourceJsonFull = new File(mainAssetsFolder, 'open_source_licenses.full.json')
+    Object report = new JsonSlurper().parseText(openSourceJsonFull.text)
 
     then:
     result.task(":${taskName}").outcome == SUCCESS
@@ -2487,8 +2488,8 @@ final class LicensePluginAndroidSpec extends Specification {
       """
 
     when: 'the report is generated once'
-    def first = gradleWithCommand(testProjectDir.root, 'licenseDebugReport', '-s')
-    def openSourceHtml = new File(mainAssetsFolder, 'open_source_licenses.html')
+    BuildResult first = gradleWithCommand(testProjectDir.root, 'licenseDebugReport', '-s')
+    File openSourceHtml = new File(mainAssetsFolder, 'open_source_licenses.html')
 
     then:
     first.task(':licenseDebugReport').outcome == SUCCESS
@@ -2496,7 +2497,7 @@ final class LicensePluginAndroidSpec extends Specification {
 
     when: 'the packaged copy is deleted and the build re-run'
     openSourceHtml.delete()
-    def second = gradleWithCommand(testProjectDir.root, 'licenseDebugReport', '-s')
+    BuildResult second = gradleWithCommand(testProjectDir.root, 'licenseDebugReport', '-s')
 
     then: 'the task re-runs rather than reporting UP-TO-DATE'
     second.task(':licenseDebugReport').outcome == SUCCESS
@@ -2544,7 +2545,7 @@ final class LicensePluginAndroidSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, 'licenseDebugReport', '-s')
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseDebugReport', '-s')
 
     then:
     result.task(':licenseDebugReport').outcome == SUCCESS
@@ -2558,7 +2559,7 @@ final class LicensePluginAndroidSpec extends Specification {
     ['csv', 'html', 'json', 'full.json', 'txt'].each { extension ->
       new File(mainAssetsFolder, "open_source_licenses.${extension}").delete()
     }
-    def second = gradleWithCommand(testProjectDir.root, 'licenseDebugReport', '-s')
+    BuildResult second = gradleWithCommand(testProjectDir.root, 'licenseDebugReport', '-s')
 
     then:
     second.task(':licenseDebugReport').outcome == SUCCESS
@@ -2610,7 +2611,7 @@ final class LicensePluginAndroidSpec extends Specification {
       """
 
     when: 'the report task is run on the dynamic feature module'
-    def result = gradleWithCommand(testProjectDir.root, ':feature:licenseDebugReport', '-s')
+    BuildResult result = gradleWithCommand(testProjectDir.root, ':feature:licenseDebugReport', '-s')
 
     then: 'applying the plugin does not fail the build'
     result.task(':feature:licenseDebugReport').outcome == SUCCESS
@@ -2639,7 +2640,7 @@ final class LicensePluginAndroidSpec extends Specification {
       """
 
     when: 'the plugin is applied'
-    def result = gradleWithCommand(testProjectDir.root, 'tasks', '--all', '-s')
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'tasks', '--all', '-s')
 
     then: 'it does not fail with the unsupported-project error'
     !result.output.contains('requires Java, Kotlin or Android Gradle based plugins')

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJvmSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJvmSpec.groovy
@@ -1,6 +1,7 @@
 package com.jaredsburrows.license
 
 import groovy.json.JsonSlurper
+import org.gradle.testkit.runner.BuildResult
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Issue
@@ -39,10 +40,10 @@ final class LicensePluginJvmSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
-    def actualCsv = new File(reportFolder, 'licenseReport.csv')
-    def actualHtml = new File(reportFolder, 'licenseReport.html')
-    def expectedHtml =
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    File actualCsv = new File(reportFolder, 'licenseReport.csv')
+    File actualHtml = new File(reportFolder, 'licenseReport.html')
+    String expectedHtml =
       """
       <!DOCTYPE html>
       <html lang="en">
@@ -56,12 +57,12 @@ final class LicensePluginJvmSpec extends Specification {
         </body>
       </html>
       """
-    def actualJson = new File(reportFolder, 'licenseReport.json')
-    def expectedJson =
+    File actualJson = new File(reportFolder, 'licenseReport.json')
+    String expectedJson =
       """
       []
       """
-    def actualText = new File(reportFolder, 'licenseReport.txt')
+    File actualText = new File(reportFolder, 'licenseReport.txt')
 
     then:
     result.task(':licenseReport').outcome == SUCCESS
@@ -98,10 +99,10 @@ final class LicensePluginJvmSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
-    def actualCsv = new File(reportFolder, 'licenseReport.csv')
-    def actualHtml = new File(reportFolder, 'licenseReport.html')
-    def expectedHtml =
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    File actualCsv = new File(reportFolder, 'licenseReport.csv')
+    File actualHtml = new File(reportFolder, 'licenseReport.html')
+    String expectedHtml =
       """
       <!DOCTYPE html>
       <html lang="en">
@@ -126,8 +127,8 @@ final class LicensePluginJvmSpec extends Specification {
         </body>
       </html>
       """
-    def actualJson = new File(reportFolder, 'licenseReport.json')
-    def expectedJson =
+    File actualJson = new File(reportFolder, 'licenseReport.json')
+    String expectedJson =
       """
       [
         {
@@ -142,7 +143,7 @@ final class LicensePluginJvmSpec extends Specification {
         }
       ]
       """
-    def actualText = new File(reportFolder, 'licenseReport.txt')
+    File actualText = new File(reportFolder, 'licenseReport.txt')
 
     then:
     result.task(':licenseReport').outcome == SUCCESS
@@ -184,10 +185,10 @@ final class LicensePluginJvmSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
-    def actualCsv = new File(reportFolder, 'licenseReport.csv')
-    def actualHtml = new File(reportFolder, 'licenseReport.html')
-    def expectedHtml =
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    File actualCsv = new File(reportFolder, 'licenseReport.csv')
+    File actualHtml = new File(reportFolder, 'licenseReport.html')
+    String expectedHtml =
       """
       <!DOCTYPE html>
       <html lang="en">
@@ -220,8 +221,8 @@ final class LicensePluginJvmSpec extends Specification {
         </body>
       </html>
       """
-    def actualJson = new File(reportFolder, 'licenseReport.json')
-    def expectedJson =
+    File actualJson = new File(reportFolder, 'licenseReport.json')
+    String expectedJson =
       """
       [
         {
@@ -256,7 +257,7 @@ final class LicensePluginJvmSpec extends Specification {
         }
       ]
       """
-    def actualText = new File(reportFolder, 'licenseReport.txt')
+    File actualText = new File(reportFolder, 'licenseReport.txt')
 
     then:
     result.task(':licenseReport').outcome == SUCCESS
@@ -295,10 +296,10 @@ final class LicensePluginJvmSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
-    def actualCsv = new File(reportFolder, 'licenseReport.csv')
-    def actualHtml = new File(reportFolder, 'licenseReport.html')
-    def expectedHtml =
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    File actualCsv = new File(reportFolder, 'licenseReport.csv')
+    File actualHtml = new File(reportFolder, 'licenseReport.html')
+    String expectedHtml =
       """
       <!DOCTYPE html>
       <html lang="en">
@@ -331,8 +332,8 @@ final class LicensePluginJvmSpec extends Specification {
         </body>
       </html>
       """
-    def actualJson = new File(reportFolder, 'licenseReport.json')
-    def expectedJson =
+    File actualJson = new File(reportFolder, 'licenseReport.json')
+    String expectedJson =
       """
       [
         {
@@ -367,7 +368,7 @@ final class LicensePluginJvmSpec extends Specification {
         }
       ]
       """
-    def actualText = new File(reportFolder, 'licenseReport.txt')
+    File actualText = new File(reportFolder, 'licenseReport.txt')
 
     then:
     result.task(':licenseReport').outcome == SUCCESS
@@ -404,10 +405,10 @@ final class LicensePluginJvmSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
-    def actualCsv = new File(reportFolder, 'licenseReport.csv')
-    def actualHtml = new File(reportFolder, 'licenseReport.html')
-    def expectedHtml =
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    File actualCsv = new File(reportFolder, 'licenseReport.csv')
+    File actualHtml = new File(reportFolder, 'licenseReport.html')
+    String expectedHtml =
       """
       <!DOCTYPE html>
       <html lang="en">
@@ -421,12 +422,12 @@ final class LicensePluginJvmSpec extends Specification {
         </body>
       </html>
       """
-    def actualJson = new File(reportFolder, 'licenseReport.json')
-    def expectedJson =
+    File actualJson = new File(reportFolder, 'licenseReport.json')
+    String expectedJson =
       """
       []
       """
-    def actualText = new File(reportFolder, 'licenseReport.txt')
+    File actualText = new File(reportFolder, 'licenseReport.txt')
 
     then:
     result.task(':licenseReport').outcome == SUCCESS
@@ -463,10 +464,10 @@ final class LicensePluginJvmSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
-    def actualCsv = new File(reportFolder, 'licenseReport.csv')
-    def actualHtml = new File(reportFolder, 'licenseReport.html')
-    def expectedHtml =
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    File actualCsv = new File(reportFolder, 'licenseReport.csv')
+    File actualHtml = new File(reportFolder, 'licenseReport.html')
+    String expectedHtml =
       """
       <!DOCTYPE html>
       <html lang="en">
@@ -494,8 +495,8 @@ final class LicensePluginJvmSpec extends Specification {
         </body>
       </html>
       """
-    def actualJson = new File(reportFolder, 'licenseReport.json')
-    def expectedJson =
+    File actualJson = new File(reportFolder, 'licenseReport.json')
+    String expectedJson =
       """
       [
         {
@@ -517,7 +518,7 @@ final class LicensePluginJvmSpec extends Specification {
         }
       ]
       """
-    def actualText = new File(reportFolder, 'licenseReport.txt')
+    File actualText = new File(reportFolder, 'licenseReport.txt')
 
     then:
     result.task(':licenseReport').outcome == SUCCESS
@@ -554,10 +555,10 @@ final class LicensePluginJvmSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
-    def actualCsv = new File(reportFolder, 'licenseReport.csv')
-    def actualHtml = new File(reportFolder, 'licenseReport.html')
-    def expectedHtml =
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    File actualCsv = new File(reportFolder, 'licenseReport.csv')
+    File actualHtml = new File(reportFolder, 'licenseReport.html')
+    String expectedHtml =
       """
       <!DOCTYPE html>
       <html lang="en">
@@ -589,8 +590,8 @@ final class LicensePluginJvmSpec extends Specification {
         </body>
       </html>
       """
-    def actualJson = new File(reportFolder, 'licenseReport.json')
-    def expectedJson =
+    File actualJson = new File(reportFolder, 'licenseReport.json')
+    String expectedJson =
       """
       [
         {
@@ -616,7 +617,7 @@ final class LicensePluginJvmSpec extends Specification {
         }
       ]
       """
-    def actualText = new File(reportFolder, 'licenseReport.txt')
+    File actualText = new File(reportFolder, 'licenseReport.txt')
 
     then:
     result.task(':licenseReport').outcome == SUCCESS
@@ -654,10 +655,10 @@ final class LicensePluginJvmSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
-    def actualCsv = new File(reportFolder, 'licenseReport.csv')
-    def actualHtml = new File(reportFolder, 'licenseReport.html')
-    def expectedHtml =
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    File actualCsv = new File(reportFolder, 'licenseReport.csv')
+    File actualHtml = new File(reportFolder, 'licenseReport.html')
+    String expectedHtml =
       """
       <!DOCTYPE html>
       <html lang="en">
@@ -697,8 +698,8 @@ final class LicensePluginJvmSpec extends Specification {
         </body>
       </html>
       """
-    def actualJson = new File(reportFolder, 'licenseReport.json')
-    def expectedJson =
+    File actualJson = new File(reportFolder, 'licenseReport.json')
+    String expectedJson =
       """
       [
         {
@@ -735,7 +736,7 @@ final class LicensePluginJvmSpec extends Specification {
         }
       ]
       """
-    def actualText = new File(reportFolder, 'licenseReport.txt')
+    File actualText = new File(reportFolder, 'licenseReport.txt')
 
     then:
     result.task(':licenseReport').outcome == SUCCESS
@@ -774,9 +775,9 @@ final class LicensePluginJvmSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
-    def actualJson = new File(reportFolder, 'licenseReport.json')
-    def expectedJson =
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    File actualJson = new File(reportFolder, 'licenseReport.json')
+    String expectedJson =
       """
       [
         {
@@ -841,10 +842,10 @@ final class LicensePluginJvmSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
-    def actualCsv = new File(reportFolder, 'licenseReport.csv')
-    def actualHtml = new File(reportFolder, 'licenseReport.html')
-    def expectedHtml =
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    File actualCsv = new File(reportFolder, 'licenseReport.csv')
+    File actualHtml = new File(reportFolder, 'licenseReport.html')
+    String expectedHtml =
       """
       <!DOCTYPE html>
       <html lang="en">
@@ -883,8 +884,8 @@ final class LicensePluginJvmSpec extends Specification {
         </body>
       </html>
       """
-    def actualJson = new File(reportFolder, 'licenseReport.json')
-    def expectedJson =
+    File actualJson = new File(reportFolder, 'licenseReport.json')
+    String expectedJson =
       """
       [
         {
@@ -929,7 +930,7 @@ final class LicensePluginJvmSpec extends Specification {
         }
       ]
       """
-    def actualText = new File(reportFolder, 'licenseReport.txt')
+    File actualText = new File(reportFolder, 'licenseReport.txt')
 
     then:
     result.task(':licenseReport').outcome == SUCCESS
@@ -982,10 +983,10 @@ final class LicensePluginJvmSpec extends Specification {
       }
       """
     when:
-    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
-    def actualCsv = new File(reportFolder, 'licenseReport.csv')
-    def actualHtml = new File(reportFolder, 'licenseReport.html')
-    def expectedHtml =
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    File actualCsv = new File(reportFolder, 'licenseReport.csv')
+    File actualHtml = new File(reportFolder, 'licenseReport.html')
+    String expectedHtml =
       """
       <!DOCTYPE html>
       <html lang="en">
@@ -1018,8 +1019,8 @@ final class LicensePluginJvmSpec extends Specification {
         </body>
       </html>
       """
-    def actualJson = new File(reportFolder, 'licenseReport.json')
-    def expectedJson =
+    File actualJson = new File(reportFolder, 'licenseReport.json')
+    String expectedJson =
       """
       [
         {
@@ -1054,7 +1055,7 @@ final class LicensePluginJvmSpec extends Specification {
         }
       ]
       """
-    def actualText = new File(reportFolder, 'licenseReport.txt')
+    File actualText = new File(reportFolder, 'licenseReport.txt')
 
     then:
     result.task(':licenseReport').outcome == SUCCESS
@@ -1072,7 +1073,7 @@ final class LicensePluginJvmSpec extends Specification {
 
   def 'licenseReport with project dependencies - deep dependency graph'() {
     given:
-    def depth = 18
+    int depth = 18
 
     testProjectDir.newFile('settings.gradle') <<
       """
@@ -1172,10 +1173,10 @@ final class LicensePluginJvmSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
-    def actualCsv = new File(reportFolder, 'licenseReport.csv')
-    def actualHtml = new File(reportFolder, 'licenseReport.html')
-    def expectedHtml =
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    File actualCsv = new File(reportFolder, 'licenseReport.csv')
+    File actualHtml = new File(reportFolder, 'licenseReport.html')
+    String expectedHtml =
       """
       <!DOCTYPE html>
       <html lang="en">
@@ -1208,8 +1209,8 @@ final class LicensePluginJvmSpec extends Specification {
         </body>
       </html>
       """
-    def actualJson = new File(reportFolder, 'licenseReport.json')
-    def expectedJson =
+    File actualJson = new File(reportFolder, 'licenseReport.json')
+    String expectedJson =
       """
       [
         {
@@ -1244,7 +1245,7 @@ final class LicensePluginJvmSpec extends Specification {
         }
       ]
       """
-    def actualText = new File(reportFolder, 'licenseReport.txt')
+    File actualText = new File(reportFolder, 'licenseReport.txt')
 
     then:
     result.task(':licenseReport').outcome == SUCCESS
@@ -1297,10 +1298,10 @@ final class LicensePluginJvmSpec extends Specification {
       }
       """
     when:
-    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
-    def actualCsv = new File(reportFolder, 'licenseReport.csv')
-    def actualHtml = new File(reportFolder, 'licenseReport.html')
-    def expectedHtml =
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    File actualCsv = new File(reportFolder, 'licenseReport.csv')
+    File actualHtml = new File(reportFolder, 'licenseReport.html')
+    String expectedHtml =
       """
       <!DOCTYPE html>
       <html lang="en">
@@ -1333,8 +1334,8 @@ final class LicensePluginJvmSpec extends Specification {
         </body>
       </html>
       """
-    def actualJson = new File(reportFolder, 'licenseReport.json')
-    def expectedJson =
+    File actualJson = new File(reportFolder, 'licenseReport.json')
+    String expectedJson =
       """
       [
         {
@@ -1369,7 +1370,7 @@ final class LicensePluginJvmSpec extends Specification {
         }
       ]
       """
-    def actualText = new File(reportFolder, 'licenseReport.txt')
+    File actualText = new File(reportFolder, 'licenseReport.txt')
 
     then:
     result.task(':licenseReport').outcome == SUCCESS
@@ -1407,7 +1408,7 @@ final class LicensePluginJvmSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
 
     then:
     result.task(':licenseReport').outcome == SUCCESS
@@ -1436,9 +1437,9 @@ final class LicensePluginJvmSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, "licenseReport", '-s')
-    def actualHtml = new File(reportFolder, "licenseReport.html").text
-    def expectedHtml =
+    BuildResult result = gradleWithCommand(testProjectDir.root, "licenseReport", '-s')
+    String actualHtml = new File(reportFolder, "licenseReport.html").text
+    String expectedHtml =
       """
       <!DOCTYPE html>
       <html lang="en">
@@ -1467,8 +1468,8 @@ final class LicensePluginJvmSpec extends Specification {
         </body>
       </html>
       """
-    def actualJson = new File(reportFolder, "licenseReport.json").text
-    def expectedJson =
+    String actualJson = new File(reportFolder, "licenseReport.json").text
+    String expectedJson =
       """
       [
         {
@@ -1525,9 +1526,9 @@ final class LicensePluginJvmSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
-    def actualJson = new File(reportFolder, 'licenseReport.json')
-    def expectedJson =
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    File actualJson = new File(reportFolder, 'licenseReport.json')
+    String expectedJson =
       """
       [
         {
@@ -1574,9 +1575,9 @@ final class LicensePluginJvmSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
-    def actualJson = new File(reportFolder, 'licenseReport.json')
-    def expectedJson =
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    File actualJson = new File(reportFolder, 'licenseReport.json')
+    String expectedJson =
       """
       [
         {
@@ -1618,9 +1619,9 @@ final class LicensePluginJvmSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
-    def actualJson = new File(reportFolder, 'licenseReport.json')
-    def expectedJson =
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    File actualJson = new File(reportFolder, 'licenseReport.json')
+    String expectedJson =
       """
       [
         {
@@ -1663,9 +1664,9 @@ final class LicensePluginJvmSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
-    def actualJson = new File(reportFolder, 'licenseReport.json')
-    def expectedJson =
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    File actualJson = new File(reportFolder, 'licenseReport.json')
+    String expectedJson =
       """
       [
         {
@@ -1712,9 +1713,9 @@ final class LicensePluginJvmSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
-    def actualJson = new File(reportFolder, 'licenseReport.json')
-    def expectedJson =
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    File actualJson = new File(reportFolder, 'licenseReport.json')
+    String expectedJson =
       """
       [
         {
@@ -1773,7 +1774,7 @@ final class LicensePluginJvmSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
 
     then: 'the report is generated without resolving any configuration during configuration'
     result.task(':licenseReport').outcome == SUCCESS
@@ -1783,8 +1784,8 @@ final class LicensePluginJvmSpec extends Specification {
   @Issue("jaredsburrows/gradle-license-plugin/issues/804")
   def 'licenseReport re-runs when a POM changes in place'() {
     given: 'a dependency in a file-based repository inside the test project'
-    def repoDir = testProjectDir.newFolder('repo', 'group', 'local', '1.0.0')
-    def pomFile = new File(repoDir, 'local-1.0.0.pom')
+    File repoDir = testProjectDir.newFolder('repo', 'group', 'local', '1.0.0')
+    File pomFile = new File(repoDir, 'local-1.0.0.pom')
     pomFile.text = """<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0">
   <modelVersion>4.0.0</modelVersion>
@@ -1820,21 +1821,21 @@ final class LicensePluginJvmSpec extends Specification {
       """
 
     when: 'the report is generated'
-    def first = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    BuildResult first = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
 
     then:
     first.task(':licenseReport').outcome == SUCCESS
     new File(reportFolder, 'licenseReport.json').text.contains('License A')
 
     when: 'nothing changes'
-    def second = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    BuildResult second = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
 
     then:
     second.task(':licenseReport').outcome == UP_TO_DATE
 
     when: 'the POM content changes at the same path'
     pomFile.text = pomFile.text.replace('License A', 'License B')
-    def third = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    BuildResult third = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
 
     then: 'the task is not up-to-date and regenerates the report'
     third.task(':licenseReport').outcome == SUCCESS
@@ -1870,9 +1871,9 @@ final class LicensePluginJvmSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
-    def actualJson = new File(reportFolder, 'licenseReport.json')
-    def expectedJson =
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    File actualJson = new File(reportFolder, 'licenseReport.json')
+    String expectedJson =
       """
       [
         {
@@ -1955,8 +1956,8 @@ final class LicensePluginJvmSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
-    def actualJson = new File(reportFolder, 'licenseReport.json')
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    File actualJson = new File(reportFolder, 'licenseReport.json')
 
     then: 'only the exact artifact is ignored, not its -suffix sibling'
     result.task(':licenseReport').outcome == SUCCESS
@@ -1993,10 +1994,10 @@ final class LicensePluginJvmSpec extends Specification {
       """
 
     when: 'the report task runs as part of the build task graph, not directly'
-    def result = gradleWithCommand(testProjectDir.root, 'build', '-s')
-    def actualJson = new File(reportFolder, 'licenseReport.json')
-    def bundledJson = new File(testProjectDir.root, 'build/resources/main/public/oss/licenseReport.json')
-    def expectedJson =
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'build', '-s')
+    File actualJson = new File(reportFolder, 'licenseReport.json')
+    File bundledJson = new File(testProjectDir.root, 'build/resources/main/public/oss/licenseReport.json')
+    String expectedJson =
       """
       [
         {
@@ -2048,8 +2049,8 @@ final class LicensePluginJvmSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
-    def actualJsonFull = new File(reportFolder, 'licenseReport.full.json')
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    File actualJsonFull = new File(reportFolder, 'licenseReport.full.json')
 
     then:
     result.task(':licenseReport').outcome == SUCCESS
@@ -2085,12 +2086,12 @@ final class LicensePluginJvmSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
-    def actualJsonFull = new File(reportFolder, 'licenseReport.full.json')
-    def actualJson = new File(reportFolder, 'licenseReport.json')
-    def report = new JsonSlurper().parseText(actualJsonFull.text)
-    def known = report.dependencies.find { it.dependency == 'pl.droidsonroids.gif:android-gif-drawable:1.2.3' }
-    def unknown = report.dependencies.find { it.dependency == 'group:name:1.0.0' }
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    File actualJsonFull = new File(reportFolder, 'licenseReport.full.json')
+    File actualJson = new File(reportFolder, 'licenseReport.json')
+    Object report = new JsonSlurper().parseText(actualJsonFull.text)
+    Object known = report.dependencies.find { it.dependency == 'pl.droidsonroids.gif:android-gif-drawable:1.2.3' }
+    Object unknown = report.dependencies.find { it.dependency == 'group:name:1.0.0' }
 
     then:
     result.task(':licenseReport').outcome == SUCCESS
@@ -2136,9 +2137,9 @@ final class LicensePluginJvmSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
-    def actualJsonFull = new File(reportFolder, 'licenseReport.full.json')
-    def report = new JsonSlurper().parseText(actualJsonFull.text)
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    File actualJsonFull = new File(reportFolder, 'licenseReport.full.json')
+    Object report = new JsonSlurper().parseText(actualJsonFull.text)
 
     then:
     result.task(':licenseReport').outcome == SUCCESS
@@ -2168,7 +2169,7 @@ final class LicensePluginJvmSpec extends Specification {
       """
 
     when: 'the parent chain is walked'
-    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
 
     then: 'it stops at the repeat instead of recursing until the stack overflows'
     result.task(':licenseReport').outcome == SUCCESS
@@ -2206,18 +2207,18 @@ final class LicensePluginJvmSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
 
     then:
     result.task(':licenseReport').outcome == SUCCESS
 
     and: 'the HTML inlines the full EPL text rather than only linking to it'
-    def html = new File(reportFolder, 'licenseReport.html').text
+    String html = new File(reportFolder, 'licenseReport.html').text
     html.contains('Eclipse Public License - v 1.0')
     html.contains('EPL library')
 
     and: 'the full JSON carries it under its own key, not apache-2.0 or mit'
-    def full = new JsonSlurper().parseText(new File(reportFolder, 'licenseReport.full.json').text)
+    Object full = new JsonSlurper().parseText(new File(reportFolder, 'licenseReport.full.json').text)
     full.license_texts.keySet() == ['epl-1.0'] as Set
     full.dependencies[0].licenses[0].license_key == 'epl-1.0'
 
@@ -2249,8 +2250,8 @@ final class LicensePluginJvmSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
-    def json = new File(reportFolder, 'licenseReport.json').text
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    String json = new File(reportFolder, 'licenseReport.json').text
 
     then:
     result.task(':licenseReport').outcome == SUCCESS
@@ -2283,8 +2284,8 @@ final class LicensePluginJvmSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
-    def json = new File(reportFolder, 'licenseReport.json').text
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    String json = new File(reportFolder, 'licenseReport.json').text
 
     then:
     result.task(':licenseReport').outcome == SUCCESS
@@ -2318,9 +2319,9 @@ final class LicensePluginJvmSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
-    def json = new JsonSlurper().parseText(new File(reportFolder, 'licenseReport.json').text)
-    def entry = json.find { it.dependency == 'group:inheritchild:1.0.0' }
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    Object json = new JsonSlurper().parseText(new File(reportFolder, 'licenseReport.json').text)
+    Object entry = json.find { it.dependency == 'group:inheritchild:1.0.0' }
 
     then:
     result.task(':licenseReport').outcome == SUCCESS
@@ -2358,9 +2359,9 @@ final class LicensePluginJvmSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
-    def json = new JsonSlurper().parseText(new File(reportFolder, 'licenseReport.json').text)
-    def entry = json.find { it.dependency == 'group:devid:1.0.0' }
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    Object json = new JsonSlurper().parseText(new File(reportFolder, 'licenseReport.json').text)
+    Object entry = json.find { it.dependency == 'group:devid:1.0.0' }
 
     then:
     result.task(':licenseReport').outcome == SUCCESS
@@ -2374,7 +2375,7 @@ final class LicensePluginJvmSpec extends Specification {
 
   def 'the plugin works without the Kotlin Gradle Plugin or AGP on the buildscript classpath'() {
     given: 'the plugin classpath with every Kotlin and Android Gradle plugin jar removed'
-    def withoutOptionalPlugins = getClass().classLoader.getResource('plugin-classpath.txt')
+    String withoutOptionalPlugins = getClass().classLoader.getResource('plugin-classpath.txt')
       .readLines()
       .findAll { !(it.contains('kotlin-gradle-plugin') || it.contains('com.android.tools')) }
       .collect { "'${new File(it).absolutePath.replace('\\', '\\\\')}'" }
@@ -2403,7 +2404,7 @@ final class LicensePluginJvmSpec extends Specification {
       """
 
     when: 'a plain Java consumer runs the report'
-    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
 
     then: 'compileOnly AGP and KGP types are never loaded, so nothing fails to resolve'
     result.task(':licenseReport').outcome == SUCCESS

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginKmpSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginKmpSpec.groovy
@@ -1,6 +1,7 @@
 package com.jaredsburrows.license
 
 import groovy.json.JsonSlurper
+import org.gradle.testkit.runner.BuildResult
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
@@ -20,7 +21,7 @@ final class LicensePluginKmpSpec extends Specification {
     // withPluginClasspath() exposes only the plugin's own runtime classpath, so a test that needs
     // the Kotlin Gradle Plugin reads the full test runtime classpath instead, as the Android spec
     // does for AGP.
-    def pluginClasspathResource = getClass().classLoader.getResource('plugin-classpath.txt')
+    URL pluginClasspathResource = getClass().classLoader.getResource('plugin-classpath.txt')
     if (pluginClasspathResource == null) {
       throw new IllegalStateException(
         'Did not find plugin classpath resource, run `testClasses` build task.')
@@ -68,8 +69,8 @@ final class LicensePluginKmpSpec extends Specification {
       """
 
     when: 'the per-target report task is run'
-    def result = gradleWithCommand(testProjectDir.root, 'licenseJvmReport', '-s')
-    def json = new JsonSlurper().parseText(new File(reportFolder, 'licenseJvmReport.json').text)
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseJvmReport', '-s')
+    Object json = new JsonSlurper().parseText(new File(reportFolder, 'licenseJvmReport.json').text)
 
     then: 'applying the plugin no longer fails the build'
     result.task(':licenseJvmReport').outcome == SUCCESS

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginSpec.groovy
@@ -1,5 +1,6 @@
 package com.jaredsburrows.license
 
+import org.gradle.testkit.runner.BuildResult
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
@@ -18,7 +19,7 @@ final class LicensePluginSpec extends Specification {
   private File buildFile
 
   def 'setup'() {
-    def pluginClasspathResource = getClass().classLoader.getResource('plugin-classpath.txt')
+    URL pluginClasspathResource = getClass().classLoader.getResource('plugin-classpath.txt')
     if (pluginClasspathResource == null) {
       throw new IllegalStateException(
         'Did not find plugin classpath resource, run `testClasses` build task.')
@@ -52,7 +53,7 @@ final class LicensePluginSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
 
     then:
     result.task(':licenseReport').outcome == SUCCESS
@@ -77,7 +78,7 @@ final class LicensePluginSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommandWithFail(testProjectDir.root, 'licenseReport', '-s')
+    BuildResult result = gradleWithCommandWithFail(testProjectDir.root, 'licenseReport', '-s')
 
     then:
     result.output.contains("'com.jaredsburrows.license' requires Java, Kotlin or Android Gradle based plugins.")
@@ -94,7 +95,7 @@ final class LicensePluginSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
 
     then:
     result.task(':licenseReport').outcome == SUCCESS
@@ -110,7 +111,7 @@ final class LicensePluginSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommandWithFail(testProjectDir.root, 'licenseReport', '-s')
+    BuildResult result = gradleWithCommandWithFail(testProjectDir.root, 'licenseReport', '-s')
 
     then:
     result.output.contains("'com.jaredsburrows.license' requires Java, Kotlin or Android Gradle based plugins.")
@@ -128,7 +129,7 @@ final class LicensePluginSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommandWithFail(testProjectDir.root, 'licenseReport', '-s')
+    BuildResult result = gradleWithCommandWithFail(testProjectDir.root, 'licenseReport', '-s')
 
     then:
     result.output.contains("'com.jaredsburrows.license' requires Java, Kotlin or Android Gradle based plugins.")
@@ -165,7 +166,7 @@ final class LicensePluginSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
 
     then:
     result.task(':licenseReport').outcome == SUCCESS
@@ -251,7 +252,7 @@ final class LicensePluginSpec extends Specification {
       """
 
     when:
-    def result = gradleWithCommand(testProjectDir.root, 'licenseDebugReport', '-s')
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseDebugReport', '-s')
 
     then:
     result.task(':licenseDebugReport').outcome == SUCCESS

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginVersionSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginVersionSpec.groovy
@@ -1,5 +1,6 @@
 package com.jaredsburrows.license
 
+import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
@@ -23,7 +24,7 @@ final class LicensePluginVersionSpec extends Specification {
   private String reportFolder
 
   def 'setup'() {
-    def pluginClasspathResource = getClass().classLoader.getResource('plugin-classpath.txt')
+    URL pluginClasspathResource = getClass().classLoader.getResource('plugin-classpath.txt')
     if (pluginClasspathResource == null) {
       throw new IllegalStateException(
         'Did not find plugin classpath resource, run `testClasses` build task.')
@@ -34,7 +35,7 @@ final class LicensePluginVersionSpec extends Specification {
       .collect { it.absolutePath.replace('\\', '\\\\') } // escape backslashes in Windows paths
       .collect { "'$it'" }
       .join(", ")
-    def mainClasspathResource = getClass().classLoader.getResource('plugin-classpath-main.txt')
+    URL mainClasspathResource = getClass().classLoader.getResource('plugin-classpath-main.txt')
     mainClasspathString = mainClasspathResource.readLines().collect { new File(it) }
       .collect { it.absolutePath.replace('\\', '\\\\') }
       .collect { "'$it'" }
@@ -56,7 +57,7 @@ final class LicensePluginVersionSpec extends Specification {
       """
 
     when:
-    def result = GradleRunner.create()
+    BuildResult result = GradleRunner.create()
       .withGradleVersion(gradleVersion)
       .withProjectDir(testProjectDir.root)
       .withArguments('licenseReport', '-s')
@@ -112,7 +113,7 @@ final class LicensePluginVersionSpec extends Specification {
     """
 
     when:
-    def result = GradleRunner.create()
+    BuildResult result = GradleRunner.create()
       .withGradleVersion(gradleVersion as String)
       .withProjectDir(testProjectDir.root)
       .withArguments('licenseDebugReport', '-s')


### PR DESCRIPTION
Finishes what #857 started, across the remaining functional specs. Every local `def` in `src/test/groovy` now carries an explicit type.

### What changed

312 declarations across five specs:

| type | count | from |
|---|---|---|
| `File` | 123 | `new File(reportFolder, 'licenseReport.json')` |
| `String` | 92 | heredocs and string expressions |
| `BuildResult` | 77 | `gradleWithCommand(...)` |
| `Object` | 11 | `JsonSlurper().parseText(...)`, `.find { }` |
| `URL` | 6 | `getResource('plugin-classpath.txt')` |
| `int` | 1 | |

Plus the imports those needed (`BuildResult`).

### Deliberately left as `def`

Two, both inside `"""` heredocs — they are Groovy source written into the *generated* `build.gradle` of a test project, not code in this file:

```groovy
def configurationPhase = new java.util.concurrent.atomic.AtomicBoolean(true)
```

Typing those broke the generated script, since `AtomicBoolean` is not imported in the project under test. Worth knowing for anyone running a similar sweep: a naive search-and-replace over these files will edit string contents.

### No behaviour change

Nothing here changes what executes. Two typing mistakes were caught by the suite while writing it, and both are fixed:

- `withoutOptionalPlugins` chains `.readLines().findAll { }.collect { }.join(', ')` off `getResource(...)`, so it is a `String`, not the `URL` the receiver suggests.
- The two `configurationPhase` cases above.

`URL` is correct for the five `pluginClasspathResource` / `mainClasspathResource` declarations, where the chain is a separate statement.

### Verification

`./gradlew :gradle-license-plugin:test` — 501 tests, 0 failures.
