### PR TITLE
Import AtomicBoolean in the generated scripts so the declaration reads normally

### DIFF
--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginAndroidSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginAndroidSpec.groovy
@@ -2352,6 +2352,8 @@ final class LicensePluginAndroidSpec extends Specification {
     given: 'a build that flags configuration-time resolution the same way AGP does'
     buildFile <<
       """
+      import java.util.concurrent.atomic.AtomicBoolean
+
       buildscript {
         dependencies {
           classpath files($classpathString)
@@ -2381,7 +2383,7 @@ final class LicensePluginAndroidSpec extends Specification {
       }
 
       // Mirror AGP's DependencyResolutionChecks: flag configurations resolved before the task graph is ready.
-      def configurationPhase = new java.util.concurrent.atomic.AtomicBoolean(true)
+      AtomicBoolean configurationPhase = new AtomicBoolean(true)
       gradle.taskGraph.whenReady { configurationPhase.set(false) }
       configurations.configureEach { conf ->
         conf.incoming.beforeResolve {

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJvmSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJvmSpec.groovy
@@ -1746,6 +1746,8 @@ final class LicensePluginJvmSpec extends Specification {
     given: 'a build that flags configuration-time resolution the same way AGP does'
     buildFile <<
       """
+      import java.util.concurrent.atomic.AtomicBoolean
+
       plugins {
         id 'java-library'
         id 'com.jaredsburrows.license'
@@ -1762,7 +1764,7 @@ final class LicensePluginJvmSpec extends Specification {
       }
 
       // Mirror AGP's DependencyResolutionChecks: flag configurations resolved before the task graph is ready.
-      def configurationPhase = new java.util.concurrent.atomic.AtomicBoolean(true)
+      AtomicBoolean configurationPhase = new AtomicBoolean(true)
       gradle.taskGraph.whenReady { configurationPhase.set(false) }
       configurations.configureEach { conf ->
         conf.incoming.beforeResolve {


### PR DESCRIPTION
Follow-up to #864, which left two declarations as `def`.

Both live inside `"""` heredocs — they are Groovy source written into the generated `build.gradle` of a test project, so the short type name has to resolve *there*, not in the spec. Adding the import to the generated script is enough:

```diff
       """
+      import java.util.concurrent.atomic.AtomicBoolean
+
       plugins {
         id 'java-library'
         id 'com.jaredsburrows.license'
       }
 ...
-      def configurationPhase = new java.util.concurrent.atomic.AtomicBoolean(true)
+      AtomicBoolean configurationPhase = new AtomicBoolean(true)
```

An `import` is allowed ahead of the `plugins {}` block, so this works in both the plain and the `buildscript {}`-prefixed script.

With this, `src/test/groovy` has no bare `def` left at all.

### Verification

`./gradlew :gradle-license-plugin:test --tests '*does not resolve configurations*'` — the three affected tests pass. Full suite was green at 501/0 on this change before rebasing onto #864.
