### PR TITLE
Unify format in GPL 2.0 with classpath exception

### DIFF
--- a/gradle-license-plugin/src/main/resources/license/gpl-2.0-with-classpath-exception.txt
+++ b/gradle-license-plugin/src/main/resources/license/gpl-2.0-with-classpath-exception.txt
@@ -341,6 +341,17 @@ Public License instead of this License.
 
 CLASSPATH EXCEPTION
 
-Linking this library statically or dynamically with other modules is making a combined work based on this library. Thus, the terms and conditions of the GNU General Public License cover the whole combination.
+Linking this library statically or dynamically with other modules is making a
+combined work based on this library. Thus, the terms and conditions of the
+GNU General Public License cover the whole combination.
 
-As a special exception, the copyright holders of this library give you permission to link this library with independent modules to produce an executable, regardless of the license terms of these independent modules, and to copy and distribute the resulting executable under terms of your choice, provided that you also meet, for each linked independent module, the terms and conditions of the license of that module. An independent module is a module which is not derived from or based on this library. If you modify this library, you may extend this exception to your version of the library, but you are not obligated to do so. If you do not wish to do so, delete this exception statement from your version.
+As a special exception, the copyright holders of this library give you
+permission to link this library with independent modules to produce an
+executable, regardless of the license terms of these independent modules, and
+to copy and distribute the resulting executable under terms of your choice,
+provided that you also meet, for each linked independent module, the terms
+and conditions of the license of that module. An independent module is a
+module which is not derived from or based on this library. If you modify this
+library, you may extend this exception to your version of the library, but
+you are not obligated to do so. If you do not wish to do so, delete this
+exception statement from your version.


### PR DESCRIPTION
Formats the classpath exception to break after 78 characters, so that its width matches the preceeding text of the GPL 2.0 license.

At the moment, the GPL 2.0 with classpath exception looks like this on a wide screen:
<img width="1895" height="739" alt="image" src="https://github.com/user-attachments/assets/0373e08c-01f0-4d5c-a1ed-f443ea17e581" />
