### PR TITLE
Ask the Android component for its configuration names

### DIFF
--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/ProjectAndroid.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/ProjectAndroid.kt
@@ -115,12 +115,19 @@ private fun Project.configureComponent(component: Component) {
     }
 
   tasks.register("license${name}Report", LicenseReportTask::class.java) {
-    // Apply common task configuration first
+    // Apply common task configuration first.
+    //
+    // Ask the component for its configuration names rather than assembling them from the component
+    // name. The two coincide for the standard variants -- "debug" resolves debugCompileClasspath --
+    // but not for an AGP-KMP library, whose component is named "androidMain" while its
+    // configurations are androidCompileClasspath / androidRuntimeClasspath. The assembled names
+    // matched nothing there, and a name that matches nothing is skipped rather than failing, so
+    // licenseAndroidMainReport quietly wrote an empty report.
     configureCommon(
       it,
       listOf(
-        "${component.name}CompileClasspath",
-        "${component.name}RuntimeClasspath",
+        component.compileConfiguration.name,
+        component.runtimeConfiguration.name,
       ),
     )
 

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginAndroidSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginAndroidSpec.groovy
@@ -2629,6 +2629,12 @@ final class LicensePluginAndroidSpec extends Specification {
         }
       }
 
+      repositories {
+        maven {
+          url '${mavenRepoUrl}'
+        }
+      }
+
       apply plugin: 'org.jetbrains.kotlin.multiplatform'
       apply plugin: 'com.android.kotlin.multiplatform.library'
       apply plugin: 'com.jaredsburrows.license'
@@ -2638,17 +2644,28 @@ final class LicensePluginAndroidSpec extends Specification {
           namespace = 'com.example.kmp'
           compileSdk = $compileSdkVersion
         }
+
+        sourceSets {
+          androidMain {
+            dependencies {
+              implementation 'com.android.support:design:26.1.0'
+            }
+          }
+        }
       }
       """
 
-    when: 'the plugin is applied'
-    BuildResult result = gradleWithCommand(testProjectDir.root, 'tasks', '--all', '-s')
+    when: 'the report task registered for the android target is run'
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseAndroidMainReport', '-s')
+    File actualJson = new File(reportFolder, 'licenseAndroidMainReport.json')
 
     then: 'it does not fail with the unsupported-project error'
     !result.output.contains('requires Java, Kotlin or Android Gradle based plugins')
+    result.task(':licenseAndroidMainReport').outcome == SUCCESS
 
-    and: 'a report task is registered for the android target'
-    result.output.contains('licenseAndroidMainReport')
+    and: 'the component is named androidMain but its configurations are not, so the report is populated'
+    actualJson.text.trim() != '[]'
+    actualJson.text.contains('com.android.support:design')
   }
 
 }


### PR DESCRIPTION
Follow-up to #871, same bug class on the Android side.

`configureComponent` builds the configuration names it resolves out of the component name:

```kotlin
listOf("${component.name}CompileClasspath", "${component.name}RuntimeClasspath")
```

I probed every module type the plugin claims to support, comparing that guess against what `Component.compileConfiguration` / `Component.runtimeConfiguration` actually report:

| module | plugin | component | AGP says | guess exists? |
|---|---|---|---|---|
| app | `com.android.application` | `debug`, `release`, `debugUnitTest`, `debugAndroidTest` | `debugCompileClasspath` … | ✅ match |
| lib | `com.android.library` | same four | same | ✅ match |
| feature | `com.android.dynamic-feature` | same four | same | ✅ match |
| androidtest | `com.android.test` | `debug` | same | ✅ match |
| **kmplib** | **`com.android.kotlin.multiplatform.library`** | **`androidMain`** | **`androidCompileClasspath`** / `androidRuntimeClasspath` | ❌ **neither exists** |

So `licenseAndroidMainReport` asked for `androidMainCompileClasspath`, got nothing, and — because `buildPomInput` does `configurationNames.mapNotNull { configurations.findByName(it) }`, silently dropping a name that matches nothing — succeeded while writing `[]`.

For reference, the same probe confirms the JVM side is correct: `ProjectJvm` hardcodes `compileClasspath` / `runtimeClasspath`, and the main source set reports exactly those. No change needed there.

## Fix

```kotlin
configureCommon(
  it,
  listOf(
    component.compileConfiguration.name,
    component.runtimeConfiguration.name,
  ),
)
```

`compileConfiguration` and `runtimeConfiguration` are **stable** AGP API — not `@Incubating`, unlike the neighbouring `compileClasspath` — present since AGP 8.0.0 (verified against the 8.0.0, 8.7.0 and 8.13.0 jars), and documented as "the debugCompileClasspath [Configuration] for the debug variant".

## Behavioural delta

- **AGP-KMP library modules** (`com.android.kotlin.multiplatform.library`): report goes from empty to the actual dependencies. This is the fix.
- **application / library / test / dynamic-feature**: no change — the component reports the same names that were being assembled, for every variant and nested test component.

## Tests

The existing AGP-KMP test only asserted the task was *registered*, never that it produced anything — which is why this was invisible. It now runs `licenseAndroidMainReport` against a dependency and asserts the report is neither `[]` nor missing it. Verified it **fails against the current code**:

```
Condition not satisfied: actualJson.text.trim() != '[]'
                         |                          |
                         []                         false
```

`:gradle-license-plugin:build` green — 502 tests, 0 failures. `-p test-apps clean build` green, and the app reports are still populated.