### PR TITLE
Ignore the .claude and .kotlin tool directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,9 @@ hs_err_pid*
 ### Gradle License Plugin ###
 # Reports the plugin copies into the test app assets while building
 test-apps/*/src/*/assets/open_source_licenses.*
+
+### Tooling ###
+# Claude Code keeps session state and scratch worktrees here
+.claude/
+# Kotlin compiler session directory
+.kotlin/


### PR DESCRIPTION
Neither `.claude/` nor `.kotlin/` was ignored, so both showed up as untracked working tree content.
`.idea/` was already ignored; these are the two that were missed.

`.claude/` holds Claude Code session state and scratch git worktrees. This is not hypothetical -
during a conflict resolution in this repo, a `git add -A` staged an **embedded git repository** from
it:

```
warning: adding embedded git repository: .claude/worktrees/spockk-groovy5-spike
```

It was caught and unstaged, but only because the warning happened to be read.

`.kotlin/` is the Kotlin compiler's session directory; it currently holds
`.kotlin/errors/errors-*.log`.

Verified neither path is tracked, so the ignore rule is sufficient on its own - no `git rm --cached`
needed - and `git status` is now clean with nothing untracked.
