### PR TITLE
Run the functional tests with the configuration cache

### DIFF
--- a/gradle-license-plugin/src/test/groovy/test/TestUtils.groovy
+++ b/gradle-license-plugin/src/test/groovy/test/TestUtils.groovy
@@ -55,28 +55,25 @@ final class TestUtils {
   }
 
   /**
-   * TestKit builds do not inherit the repository's gradle.properties, so the plugin's
-   * configuration cache compatibility went unverified: a build that breaks it still passed. Forcing
-   * the flag here means every functional test asserts it.
+   * A runner for the build in [file], differing only in whether the caller expects it to succeed.
+   *
+   * --configuration-cache is forced here: TestKit builds do not inherit the repository's
+   * gradle.properties, so the plugin's configuration cache compatibility went unverified and a
+   * build that breaks it still passed.
    */
-  private static String[] withConfigurationCache(String... commands) {
-    return (commands.toList() + '--configuration-cache') as String[]
+  private static GradleRunner runner(File file, String... commands) {
+    return GradleRunner.create()
+      .withProjectDir(file)
+      .withArguments((commands.toList() + '--configuration-cache') as String[])
+      .withPluginClasspath()
   }
 
   static BuildResult gradleWithCommand(File file, String... commands) {
-    return GradleRunner.create()
-      .withProjectDir(file)
-      .withArguments(withConfigurationCache(commands))
-      .withPluginClasspath()
-      .build()
+    return runner(file, commands).build()
   }
 
   static BuildResult gradleWithCommandWithFail(File file, String... commands) {
-    return GradleRunner.create()
-      .withProjectDir(file)
-      .withArguments(withConfigurationCache(commands))
-      .withPluginClasspath()
-      .buildAndFail()
+    return runner(file, commands).buildAndFail()
   }
 
   static String getLicenseText(String fileName) {

--- a/gradle-license-plugin/src/test/groovy/test/TestUtils.groovy
+++ b/gradle-license-plugin/src/test/groovy/test/TestUtils.groovy
@@ -54,10 +54,19 @@ final class TestUtils {
     return jsonAdapter.fromJson(text)
   }
 
+  /**
+   * TestKit builds do not inherit the repository's gradle.properties, so the plugin's
+   * configuration cache compatibility went unverified: a build that breaks it still passed. Forcing
+   * the flag here means every functional test asserts it.
+   */
+  private static String[] withConfigurationCache(String... commands) {
+    return (commands.toList() + '--configuration-cache') as String[]
+  }
+
   static BuildResult gradleWithCommand(File file, String... commands) {
     return GradleRunner.create()
       .withProjectDir(file)
-      .withArguments(commands)
+      .withArguments(withConfigurationCache(commands))
       .withPluginClasspath()
       .build()
   }
@@ -65,7 +74,7 @@ final class TestUtils {
   static BuildResult gradleWithCommandWithFail(File file, String... commands) {
     return GradleRunner.create()
       .withProjectDir(file)
-      .withArguments(commands)
+      .withArguments(withConfigurationCache(commands))
       .withPluginClasspath()
       .buildAndFail()
   }


### PR DESCRIPTION
TestKit builds do **not** inherit the repository's `gradle.properties`, so
`org.gradle.configuration-cache=true` applied only to the outer build. The inner builds - the ones
that actually exercise the plugin - ran without it, and nothing in the suite asserted the plugin is
configuration cache compatible.

## Measured, not assumed

I injected a plain configuration cache violation (a `Task.project` access at execution time) and ran
the functional specs both ways:

| runner | result |
| --- | --- |
| **with** `--configuration-cache` | **35 of 35 fail** |
| **without** (today) | **35 of 35 pass** - violation invisible |

The failure is the expected one:

```
1 problem was found storing the configuration cache.
- Task `:licenseReport` of type `com.jaredsburrows.license.LicenseReportTask` ...
```

## This gap already cost us

#846's iterative parent walk broke the configuration cache with *"cannot serialize Gradle script
object references"* - a Kotlin script-level `val` captured in `doLast`. It was caught by reading the
code, not by a failing test. With this in place the suite would have caught it.

## Nothing to fix first

**All 501 tests pass with the flag on**, so the plugin is already compatible. This is hardening, not
a repair.

## Two details

- It goes in **both** runners - `gradleWithCommand` and `gradleWithCommandWithFail` - or the
  failure-path specs stay unverified. Shared helper rather than a duplicated argument.
- The obvious spread form does **not** compile:
  `[*commands, '--configuration-cache']` fails groovyc with
  `BUG! exception in phase 'class generation' ... SpreadExpression should not be visited here`.
  `(commands.toList() + '--configuration-cache') as String[]` works.

Clean `ktlintCheck build` with the cache disabled: 501 tests, 0 failures, ~2m - no measurable change
in suite time, though CI on a cold runner is the real check.
