### PR TITLE
Ask the main source set for its configuration names

### DIFF
--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/ProjectJvm.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/ProjectJvm.kt
@@ -1,8 +1,10 @@
 package com.jaredsburrows.license
 
 import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.tasks.SourceSet
 
-/** Returns true if a plain JVM Gradle project: Java, or Kotlin targeting the JVM. */
+/** Returns true if Java or Kotlin Gradle project. */
 internal fun Project.isJvmProject(): Boolean =
   hasPlugin(
     listOf(
@@ -16,7 +18,25 @@ internal fun Project.isJvmProject(): Boolean =
 /** Configure for JVM projects, which produce a single artifact and so a single report. */
 internal fun Project.configureJvmProject() {
   tasks.register("licenseReport", LicenseReportTask::class.java) {
+    // Ask the main source set for its configuration names rather than hardcoding them. The two it
+    // reports are "compileClasspath" and "runtimeClasspath" -- main is the one source set Gradle
+    // does not prefix -- so this changes no behaviour here. It is the same assumption that was
+    // wrong on both other paths, though: an Android component named "androidMain" resolves
+    // "androidCompileClasspath", and a Kotlin/Native target resolves "<target>CompileKlibraries"
+    // and has no runtime configuration at all. Both reported nothing until they were asked.
+    val main =
+      extensions
+        .getByType(JavaPluginExtension::class.java)
+        .sourceSets
+        .getByName(SourceSet.MAIN_SOURCE_SET_NAME)
+
     // Apply common task configuration first
-    configureCommon(it, listOf("compileClasspath", "runtimeClasspath"))
+    configureCommon(
+      it,
+      listOf(
+        main.compileClasspathConfigurationName,
+        main.runtimeClasspathConfigurationName,
+      ),
+    )
   }
 }

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJvmSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJvmSpec.groovy
@@ -21,8 +21,21 @@ final class LicensePluginJvmSpec extends Specification {
   private String mavenRepoUrl
   private File buildFile
   private String reportFolder
+  private String classpathString
 
   def 'setup'() {
+    // withPluginClasspath() exposes only the plugin's own runtime classpath, so a test that needs
+    // the Kotlin Gradle Plugin reads the full test runtime classpath instead, as the KMP spec does.
+    URL pluginClasspathResource = getClass().classLoader.getResource('plugin-classpath.txt')
+    if (pluginClasspathResource == null) {
+      throw new IllegalStateException(
+        'Did not find plugin classpath resource, run `testClasses` build task.')
+    }
+    classpathString = pluginClasspathResource.readLines()
+      .collect { new File(it).absolutePath.replace('\\', '\\\\') }
+      .collect { "'$it'" }
+      .join(', ')
+
     mavenRepoUrl = getClass().getResource('/maven').toURI()
     buildFile = testProjectDir.newFile('build.gradle')
     // In case we're on Windows, fix the \s in the string containing the name
@@ -2417,4 +2430,39 @@ final class LicensePluginJvmSpec extends Specification {
     new File(reportFolder, 'licenseReport.json').text.contains('group:name:1.0.0')
   }
 
+  def 'licenseReport for a Kotlin JVM project'() {
+    given: 'a project applying only the Kotlin JVM plugin, which brings the java plugin with it'
+    buildFile <<
+      """
+      buildscript {
+        dependencies {
+          classpath files($classpathString)
+        }
+      }
+
+      repositories {
+        maven {
+          url '${mavenRepoUrl}'
+        }
+      }
+
+      apply plugin: 'org.jetbrains.kotlin.jvm'
+      apply plugin: 'com.jaredsburrows.license'
+
+      dependencies {
+        implementation 'com.android.support:design:26.1.0'
+      }
+      """
+
+    when:
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    File actualJson = new File(reportFolder, 'licenseReport.json')
+
+    then: 'the main source set resolves compileClasspath and runtimeClasspath'
+    result.task(':licenseReport').outcome == SUCCESS
+
+    and:
+    actualJson.text.trim() != '[]'
+    actualJson.text.contains('com.android.support:design')
+  }
 }


### PR DESCRIPTION
Third and last of the hardcoded-classpath sites, after #871 (KMP) and #872 (Android) — and **the only one that was not actually broken**.

## The evidence first

`main` is the one source set Gradle does not prefix, so `compileClasspath` / `runtimeClasspath` really are its configuration names. I probed every JVM plugin that `isJvmProject()` can match:

| project | plugin | main compile cfg | main runtime cfg | |
|---|---|---|---|---|
| `:javalib` | `java-library` | `compileClasspath` | `runtimeClasspath` | ✅ |
| `:kotlinjvm` | `org.jetbrains.kotlin.jvm` | same | same | ✅ |
| `:app` | `application` | same | same | ✅ |
| `:groovylib` | `groovy` | same | same | ✅ |
| `:scalalib` | `scala` | same | same | ✅ |
| `:warlib` | `war` | same | same | ✅ |
| `:fixtures` | `java-library` + `java-test-fixtures` | same | same | ✅ |

**So this PR changes no behaviour.** If that is not worth the churn, close it — #871 and #872 are the ones that fix real empty reports.

## Why I think it is worth it anyway

The same "the name is obviously `<thing>Classpath`" assumption was wrong at both other sites:

- an Android component named `androidMain` resolves **`androidCompileClasspath`** (#872)
- a Kotlin/Native target resolves **`<target>CompileKlibraries`** and has **no runtime configuration at all** (#871)

Both reported nothing, and both did it silently, because `buildPomInput` does `configurationNames.mapNotNull { configurations.findByName(it) }` — a name matching no configuration is dropped without a word. With all three paths asking rather than guessing, that class of bug cannot recur.

```kotlin
val main =
  extensions
    .getByType(JavaPluginExtension::class.java)
    .sourceSets
    .getByName(SourceSet.MAIN_SOURCE_SET_NAME)

configureCommon(
  it,
  listOf(
    main.compileClasspathConfigurationName,
    main.runtimeClasspathConfigurationName,
  ),
)
```

## The test is the real content

`isJvmProject()` has listed `org.jetbrains.kotlin.jvm` since forever, but **nothing exercised it** — the parameterised `apply with allowed java plugins` test covers only Gradle's own nine. It is also precisely the case this change leans on, since KGP applies the java plugin rather than the build declaring it, and the new code reads `JavaPluginExtension`.

The new test applies *only* `org.jetbrains.kotlin.jvm` and asserts a populated report. I ran it against the unmodified `ProjectJvm` as well and it passes there too — so it is coverage for an untested plugin, not a pin for a fix.

`:gradle-license-plugin:build` green — 502 tests, 0 failures.