### PR TITLE
Assert report content for every supported plugin type and component

### DIFF
--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginAndroidSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginAndroidSpec.groovy
@@ -2580,12 +2580,22 @@ final class LicensePluginAndroidSpec extends Specification {
     testProjectDir.newFolder('feature')
     testProjectDir.newFile('feature/build.gradle') <<
       """
+      repositories {
+        maven {
+          url '${mavenRepoUrl}'
+        }
+      }
+
       apply plugin: 'com.android.dynamic-feature'
       apply plugin: 'com.jaredsburrows.license'
 
       android {
         compileSdk = $compileSdkVersion
         namespace 'com.example.feature'
+      }
+
+      dependencies {
+        implementation 'com.android.support:design:26.1.0'
       }
       """
 
@@ -2614,9 +2624,15 @@ final class LicensePluginAndroidSpec extends Specification {
 
     when: 'the report task is run on the dynamic feature module'
     BuildResult result = gradleWithCommand(testProjectDir.root, ':feature:licenseDebugReport', '-s')
+    File featureJson =
+      new File(testProjectDir.root, 'feature/build/reports/licenses/licenseDebugReport.json')
 
     then: 'applying the plugin does not fail the build'
     result.task(':feature:licenseDebugReport').outcome == SUCCESS
+
+    and: 'the feature module reports its own dependencies'
+    featureJson.text.trim() != '[]'
+    featureJson.text.contains('com.android.support:design')
   }
 
   def 'licenseReport supports a kotlin multiplatform android library module'() {
@@ -2722,5 +2738,107 @@ final class LicensePluginAndroidSpec extends Specification {
 
     and: 'the android target is not also reported under its multiplatform target name'
     !new File(reportFolder, 'licenseAndroidReport.json').exists()
+  }
+
+  def 'licenseDebugReport for a standalone android library module'() {
+    given: 'a library module, not a library consumed by an app'
+    buildFile <<
+      """
+      buildscript {
+        dependencies {
+          classpath files($classpathString)
+        }
+      }
+
+      repositories {
+        maven {
+          url '${mavenRepoUrl}'
+        }
+      }
+
+      apply plugin: 'com.android.library'
+      apply plugin: 'com.jaredsburrows.license'
+
+      android {
+        compileSdk = $compileSdkVersion
+        namespace 'com.example.lib'
+      }
+
+      dependencies {
+        implementation 'com.android.support:design:26.1.0'
+      }
+      """
+
+    when:
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseDebugReport', '-s')
+    File actualJson = new File(reportFolder, 'licenseDebugReport.json')
+
+    then:
+    result.task(':licenseDebugReport').outcome == SUCCESS
+
+    and:
+    actualJson.text.trim() != '[]'
+    actualJson.text.contains('com.android.support:design')
+  }
+
+  def 'licenseDebugReport for an android test module'() {
+    given: 'a com.android.test module targeting an application module'
+    testProjectDir.newFile('settings.gradle') <<
+      """
+      include 'subproject'
+      """
+    testProjectDir.newFolder('subproject')
+    testProjectDir.newFile('subproject/build.gradle') <<
+      """
+      apply plugin: 'com.android.application'
+
+      android {
+        compileSdk = $compileSdkVersion
+        namespace 'com.example.target'
+
+        defaultConfig {
+          applicationId 'com.example.target'
+        }
+      }
+      """
+
+    buildFile <<
+      """
+      buildscript {
+        dependencies {
+          classpath files($classpathString)
+        }
+      }
+
+      repositories {
+        maven {
+          url '${mavenRepoUrl}'
+        }
+      }
+
+      apply plugin: 'com.android.test'
+      apply plugin: 'com.jaredsburrows.license'
+
+      android {
+        compileSdk = $compileSdkVersion
+        namespace 'com.example.test'
+        targetProjectPath ':subproject'
+      }
+
+      dependencies {
+        implementation 'com.android.support:design:26.1.0'
+      }
+      """
+
+    when:
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseDebugReport', '-s')
+    File actualJson = new File(reportFolder, 'licenseDebugReport.json')
+
+    then:
+    result.task(':licenseDebugReport').outcome == SUCCESS
+
+    and:
+    actualJson.text.trim() != '[]'
+    actualJson.text.contains('com.android.support:design')
   }
 }

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginAndroidSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginAndroidSpec.groovy
@@ -2841,4 +2841,58 @@ final class LicensePluginAndroidSpec extends Specification {
     actualJson.text.trim() != '[]'
     actualJson.text.contains('com.android.support:design')
   }
+
+  def 'licenseReport registers a report for the nested unit test and android test components'() {
+    given: 'an app whose test source sets carry dependencies the main one does not'
+    buildFile <<
+      """
+      buildscript {
+        dependencies {
+          classpath files($classpathString)
+        }
+      }
+
+      repositories {
+        maven {
+          url '${mavenRepoUrl}'
+        }
+      }
+
+      apply plugin: 'com.android.application'
+      apply plugin: 'com.jaredsburrows.license'
+
+      android {
+        compileSdk = $compileSdkVersion
+        namespace 'com.example'
+
+        defaultConfig {
+          applicationId 'com.example'
+        }
+      }
+
+      dependencies {
+        implementation 'com.android.support:appcompat-v7:26.1.0'
+        testImplementation 'com.google.firebase:firebase-core:10.0.1'
+        androidTestImplementation 'com.android.support:design:26.1.0'
+      }
+      """
+
+    when: 'the reports for the nested components are run'
+    BuildResult result = gradleWithCommand(
+      testProjectDir.root, 'licenseDebugUnitTestReport', 'licenseDebugAndroidTestReport', '-s')
+    File unitTestJson = new File(reportFolder, 'licenseDebugUnitTestReport.json')
+    File androidTestJson = new File(reportFolder, 'licenseDebugAndroidTestReport.json')
+
+    then: 'Variant.nestedComponents still yields them, incubating though it is'
+    result.task(':licenseDebugUnitTestReport').outcome == SUCCESS
+    result.task(':licenseDebugAndroidTestReport').outcome == SUCCESS
+
+    and: 'each reports the dependencies of its own source set'
+    unitTestJson.text.contains('com.google.firebase:firebase-core')
+    androidTestJson.text.contains('com.android.support:design')
+
+    and: 'and the main dependency they both inherit'
+    unitTestJson.text.contains('com.android.support:appcompat-v7')
+    androidTestJson.text.contains('com.android.support:appcompat-v7')
+  }
 }

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJvmSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJvmSpec.groovy
@@ -2465,4 +2465,35 @@ final class LicensePluginJvmSpec extends Specification {
     actualJson.text.trim() != '[]'
     actualJson.text.contains('com.android.support:design')
   }
+
+  def 'licenseReport for a project applying the plain java plugin'() {
+    given: 'a project applying java rather than java-library'
+    buildFile <<
+      """
+      plugins {
+        id 'java'
+        id 'com.jaredsburrows.license'
+      }
+
+      repositories {
+        maven {
+          url '${mavenRepoUrl}'
+        }
+      }
+
+      dependencies {
+        implementation 'com.google.firebase:firebase-core:10.0.1'
+      }
+      """
+
+    when:
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    File actualJson = new File(reportFolder, 'licenseReport.json')
+
+    then:
+    result.task(':licenseReport').outcome == SUCCESS
+
+    and: 'the main source set resolves compileClasspath and runtimeClasspath'
+    actualJson.text.contains('com.google.firebase:firebase-core:10.0.1')
+  }
 }

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginKmpSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginKmpSpec.groovy
@@ -172,4 +172,42 @@ final class LicensePluginKmpSpec extends Specification {
     reportText != '[]'
     attributesCoroutines
   }
+
+  def 'licenseReport registers a report for every target except metadata'() {
+    given: 'a multiplatform project with targets on two different platform types'
+    buildFile <<
+      """
+      buildscript {
+        dependencies {
+          classpath files($classpathString)
+        }
+      }
+
+      apply plugin: 'org.jetbrains.kotlin.multiplatform'
+      apply plugin: 'com.jaredsburrows.license'
+
+      repositories {
+        mavenCentral()
+      }
+
+      kotlin {
+        jvm()
+        linuxX64()
+      }
+      """
+
+    when:
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'tasks', '--all', '-s')
+    String output = result.output
+    boolean registersJvm = output.contains('licenseJvmReport')
+    boolean registersLinuxX64 = output.contains('licenseLinuxX64Report')
+    boolean registersMetadata = output.contains('licenseMetadataReport')
+
+    then: 'every target that resolves dependencies of its own gets one'
+    registersJvm
+    registersLinuxX64
+
+    and: 'the metadata target, which does not, is skipped'
+    !registersMetadata
+  }
 }

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginKmpSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginKmpSpec.groovy
@@ -128,4 +128,48 @@ final class LicensePluginKmpSpec extends Specification {
     attributesCoroutines
   }
 
+  def 'licenseReport resolves a js target'() {
+    given: 'a multiplatform project with a Kotlin/JS target'
+    buildFile <<
+      """
+      buildscript {
+        dependencies {
+          classpath files($classpathString)
+        }
+      }
+
+      apply plugin: 'org.jetbrains.kotlin.multiplatform'
+      apply plugin: 'com.jaredsburrows.license'
+
+      repositories {
+        mavenCentral()
+      }
+
+      kotlin {
+        js {
+          nodejs()
+        }
+        sourceSets {
+          commonMain {
+            dependencies {
+              implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0'
+            }
+          }
+        }
+      }
+      """
+
+    when: 'the per-target report runs'
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseJsReport', '-s')
+    TaskOutcome outcome = result.task(':licenseJsReport').outcome
+    String reportText = new File(reportFolder, 'licenseJsReport.json').text.trim()
+    boolean attributesCoroutines = reportText.contains('org.jetbrains.kotlinx:kotlinx-coroutines-core')
+
+    then:
+    outcome == SUCCESS
+
+    and: 'the task named in configureKmpProject\'s own documentation is populated'
+    reportText != '[]'
+    attributesCoroutines
+  }
 }


### PR DESCRIPTION
One solid test per supported plugin type and component, where **solid means it asserts the report's content** — not just that the task registered and succeeded.

That distinction is the whole point: a task that registers and succeeds while writing `[]` is exactly what #871, #872 and #874 each turned out to be. For the rows marked new below, "the build is green" was not evidence of anything.

## The two that matter most

**Nested test components had no coverage at all.** `licenseDebugUnitTestReport` and `licenseDebugAndroidTestReport` appear *nowhere* in the suite, though `configureVariant` registers one for every variant through `Variant.nestedComponents` — an `@Incubating` API carrying a `@Suppress("UnstableApiUsage")`. A whole family of registered tasks, resting on an API AGP reserves the right to change, and nothing watched it. The new test gives the unit-test and android-test source sets dependencies the main one lacks, so it also pins that each component reports *its own* classpath rather than the variant's.

**The `js` target** is named in `configureKmpProject`'s own KDoc as an example of what it registers (`licenseJsReport`), but only `jvm` and `linuxX64` were tested.

## Coverage after this PR

| type / component | test | status |
|---|---|---|
| `java` | plain java plugin | new *(marginal — see below)* |
| `java-library` | JvmSpec — 9 tests, full HTML/CSV/JSON | existing |
| `org.jetbrains.kotlin.jvm` | Kotlin JVM project | #873 |
| KMP `jvm` target | KmpSpec | existing |
| KMP `linuxX64` target | KmpSpec | #871 |
| **KMP `js` target** | `licenseReport resolves a js target` | **new** |
| `com.android.application` | AndroidSpec — ~30 tests | existing |
| android **build types** | `assertHtml` + `assertJson` | existing |
| android **product flavors** | per-flavor deps, 2 dimensions, full HTML/CSV | existing |
| **android nested unit test** | `...nested unit test and android test components` | **new** |
| **android nested androidTest** | same test | **new** |
| `com.android.library` | standalone library module | **new** |
| `com.android.test` | android test module | **new** |
| `com.android.dynamic-feature` | dynamic feature module | **strengthened** |
| `com.android.kotlin.multiplatform.library` | AGP-KMP library | #872 |
| multiplatform **+ android** | every target of a KMP+android module | #874 |

## What was actually missing

- **`com.android.library`** — applied exactly once in the whole suite, and there only as a *subproject consumed by an app*. No test ever reported a library module itself.
- **`com.android.test`** — covered only by the parameterised apply-succeeds list, which asserts `outcome == SUCCESS` and nothing more.
- **`com.android.dynamic-feature`** — the test asserted SUCCESS on a feature module that declared **no dependencies at all**, so an empty report passed it. It now declares one and asserts the report contains it.
- **nested test components** and **KMP `js`**, above.

**On plain `java`: this one is marginal and I'd rather say so than pad the list.** `java-library` applies `java` — the spec's own comment records it — and `isJvmProject()` matches on `hasPlugin("java")`, which is already true in all nine existing `java-library` tests. A project applying only `java` resolves the identical `main` source set. The new test asserts that directly rather than transitively; it is not filling a real hole. Happy to drop it if you'd rather keep the suite lean.

Build types and product flavors were **already solid** — the flavor test asserts full HTML and CSV with per-flavor dependencies across two dimensions. I left both alone.

## Honest note

Every test here passes against current master. They lock in behaviour that already works; **none of them found a bug**. The value is that the next `androidMain`-shaped surprise fails a test instead of shipping an empty report — and that the incubating-API dependency now has a tripwire.

`:gradle-license-plugin:build` green — 509 tests, 0 failures.