### PR TITLE
Run the multiplatform wiring for a module that is also Android

### DIFF
--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicensePlugin.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicensePlugin.kt
@@ -17,16 +17,22 @@ class LicensePlugin : Plugin<Project> {
     // plugins, which is only known after evaluation. Android was already handled above, so here we
     // only register the Java task or fail when no supported plugin is present.
     project.afterEvaluate {
-      if (!project.isAndroidProject()) {
-        when {
-          // Multiplatform first: it also applies a Kotlin plugin, but has per-target classpaths
-          // rather than the single compileClasspath/runtimeClasspath a JVM project has.
-          project.isKmpProject() -> project.configureKmpProject()
-          project.isJvmProject() -> project.configureJvmProject()
-          else -> throw UnsupportedOperationException(
-            "'com.jaredsburrows.license' requires Java, Kotlin or Android Gradle based plugins.",
-          )
-        }
+      when {
+        // Multiplatform first: it also applies a Kotlin plugin, but has per-target classpaths
+        // rather than the single compileClasspath/runtimeClasspath a JVM project has.
+        //
+        // Checked before Android rather than after it. A multiplatform module commonly applies an
+        // Android plugin too, and it needs both paths: configureAndroidProject above covers its
+        // android target, and this covers every other one. Returning early on isAndroidProject()
+        // left such a module with only the android report, which for a jvm + native library is
+        // most of the report missing.
+        project.isKmpProject() -> project.configureKmpProject()
+        // Already wired by configureAndroidProject, which had to run during configuration.
+        project.isAndroidProject() -> Unit
+        project.isJvmProject() -> project.configureJvmProject()
+        else -> throw UnsupportedOperationException(
+          "'com.jaredsburrows.license' requires Java, Kotlin or Android Gradle based plugins.",
+        )
       }
     }
   }

--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/ProjectKmp.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/ProjectKmp.kt
@@ -3,6 +3,7 @@ package com.jaredsburrows.license
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 
 /** Returns true if a JetBrains Kotlin Multiplatform project. */
 internal fun Project.isKmpProject(): Boolean = hasPlugin(listOf("org.jetbrains.kotlin.multiplatform"))
@@ -19,11 +20,25 @@ internal fun Project.isKmpProject(): Boolean = hasPlugin(listOf("org.jetbrains.k
  * that is not multiplatform.
  */
 internal fun Project.configureKmpProject() {
+  // Declared inside the function, not at file level. A file-level `val` is initialized in this
+  // file's facade class, which also carries [isKmpProject] -- so every project, multiplatform or
+  // not, would resolve KotlinPlatformType on the way to asking whether it is multiplatform, and
+  // fail with NoClassDefFoundError wherever the Kotlin Gradle Plugin is absent. It is compileOnly.
+  //
+  // Targets deliberately left alone, matched by platform type rather than by target name so a
+  // rename cannot silently turn the filter off:
+  //
+  // - common is the metadata target, which resolves no dependencies of its own.
+  // - androidJvm belongs to [configureAndroidProject]. An android target only exists when an
+  //   Android plugin is applied, and that path reports it per variant and wires up the asset
+  //   directories, which this one cannot. Both resolve the same configurations, so registering
+  //   here as well would produce a second task with identical output under a different name.
+  val skippedPlatformTypes = setOf(KotlinPlatformType.common, KotlinPlatformType.androidJvm)
+
   extensions
     .getByType(KotlinMultiplatformExtension::class.java)
     .targets
-    // The common target resolves no runtime dependencies of its own.
-    .filterNot { it.name == METADATA_TARGET }
+    .filterNot { it.platformType in skippedPlatformTypes }
     .forEach { target ->
       val name = target.name.replaceFirstChar { it.uppercase() }
 
@@ -44,5 +59,3 @@ internal fun Project.configureKmpProject() {
       }
     }
 }
-
-private const val METADATA_TARGET = "metadata"

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginAndroidSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginAndroidSpec.groovy
@@ -2668,4 +2668,59 @@ final class LicensePluginAndroidSpec extends Specification {
     actualJson.text.contains('com.android.support:design')
   }
 
+  def 'licenseReport registers a report for every target of a multiplatform module with an android target'() {
+    given: 'a multiplatform module applying an android plugin alongside jvm and native targets'
+    buildFile <<
+      """
+      buildscript {
+        dependencies {
+          classpath files($classpathString)
+        }
+      }
+
+      repositories {
+        mavenCentral()
+      }
+
+      apply plugin: 'org.jetbrains.kotlin.multiplatform'
+      apply plugin: 'com.android.kotlin.multiplatform.library'
+      apply plugin: 'com.jaredsburrows.license'
+
+      kotlin {
+        androidLibrary {
+          namespace = 'com.example.kmp'
+          compileSdk = $compileSdkVersion
+        }
+        jvm()
+        linuxX64()
+
+        sourceSets {
+          commonMain {
+            dependencies {
+              implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0'
+            }
+          }
+        }
+      }
+      """
+
+    when: 'the reports for the non-android targets are run'
+    BuildResult result = gradleWithCommand(
+      testProjectDir.root, 'licenseJvmReport', 'licenseLinuxX64Report', 'licenseAndroidMainReport', '-s')
+
+    then: 'the android plugin no longer suppresses the multiplatform wiring'
+    result.task(':licenseJvmReport').outcome == SUCCESS
+    result.task(':licenseLinuxX64Report').outcome == SUCCESS
+
+    and: 'the android target keeps the report registered by the android path'
+    result.task(':licenseAndroidMainReport').outcome == SUCCESS
+
+    and: 'each is populated'
+    new File(reportFolder, 'licenseJvmReport.json').text.contains('kotlinx-coroutines-core')
+    new File(reportFolder, 'licenseLinuxX64Report.json').text.contains('kotlinx-coroutines-core')
+    new File(reportFolder, 'licenseAndroidMainReport.json').text.contains('kotlinx-coroutines-core')
+
+    and: 'the android target is not also reported under its multiplatform target name'
+    !new File(reportFolder, 'licenseAndroidReport.json').exists()
+  }
 }


### PR DESCRIPTION
Audit finding #2, and the last hole in the coverage #871–#873 established.

`LicensePlugin` returned early on `isAndroidProject()`:

```kotlin
project.afterEvaluate {
  if (!project.isAndroidProject()) {
    when {
      project.isKmpProject() -> project.configureKmpProject()
      ...
```

So a multiplatform module that also applies an Android plugin got only what `configureAndroidProject` registers. For an `androidLibrary` + `jvm()` + `linuxX64()` library — a very common multiplatform shape — that means `licenseAndroidMainReport` and nothing else:

```
Task 'licenseJvmReport' not found in root project '...'
```

Most of the report was missing, and the task it would have come from didn't exist to say so.

## The collision that made this non-trivial

Simply running both paths registers two tasks for the same thing. Probing an `androidLibrary` + `jvm()` + `linuxX64()` module:

| target | platformType | compile configuration | runtime |
|---|---|---|---|
| `android` | `androidJvm` | **`androidCompileClasspath`** | `androidRuntimeClasspath` |
| `jvm` | `jvm` | `jvmCompileClasspath` | `jvmRuntimeClasspath` |
| `linuxX64` | `native` | `linuxX64CompileKlibraries` | *(none)* |
| `metadata` | `common` | `metadataCompileClasspath` | *(none)* |

The KMP `android` target resolves **exactly** the configurations the AGP component path already covers (`androidMain` → `androidCompileClasspath`, per #872). So a naive fix would give you `licenseAndroidReport` *and* `licenseAndroidMainReport` with identical content.

## Fix

Check `isKmpProject()` before `isAndroidProject()` and let both paths run, each owning what it does better:

- **android target** → `configureAndroidProject`. It reports per *variant* and wires up the asset directories; the multiplatform path can do neither.
- **every other target** → `configureKmpProject`.

The skip is by `KotlinPlatformType`, not by target name, which also retires `METADATA_TARGET = "metadata"` — `common` is the metadata target, `androidJvm` is the Android path's. A rename can't silently turn either off.

## One trap worth recording

I first wrote the skip set as a file-level `private val`. That produced **69 failures**:

```
Could not initialize class com.jaredsburrows.license.ProjectKmpKt
  > org/jetbrains/kotlin/gradle/plugin/KotlinPlatformType
```

A file-level `val` initializes in the file's facade class — which also carries `isKmpProject()`. So every project, multiplatform or not, would resolve `KotlinPlatformType` on the way to asking whether it *is* multiplatform, and fail wherever KGP is absent, it being `compileOnly`. The old `const val METADATA_TARGET` was a compile-time constant and got inlined, which is why the file had gotten away with it.

It now lives inside `configureKmpProject`, which only runs for multiplatform projects. Worth knowing before anyone adds another constant to that file.

## Tests

New functional test: `androidLibrary` + `jvm()` + `linuxX64()` with a `commonMain` dependency, asserting all three reports run and are populated, and that the android target is *not* also reported under its multiplatform target name. Verified it fails on current master with `Task 'licenseJvmReport' not found`.

`:gradle-license-plugin:build` green — 504 tests, 0 failures. `-p test-apps clean build` green.