### PR TITLE
Cover issue 878 with a parent module at five versions

### DIFF
--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJvmSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJvmSpec.groovy
@@ -2542,46 +2542,4 @@ final class LicensePluginJvmSpec extends Specification {
       json.any { (it.dependency as String).startsWith(coordinate + ':') && it.licenses }
     }
   }
-
-  @Issue("jaredsburrows/gradle-license-plugin/issues/878")
-  def 'licenseReport resolves guava-parent at both versions from issue 878'() {
-    given: 'guava alongside the two artifacts whose parent is guava-parent:26.0-android'
-    buildFile <<
-      """
-      plugins {
-        id 'java-library'
-        id 'com.jaredsburrows.license'
-      }
-
-      repositories {
-        mavenCentral()
-      }
-
-      dependencies {
-        implementation 'com.google.guava:guava:33.4.8-jre'         // guava-parent:33.4.8-jre
-        implementation 'com.google.guava:failureaccess:1.0.2'      // guava-parent:26.0-android
-        implementation 'com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava' // guava-parent:26.0-android
-      }
-      """
-
-    when:
-    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
-    List<Map> json =
-      new JsonSlurper().parseText(new File(reportFolder, 'licenseReport.json').text) as List<Map>
-    List<String> unlicensed =
-      json.findAll { !it.licenses }.collect { it.dependency as String }.sort()
-
-    then:
-    result.task(':licenseReport').outcome == SUCCESS
-
-    and: 'the older guava-parent is not dropped in favour of the one guava itself uses'
-    result.output.findAll(/Parent POM .* not found/) == []
-    result.output.findAll(/Dependency '.*' does not have a license\./) == []
-
-    and: 'both artifacts named in the issue are attributed'
-    unlicensed == []
-    ['com.google.guava:failureaccess', 'com.google.guava:listenablefuture'].every { String coordinate ->
-      json.any { (it.dependency as String).startsWith(coordinate + ':') && it.licenses }
-    }
-  }
 }

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJvmSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJvmSpec.groovy
@@ -2498,8 +2498,8 @@ final class LicensePluginJvmSpec extends Specification {
   }
 
   @Issue("jaredsburrows/gradle-license-plugin/issues/878")
-  def 'licenseReport resolves real parent POMs shared by many versions of one module'() {
-    given: 'the dependency set from issue 878, whose parents are commons-parent and guava-parent at six versions between them'
+  def 'licenseReport resolves commons-parent at the six versions from issue 878'() {
+    given: 'the Apache Commons set, pinned so their parents are commons-parent 39, 48, 72, 78 and 92'
     buildFile <<
       """
       plugins {
@@ -2512,12 +2512,11 @@ final class LicensePluginJvmSpec extends Specification {
       }
 
       dependencies {
-        implementation 'com.google.guava:guava:33.4.8-jre'
-        implementation 'commons-io:commons-io:2.18.0'
-        implementation 'org.apache.commons:commons-collections4:4.4'
-        implementation 'org.apache.commons:commons-compress:1.27.1'
-        implementation 'org.apache.commons:commons-lang3:3.18.0'
-        implementation 'org.apache.commons:commons-math3:3.6.1'
+        implementation 'commons-io:commons-io:2.18.0'              // commons-parent:78
+        implementation 'org.apache.commons:commons-collections4:4.4'  // commons-parent:48
+        implementation 'org.apache.commons:commons-compress:1.27.1'   // commons-parent:72
+        implementation 'org.apache.commons:commons-lang3:3.20.0'      // commons-parent:92
+        implementation 'org.apache.commons:commons-math3:3.6.1'       // commons-parent:39
       }
       """
 
@@ -2525,24 +2524,63 @@ final class LicensePluginJvmSpec extends Specification {
     BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
     List<Map> json =
       new JsonSlurper().parseText(new File(reportFolder, 'licenseReport.json').text) as List<Map>
-    List<String> withoutLicense =
+    List<String> unlicensed =
       json.findAll { !it.licenses }.collect { it.dependency as String }.sort()
 
     then:
     result.task(':licenseReport').outcome == SUCCESS
 
-    and: 'no parent POM is lost to conflict resolution between versions of the same module'
+    and: 'no version of commons-parent is lost to conflict resolution'
     result.output.findAll(/Parent POM .* not found/) == []
-
-    and: 'so nothing is left unattributed'
     result.output.findAll(/Dependency '.*' does not have a license\./) == []
-    withoutLicense == []
 
-    and: 'the artifacts named in the issue are attributed'
-    ['com.google.guava:failureaccess', 'com.google.guava:listenablefuture',
-     'commons-io:commons-io', 'org.apache.commons:commons-collections4',
+    and: 'every artifact named in the issue is attributed'
+    unlicensed == []
+    ['commons-io:commons-io', 'org.apache.commons:commons-collections4',
      'org.apache.commons:commons-compress', 'org.apache.commons:commons-lang3',
      'org.apache.commons:commons-math3'].every { String coordinate ->
+      json.any { (it.dependency as String).startsWith(coordinate + ':') && it.licenses }
+    }
+  }
+
+  @Issue("jaredsburrows/gradle-license-plugin/issues/878")
+  def 'licenseReport resolves guava-parent at both versions from issue 878'() {
+    given: 'guava alongside the two artifacts whose parent is guava-parent:26.0-android'
+    buildFile <<
+      """
+      plugins {
+        id 'java-library'
+        id 'com.jaredsburrows.license'
+      }
+
+      repositories {
+        mavenCentral()
+      }
+
+      dependencies {
+        implementation 'com.google.guava:guava:33.4.8-jre'         // guava-parent:33.4.8-jre
+        implementation 'com.google.guava:failureaccess:1.0.2'      // guava-parent:26.0-android
+        implementation 'com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava' // guava-parent:26.0-android
+      }
+      """
+
+    when:
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    List<Map> json =
+      new JsonSlurper().parseText(new File(reportFolder, 'licenseReport.json').text) as List<Map>
+    List<String> unlicensed =
+      json.findAll { !it.licenses }.collect { it.dependency as String }.sort()
+
+    then:
+    result.task(':licenseReport').outcome == SUCCESS
+
+    and: 'the older guava-parent is not dropped in favour of the one guava itself uses'
+    result.output.findAll(/Parent POM .* not found/) == []
+    result.output.findAll(/Dependency '.*' does not have a license\./) == []
+
+    and: 'both artifacts named in the issue are attributed'
+    unlicensed == []
+    ['com.google.guava:failureaccess', 'com.google.guava:listenablefuture'].every { String coordinate ->
       json.any { (it.dependency as String).startsWith(coordinate + ':') && it.licenses }
     }
   }

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJvmSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginJvmSpec.groovy
@@ -2496,4 +2496,54 @@ final class LicensePluginJvmSpec extends Specification {
     and: 'the main source set resolves compileClasspath and runtimeClasspath'
     actualJson.text.contains('com.google.firebase:firebase-core:10.0.1')
   }
+
+  @Issue("jaredsburrows/gradle-license-plugin/issues/878")
+  def 'licenseReport resolves real parent POMs shared by many versions of one module'() {
+    given: 'the dependency set from issue 878, whose parents are commons-parent and guava-parent at six versions between them'
+    buildFile <<
+      """
+      plugins {
+        id 'java-library'
+        id 'com.jaredsburrows.license'
+      }
+
+      repositories {
+        mavenCentral()
+      }
+
+      dependencies {
+        implementation 'com.google.guava:guava:33.4.8-jre'
+        implementation 'commons-io:commons-io:2.18.0'
+        implementation 'org.apache.commons:commons-collections4:4.4'
+        implementation 'org.apache.commons:commons-compress:1.27.1'
+        implementation 'org.apache.commons:commons-lang3:3.18.0'
+        implementation 'org.apache.commons:commons-math3:3.6.1'
+      }
+      """
+
+    when:
+    BuildResult result = gradleWithCommand(testProjectDir.root, 'licenseReport', '-s')
+    List<Map> json =
+      new JsonSlurper().parseText(new File(reportFolder, 'licenseReport.json').text) as List<Map>
+    List<String> withoutLicense =
+      json.findAll { !it.licenses }.collect { it.dependency as String }.sort()
+
+    then:
+    result.task(':licenseReport').outcome == SUCCESS
+
+    and: 'no parent POM is lost to conflict resolution between versions of the same module'
+    result.output.findAll(/Parent POM .* not found/) == []
+
+    and: 'so nothing is left unattributed'
+    result.output.findAll(/Dependency '.*' does not have a license\./) == []
+    withoutLicense == []
+
+    and: 'the artifacts named in the issue are attributed'
+    ['com.google.guava:failureaccess', 'com.google.guava:listenablefuture',
+     'commons-io:commons-io', 'org.apache.commons:commons-collections4',
+     'org.apache.commons:commons-compress', 'org.apache.commons:commons-lang3',
+     'org.apache.commons:commons-math3'].every { String coordinate ->
+      json.any { (it.dependency as String).startsWith(coordinate + ':') && it.licenses }
+    }
+  }
 }

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginVersionSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginVersionSpec.groovy
@@ -6,6 +6,7 @@ import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import groovy.transform.TypeChecked
+import spock.lang.Issue
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -147,6 +148,63 @@ final class LicensePluginVersionSpec extends Specification {
       ['8.13.0', '8.13'],
       ['9.0.0', '9.1.0'],
       ['9.2.1', '9.5.1'],
+    ]
+  }
+
+  @Issue("jaredsburrows/gradle-license-plugin/issues/724")
+  @Unroll
+  def 'licenseReport resolves shared parent POMs on gradle #gradleVersion'(String gradleVersion) {
+    given: 'the dependency set from issue 878, on the Gradle versions issue 724 is about'
+    buildFile <<
+      """
+      plugins {
+        id 'java-library'
+        id 'com.jaredsburrows.license'
+      }
+
+      repositories {
+        mavenCentral()
+      }
+
+      dependencies {
+        implementation 'com.google.guava:guava:33.4.8-jre'
+        implementation 'commons-io:commons-io:2.18.0'
+        implementation 'org.apache.commons:commons-collections4:4.4'
+        implementation 'org.apache.commons:commons-compress:1.27.1'
+        implementation 'org.apache.commons:commons-lang3:3.18.0'
+        implementation 'org.apache.commons:commons-math3:3.6.1'
+      }
+      """
+
+    when:
+    BuildResult result = GradleRunner.create()
+      .withGradleVersion(gradleVersion)
+      .withProjectDir(testProjectDir.root)
+      .withArguments('licenseReport', '-s')
+      .withPluginClasspath()
+      .build()
+    TaskOutcome outcome = result.task(':licenseReport').outcome
+    List<String> droppedParents = result.output.findAll(/Parent POM .* not found/)
+    List<String> unattributed = result.output.findAll(/Dependency '.*' does not have a license\./)
+    String reportText = new File(reportFolder, 'licenseReport.json').text
+    boolean attributesCommonsMath = reportText.contains('commons-math3')
+    boolean attributesFailureaccess = reportText.contains('failureaccess')
+
+    then: 'the plugin runs at all, which is what 724 was about'
+    outcome == SUCCESS
+
+    and: 'and resolves every parent POM, which is what 800 was about'
+    droppedParents == []
+    unattributed == []
+
+    and:
+    attributesCommonsMath
+    attributesFailureaccess
+
+    where:
+    gradleVersion << [
+      '9.0.0',
+      '9.7.1',
     ]
   }
 }

--- a/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginVersionSpec.groovy
+++ b/gradle-license-plugin/src/test/groovy/com/jaredsburrows/license/LicensePluginVersionSpec.groovy
@@ -6,7 +6,6 @@ import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import groovy.transform.TypeChecked
-import spock.lang.Issue
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -148,63 +147,6 @@ final class LicensePluginVersionSpec extends Specification {
       ['8.13.0', '8.13'],
       ['9.0.0', '9.1.0'],
       ['9.2.1', '9.5.1'],
-    ]
-  }
-
-  @Issue("jaredsburrows/gradle-license-plugin/issues/724")
-  @Unroll
-  def 'licenseReport resolves shared parent POMs on gradle #gradleVersion'(String gradleVersion) {
-    given: 'the dependency set from issue 878, on the Gradle versions issue 724 is about'
-    buildFile <<
-      """
-      plugins {
-        id 'java-library'
-        id 'com.jaredsburrows.license'
-      }
-
-      repositories {
-        mavenCentral()
-      }
-
-      dependencies {
-        implementation 'com.google.guava:guava:33.4.8-jre'
-        implementation 'commons-io:commons-io:2.18.0'
-        implementation 'org.apache.commons:commons-collections4:4.4'
-        implementation 'org.apache.commons:commons-compress:1.27.1'
-        implementation 'org.apache.commons:commons-lang3:3.18.0'
-        implementation 'org.apache.commons:commons-math3:3.6.1'
-      }
-      """
-
-    when:
-    BuildResult result = GradleRunner.create()
-      .withGradleVersion(gradleVersion)
-      .withProjectDir(testProjectDir.root)
-      .withArguments('licenseReport', '-s')
-      .withPluginClasspath()
-      .build()
-    TaskOutcome outcome = result.task(':licenseReport').outcome
-    List<String> droppedParents = result.output.findAll(/Parent POM .* not found/)
-    List<String> unattributed = result.output.findAll(/Dependency '.*' does not have a license\./)
-    String reportText = new File(reportFolder, 'licenseReport.json').text
-    boolean attributesCommonsMath = reportText.contains('commons-math3')
-    boolean attributesFailureaccess = reportText.contains('failureaccess')
-
-    then: 'the plugin runs at all, which is what 724 was about'
-    outcome == SUCCESS
-
-    and: 'and resolves every parent POM, which is what 800 was about'
-    droppedParents == []
-    unattributed == []
-
-    and:
-    attributesCommonsMath
-    attributesFailureaccess
-
-    where:
-    gradleVersion << [
-      '9.0.0',
-      '9.7.1',
     ]
   }
 }


### PR DESCRIPTION
#878 reports that 0.9.9 drops parent POMs for Apache Commons and Guava. It is fixed in 0.9.91 by #815. This adds **one** test, and I measured whether it was worth adding at all rather than assuming.

## The existing test already catches the original bug

`licenseReport with parents of the same module at different versions` uses a synthetic fixture — two children whose parents are `group:multiparent` at `1.0.0` and `2.0.0`. Reverting `resolvePomFiles` to a single batch (the 0.9.9 behaviour) **fails it**. So for the bug as reported, a new test adds nothing.

## What it cannot catch

The synthetic fixture holds one parent module at **two** versions, so it cannot tell "one batch per version" apart from "batches, up to two". Mutating the batching three ways and running both tests:

| mutation | synthetic (N=2) | commons (N=5) |
|---|---|---|
| control (real code) | PASS | PASS |
| single batch — the 0.9.9 bug | FAIL | FAIL |
| **cap batching at 2** | **PASS** ⚠️ | **FAIL** ✅ |

Any cap, off-by-one or stray `take(2)` slips past the synthetic fixture. That is the gap this closes, and it is the shape reporters actually hit — real graphs carry one parent module at five or six versions, not two.

## The test

Every library version is chosen so its parent is the one named in the issue, each read back from the artifact's POM on Maven Central rather than assumed:

```
commons-io:2.18.0             -> commons-parent:78
commons-collections4:4.4      -> commons-parent:48
commons-compress:1.27.1       -> commons-parent:72
commons-lang3:3.20.0          -> commons-parent:92
commons-math3:3.6.1           -> commons-parent:39
```

It asserts no `Parent POM ... not found`, no `does not have a license`, and a license on every report entry. Runtime **0.45s**.

## What I dropped, and why

- **The guava test** — one parent module at two versions, which is precisely what the synthetic fixture already covers.
- **A Gradle 9.0.0 / 9.7.1 pair** — ~8s plus a Gradle distribution download in CI, to exercise batching that is not Gradle-version-specific, on versions `LicensePluginVersionSpec` already runs. #724 is covered there.

`:gradle-license-plugin:build` green — 511 tests, 0 failures.