### PR TITLE
Type-check LicensePluginKmpSpec

### DIFF
--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginKmpSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginKmpSpec.groovy
@@ -1,7 +1,9 @@
 package com.jaredsburrows.license
 
 import groovy.json.JsonSlurper
+import groovy.transform.TypeChecked
 import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
@@ -9,6 +11,7 @@ import spock.lang.Specification
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 import static test.TestUtils.gradleWithCommand
 
+@TypeChecked
 final class LicensePluginKmpSpec extends Specification {
   @Rule
   public final TemporaryFolder testProjectDir = new TemporaryFolder()
@@ -70,12 +73,15 @@ final class LicensePluginKmpSpec extends Specification {
 
     when: 'the per-target report task is run'
     BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseJvmReport', '-s')
-    Object json = new JsonSlurper().parseText(new File(reportFolder, 'licenseJvmReport.json').text)
+    List<Map<String, Object>> json =
+      (List<Map<String, Object>>) new JsonSlurper().parseText(new File(reportFolder, 'licenseJvmReport.json').text)
+    TaskOutcome outcome = result.task(':licenseJvmReport').outcome
+    List<Object> dependencies = json.collect { it.dependency }
 
     then: 'applying the plugin no longer fails the build'
-    result.task(':licenseJvmReport').outcome == SUCCESS
+    outcome == SUCCESS
 
     and: 'the jvm target dependencies are resolved and attributed'
-    json*.dependency == ['group:name:1.0.0']
+    dependencies == ['group:name:1.0.0']
   }
 }


### PR DESCRIPTION
Brings `LicensePluginKmpSpec` to compile-time type checking, joining `TextReportSpec`, `CsvReportSpec` and `JsonReportSpec` from #857.

It had three errors, all from doing work inside the conditions. Spock rewrites a condition before the type checker sees it, so any method call or property access in one resolves against an untyped receiver. Moving the work into the `when:` block fixes it:

```diff
     when: 'the per-target report task is run'
     BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseJvmReport', '-s')
-    Object json = new JsonSlurper().parseText(new File(reportFolder, 'licenseJvmReport.json').text)
+    List<Map<String, Object>> json =
+      (List<Map<String, Object>>) new JsonSlurper().parseText(new File(reportFolder, 'licenseJvmReport.json').text)
+    TaskOutcome outcome = result.task(':licenseJvmReport').outcome
+    List<Object> dependencies = json.collect { it.dependency }
 
     then: 'applying the plugin no longer fails the build'
-    result.task(':licenseJvmReport').outcome == SUCCESS
+    outcome == SUCCESS
 
     and: 'the jvm target dependencies are resolved and attributed'
-    json*.dependency == ['group:name:1.0.0']
+    dependencies == ['group:name:1.0.0']
```

### No coverage or diagnostic change

The same calls run with the same arguments and the same comparisons. Both conditions stay comparisons, so a failure still renders both sides and the string diff — naming the intermediate values arguably makes the `then:` blocks read better.

### Verification

`./gradlew :gradle-license-plugin:test` — 501 tests, 0 failures.
