### PR TITLE
Add aliases for BSD 3-Clause "New" or "Revised" License

### DIFF
--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/internal/LicenseHelper.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/internal/LicenseHelper.kt
@@ -140,7 +140,9 @@ object LicenseHelper {
       "bsd 3-clause license" to "BSD-3-Clause",
       "new bsd license" to "BSD-3-Clause",
       "modified bsd license" to "BSD-3-Clause",
+      "modified bsd" to "BSD-3-Clause",
       "revised bsd license" to "BSD-3-Clause",
+      "revised bsd" to "BSD-3-Clause",
       // Creative Commons Zero v1.0 Universal
       "creative commons zero 1.0 universal" to "CC0-1.0",
       "cc0 1.0 universal" to "CC0-1.0",


### PR DESCRIPTION
Adds two new aliases to the BSD 3-Clause alias list:
* "modified bsd" - example usage: JSch: https://repo1.maven.org/maven2/com/github/mwiede/jsch/2.28.7/jsch-2.28.7.pom
* "revised bsd" - example usage: Eclipse Jersey: https://repo1.maven.org/maven2/org/glassfish/jersey/project/5.0.0-M1/project-5.0.0-M1.pom