### PR TITLE
Ask the Kotlin target for its configuration names

### DIFF
--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/ProjectKmp.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/ProjectKmp.kt
@@ -2,6 +2,7 @@ package com.jaredsburrows.license
 
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 
 /** Returns true if a JetBrains Kotlin Multiplatform project. */
 internal fun Project.isKmpProject(): Boolean = hasPlugin(listOf("org.jetbrains.kotlin.multiplatform"))
@@ -27,11 +28,17 @@ internal fun Project.configureKmpProject() {
       val name = target.name.replaceFirstChar { it.uppercase() }
 
       tasks.register("license${name}Report", LicenseReportTask::class.java) {
+        // Ask the target for its configuration names rather than assembling them from the target
+        // name: only the JVM-like targets are "<target>CompileClasspath". A native target compiles
+        // against "<target>CompileKlibraries" and has no runtime configuration at all, so building
+        // the names by hand asked for configurations that do not exist and reported nothing.
+        val main = target.compilations.getByName(KotlinCompilation.MAIN_COMPILATION_NAME)
+
         configureCommon(
           it,
-          listOf(
-            "${target.name}CompileClasspath",
-            "${target.name}RuntimeClasspath",
+          listOfNotNull(
+            main.compileDependencyConfigurationName,
+            main.runtimeDependencyConfigurationName,
           ),
         )
       }

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginKmpSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginKmpSpec.groovy
@@ -84,4 +84,48 @@ final class LicensePluginKmpSpec extends Specification {
     and: 'the jvm target dependencies are resolved and attributed'
     dependencies == ['group:name:1.0.0']
   }
+
+  def 'licenseReport resolves a native target, whose configurations are not named like the JVM ones'() {
+    given: 'a multiplatform project with a Kotlin/Native target'
+    buildFile <<
+      """
+      buildscript {
+        dependencies {
+          classpath files($classpathString)
+        }
+      }
+
+      apply plugin: 'org.jetbrains.kotlin.multiplatform'
+      apply plugin: 'com.jaredsburrows.license'
+
+      repositories {
+        mavenCentral()
+      }
+
+      kotlin {
+        linuxX64()
+        sourceSets {
+          commonMain {
+            dependencies {
+              implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0'
+            }
+          }
+        }
+      }
+      """
+
+    when: 'the per-target report runs'
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseLinuxX64Report', '-s')
+    TaskOutcome outcome = result.task(':licenseLinuxX64Report').outcome
+    String reportText = new File(reportFolder, 'licenseLinuxX64Report.json').text.trim()
+    boolean attributesCoroutines = reportText.contains('org.jetbrains.kotlinx:kotlinx-coroutines-core')
+
+    then:
+    outcome == SUCCESS
+
+    and: 'the native target resolves linuxX64CompileKlibraries, not a jvm-style name, so it is not empty'
+    reportText != '[]'
+    attributesCoroutines
+  }
+
 }


### PR DESCRIPTION
`configureKmpProject` built the configuration names it resolves out of the target name:

```kotlin
listOf("${target.name}CompileClasspath", "${target.name}RuntimeClasspath")
```

That naming only holds for JVM-like targets. Probing a real multiplatform project:

| target | name built | name that exists |
|---|---|---|
| `jvm` | `jvmCompileClasspath` / `jvmRuntimeClasspath` | same ✅ |
| `js` | `jsCompileClasspath` / `jsRuntimeClasspath` | same ✅ |
| `linuxX64` | `linuxX64CompileClasspath` / `linuxX64RuntimeClasspath` | **`linuxX64CompileKlibraries`**, and **no runtime configuration at all** ❌ |

So `licenseLinuxX64Report` asked for two configurations that do not exist, resolved nothing, and wrote `[]`. It failed silently — a configuration that isn't found is skipped, not an error — so a Kotlin/Native target produced a green build and an empty licence report.

## Fix

Read the names off the target's main compilation instead of assembling them:

```kotlin
val main = target.compilations.getByName(KotlinCompilation.MAIN_COMPILATION_NAME)

configureCommon(
  it,
  listOfNotNull(
    main.compileDependencyConfigurationName,
    main.runtimeDependencyConfigurationName,
  ),
)
```

`runtimeDependencyConfigurationName` is null on native, hence `listOfNotNull`.

## Behavioural delta

- **Kotlin/Native targets** (`linuxX64`, `macosArm64`, `mingwX64`, …): report goes from empty to the actual dependencies. This is the fix.
- **`jvm` / `js`**: no change — the compilation reports exactly the names that were hardcoded. The existing `jvm` test still asserts the same `['group:name:1.0.0']`.

## Tests

New functional test: a `linuxX64()` project depending on `org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0`, asserting the report is neither `[]` nor missing the dependency. Verified it **fails against the current code** with `reportText != '[]'  |  []  false`, and passes with the fix.

`:gradle-license-plugin:build` green — 502 tests, 0 failures.