### PR TITLE
Type-check LicenseReportExtensionSpec and the two plugin specs

### DIFF
--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginSpec.groovy
@@ -1,8 +1,10 @@
 package com.jaredsburrows.license
 
 import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
+import groovy.transform.TypeChecked
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -10,6 +12,7 @@ import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 import static test.TestUtils.gradleWithCommand
 import static test.TestUtils.gradleWithCommandWithFail
 
+@TypeChecked
 final class LicensePluginSpec extends Specification {
   @Rule
   public final TemporaryFolder testProjectDir = new TemporaryFolder()
@@ -54,9 +57,10 @@ final class LicensePluginSpec extends Specification {
 
     when:
     BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    TaskOutcome outcome = result.task(':licenseReport').outcome
 
     then:
-    result.task(':licenseReport').outcome == SUCCESS
+    outcome == SUCCESS
   }
 
   def 'apply plugin with buildscript dsl and no other plugins'() {
@@ -79,9 +83,10 @@ final class LicensePluginSpec extends Specification {
 
     when:
     BuildResult result = gradleWithCommandWithFail(testProjectDir.root, 'licenseReport', '-s')
+    boolean requiresSupportedPlugin = result.output.contains("'com.jaredsburrows.license' requires Java, Kotlin or Android Gradle based plugins.")
 
     then:
-    result.output.contains("'com.jaredsburrows.license' requires Java, Kotlin or Android Gradle based plugins.")
+    requiresSupportedPlugin
   }
 
   def 'apply plugin with plugins dsl'() {
@@ -96,9 +101,10 @@ final class LicensePluginSpec extends Specification {
 
     when:
     BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    TaskOutcome outcome = result.task(':licenseReport').outcome
 
     then:
-    result.task(':licenseReport').outcome == SUCCESS
+    outcome == SUCCESS
   }
 
   def 'apply plugin with plugins dsl and no other plugins'() {
@@ -112,9 +118,10 @@ final class LicensePluginSpec extends Specification {
 
     when:
     BuildResult result = gradleWithCommandWithFail(testProjectDir.root, 'licenseReport', '-s')
+    boolean requiresSupportedPlugin = result.output.contains("'com.jaredsburrows.license' requires Java, Kotlin or Android Gradle based plugins.")
 
     then:
-    result.output.contains("'com.jaredsburrows.license' requires Java, Kotlin or Android Gradle based plugins.")
+    requiresSupportedPlugin
   }
 
   @Unroll
@@ -130,9 +137,10 @@ final class LicensePluginSpec extends Specification {
 
     when:
     BuildResult result = gradleWithCommandWithFail(testProjectDir.root, 'licenseReport', '-s')
+    boolean requiresSupportedPlugin = result.output.contains("'com.jaredsburrows.license' requires Java, Kotlin or Android Gradle based plugins.")
 
     then:
-    result.output.contains("'com.jaredsburrows.license' requires Java, Kotlin or Android Gradle based plugins.")
+    requiresSupportedPlugin
 
     where:
     // https://github.com/gradle/gradle/find/master, search for "gradle-plugins"
@@ -167,9 +175,10 @@ final class LicensePluginSpec extends Specification {
 
     when:
     BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    TaskOutcome outcome = result.task(':licenseReport').outcome
 
     then:
-    result.task(':licenseReport').outcome == SUCCESS
+    outcome == SUCCESS
 
     where:
     // https://github.com/gradle/gradle/find/master, search for "gradle-plugins"
@@ -253,9 +262,10 @@ final class LicensePluginSpec extends Specification {
 
     when:
     BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseDebugReport', '-s')
+    TaskOutcome outcome = result.task(':licenseDebugReport').outcome
 
     then:
-    result.task(':licenseDebugReport').outcome == SUCCESS
+    outcome == SUCCESS
 
     where:
     androidPlugin << [

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginVersionSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginVersionSpec.groovy
@@ -1,9 +1,11 @@
 package com.jaredsburrows.license
 
 import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
+import groovy.transform.TypeChecked
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -13,6 +15,7 @@ import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 // https://developer.android.com/studio/releases/gradle-plugin
 // https://docs.gradle.org/current/userguide/compatibility.html#plugin-compatibility
 // https://gradle.org/releases/
+@TypeChecked
 final class LicensePluginVersionSpec extends Specification {
   @Rule
   public final TemporaryFolder testProjectDir = new TemporaryFolder()
@@ -46,7 +49,7 @@ final class LicensePluginVersionSpec extends Specification {
   }
 
   @Unroll
-  def 'licenseReport using with gradle #gradleVersion'() {
+  def 'licenseReport using with gradle #gradleVersion'(String gradleVersion) {
     given:
     buildFile <<
       """
@@ -63,13 +66,18 @@ final class LicensePluginVersionSpec extends Specification {
       .withArguments('licenseReport', '-s')
       .withPluginClasspath()
       .build()
+    TaskOutcome outcome = result.task(':licenseReport').outcome
+    String wroteCsv = result.output.find("Wrote CSV report to .*${reportFolder}/licenseReport.csv.")
+    String wroteHtml = result.output.find("Wrote HTML report to .*${reportFolder}/licenseReport.html.")
+    String wroteJson = result.output.find("Wrote JSON report to .*${reportFolder}/licenseReport.json.")
+    String wroteText = result.output.find("Wrote Text report to .*${reportFolder}/licenseReport.txt.")
 
     then:
-    result.task(':licenseReport').outcome == SUCCESS
-    result.output.find("Wrote CSV report to .*${reportFolder}/licenseReport.csv.")
-    result.output.find("Wrote HTML report to .*${reportFolder}/licenseReport.html.")
-    result.output.find("Wrote JSON report to .*${reportFolder}/licenseReport.json.")
-    result.output.find("Wrote Text report to .*${reportFolder}/licenseReport.txt.")
+    outcome == SUCCESS
+    wroteCsv
+    wroteHtml
+    wroteJson
+    wroteText
 
     where:
     gradleVersion << [
@@ -118,13 +126,18 @@ final class LicensePluginVersionSpec extends Specification {
       .withProjectDir(testProjectDir.root)
       .withArguments('licenseDebugReport', '-s')
       .build()
+    TaskOutcome outcome = result.task(':licenseDebugReport').outcome
+    String wroteCsv = result.output.find("Wrote CSV report to .*${reportFolder}/licenseDebugReport.csv.")
+    String wroteHtml = result.output.find("Wrote HTML report to .*${reportFolder}/licenseDebugReport.html.")
+    String wroteJson = result.output.find("Wrote JSON report to .*${reportFolder}/licenseDebugReport.json.")
+    String wroteText = result.output.find("Wrote Text report to .*${reportFolder}/licenseDebugReport.txt.")
 
     then:
-    result.task(':licenseDebugReport').outcome == SUCCESS
-    result.output.find("Wrote CSV report to .*${reportFolder}/licenseDebugReport.csv.")
-    result.output.find("Wrote HTML report to .*${reportFolder}/licenseDebugReport.html.")
-    result.output.find("Wrote JSON report to .*${reportFolder}/licenseDebugReport.json.")
-    result.output.find("Wrote Text report to .*${reportFolder}/licenseDebugReport.txt.")
+    outcome == SUCCESS
+    wroteCsv
+    wroteHtml
+    wroteJson
+    wroteText
 
     where:
     // AGP 8+ paired with each AGP version's minimum-compatible Gradle (all run on JDK 17).

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicenseReportExtensionSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicenseReportExtensionSpec.groovy
@@ -1,32 +1,51 @@
 package com.jaredsburrows.license
 
+import groovy.transform.TypeChecked
 import spock.lang.Specification
 
+@TypeChecked
 final class LicenseReportExtensionSpec extends Specification {
-  private LicenseReportExtension extension = new LicenseReportExtension()
-
   def 'the full JSON report is opt in'() {
+    given:
+    LicenseReportExtension extension = new LicenseReportExtension()
+    boolean generateJsonFullReport = extension.generateJsonFullReport
+    boolean copyJsonFullReportToAssets = extension.copyJsonFullReportToAssets
+
     expect: 'the license texts make it large, so it is off until asked for'
-    !extension.generateJsonFullReport
-    !extension.copyJsonFullReportToAssets
+    !generateJsonFullReport
+    !copyJsonFullReportToAssets
   }
 
   def 'the existing report defaults are unchanged'() {
+    given:
+    LicenseReportExtension extension = new LicenseReportExtension()
+    boolean generateCsvReport = extension.generateCsvReport
+    boolean generateHtmlReport = extension.generateHtmlReport
+    boolean generateJsonReport = extension.generateJsonReport
+    boolean generateTextReport = extension.generateTextReport
+    boolean copyHtmlReportToAssets = extension.copyHtmlReportToAssets
+    boolean copyCsvReportToAssets = extension.copyCsvReportToAssets
+    boolean copyJsonReportToAssets = extension.copyJsonReportToAssets
+    boolean copyTextReportToAssets = extension.copyTextReportToAssets
+    boolean useVariantSpecificAssetDirs = extension.useVariantSpecificAssetDirs
+    boolean showVersions = extension.showVersions
+    boolean noIgnoredPatterns = extension.ignoredPatterns.isEmpty()
+
     expect:
-    extension.generateCsvReport
-    extension.generateHtmlReport
-    extension.generateJsonReport
-    extension.generateTextReport
+    generateCsvReport
+    generateHtmlReport
+    generateJsonReport
+    generateTextReport
 
     and: 'only the HTML report is copied to the assets by default'
-    extension.copyHtmlReportToAssets
-    !extension.copyCsvReportToAssets
-    !extension.copyJsonReportToAssets
-    !extension.copyTextReportToAssets
+    copyHtmlReportToAssets
+    !copyCsvReportToAssets
+    !copyJsonReportToAssets
+    !copyTextReportToAssets
 
     and:
-    !extension.useVariantSpecificAssetDirs
-    !extension.showVersions
-    extension.ignoredPatterns.isEmpty()
+    !useVariantSpecificAssetDirs
+    !showVersions
+    noIgnoredPatterns
   }
 }


### PR DESCRIPTION
Type-checks three more specs, using the same pattern as #867 and #868: move member access out of the conditions and leave a comparison or a bare boolean behind.

| spec | errors before |
|---|---|
| `LicenseReportExtensionSpec` | 13 |
| `LicensePluginSpec` | 14 |
| `LicensePluginVersionSpec` | 25 |

### The three shapes

**Property reads** (`LicenseReportExtensionSpec`) — every one of its 13 errors was a bare `extension.someFlag`. A property access resolves against an untyped receiver in a condition, so wrapping it in a comparison does not help either; it has to be read in `given:`:

```diff
+    boolean generateCsvReport = extension.generateCsvReport
+
     expect:
-    extension.generateCsvReport
+    generateCsvReport
```

The block structure, ordering and descriptions are unchanged.

**Task outcomes** (both plugin specs) — as in #867:

```diff
     when:
     BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    TaskOutcome outcome = result.task(':licenseReport').outcome
 
     then:
-    result.task(':licenseReport').outcome == SUCCESS
+    outcome == SUCCESS
```

**Output matches** (`LicensePluginVersionSpec`) — `find` returns the matched text, so the hoisted local still carries it:

```diff
+    String wroteCsv = result.output.find("Wrote CSV report to .*${reportFolder}/licenseReport.csv.")
+
     then:
-    result.output.find("Wrote CSV report to .*${reportFolder}/licenseReport.csv.")
+    wroteCsv
```

`licenseReport using with gradle #gradleVersion` also gained a typed data-variable parameter, since `gradleVersion` is otherwise `Object` and does not match `withGradleVersion(String)`.

### One honest cost

The six `result.output.contains(...)` assertions in `LicensePluginSpec` become a bare boolean, so a failure now reads:

```
requiresSupportedPlugin
|
false
```

where before it printed the searched-for string. `find` and `outcome` keep their values; `contains` cannot. Named the variable for what it asserts to compensate.

### Verification

`./gradlew :gradle-license-plugin:test --rerun-tasks` — 501 tests, 0 failures.

Mutation-checked rather than assumed: breaking the expected plugin-error message and the CSV report regex fails 27 tests across the two plugin specs; flipping `copyCsvReportToAssets` fails `LicenseReportExtensionSpec`. The hoisted assertions still bite.
